### PR TITLE
Use real line numbers for asserts

### DIFF
--- a/include/JSystem/JUtility/JUTAssert.h
+++ b/include/JSystem/JUtility/JUTAssert.h
@@ -4,6 +4,8 @@
 #include <dolphin/os.h>
 
 #if DEBUG
+#if __MWERKS__
+
 #define JUT_SHOW_ASSERT(LINE, COND) JUTAssertion::showAssert(JUTAssertion::getSDevice(), __FILE__, LINE, #COND)
 
 #define JUT_ASSERT(LINE, COND) \
@@ -28,18 +30,50 @@
 #define JUT_WARN_DEVICE(LINE, DEVICE, ...)                                                                        \
     JUTAssertion::setWarningMessage_f(DEVICE, __FILE__, LINE, __VA_ARGS__);    \
 
-#define JUT_WARN(LINE, ...)                                                                        \
-    JUT_WARN_DEVICE(LINE, JUTAssertion::getSDevice(), __VA_ARGS__)
-
 #define JUT_LOG(LINE, ...)                                                                         \
     JUTAssertion::setLogMessage_f(JUTAssertion::getSDevice(), __FILE__, LINE, __VA_ARGS__)
 
 #define JUT_SET_CONFIRM(LINE, COND)                                                                \
     JUTAssertion::setConfirmMessage(JUTAssertion::getSDevice(), __FILE__, LINE, COND, #COND)
 
+#else
+
+#define JUT_SHOW_ASSERT(LINE, COND) JUTAssertion::showAssert(JUTAssertion::getSDevice(), __FILE__, __LINE__, #COND)
+
+#define JUT_ASSERT(LINE, COND) \
+    (COND) ? (void)0 : (JUT_SHOW_ASSERT(__LINE__, COND), OSPanic(__FILE__, __LINE__, "Halt"));
+
+#define JUT_ASSERT_MSG(LINE, COND, MSG) \
+    (COND) ? (void)0 : (JUTAssertion::showAssert(JUTAssertion::getSDevice(), __FILE__, __LINE__, MSG), OSPanic(__FILE__, __LINE__, "Halt"));
+
+#define JUT_ASSERT_MSG_F(LINE, COND, MSG, ...) \
+    (COND) ? (void)0 : (JUTAssertion::showAssert_f(JUTAssertion::getSDevice(), __FILE__, __LINE__, MSG, __VA_ARGS__), OSPanic(__FILE__, __LINE__, "Halt"));
+
+#define J3D_PANIC(LINE, COND, MSG) ((COND) != 0 || (OSPanic(__FILE__, __LINE__, MSG), 0));
+
+#define JUT_PANIC(LINE, TEXT)                                                                      \
+JUTAssertion::showAssert(JUTAssertion::getSDevice(), __FILE__, __LINE__, TEXT);                    \
+    OSPanic(__FILE__, __LINE__, "Halt");
+
+#define JUT_PANIC_F(LINE, MSG, ...)                                                               \
+JUTAssertion::showAssert_f(JUTAssertion::getSDevice(), __FILE__, __LINE__, MSG, __VA_ARGS__);        \
+    OSPanic(__FILE__, __LINE__, "Halt");
+
+#define JUT_WARN_DEVICE(LINE, DEVICE, ...)                                                                        \
+    JUTAssertion::setWarningMessage_f(DEVICE, __FILE__, __LINE__, __VA_ARGS__);    \
+
+#define JUT_LOG(LINE, ...)                                                                         \
+    JUTAssertion::setLogMessage_f(JUTAssertion::getSDevice(), __FILE__, __LINE__, __VA_ARGS__)
+
+#define JUT_SET_CONFIRM(LINE, COND)                                                                \
+    JUTAssertion::setConfirmMessage(JUTAssertion::getSDevice(), __FILE__, __LINE__, COND, #COND)
+
+#endif
+#define JUT_WARN(LINE, ...)                                                                        \
+    JUT_WARN_DEVICE(__LINE__, JUTAssertion::getSDevice(), __VA_ARGS__)
+
 #define JUT_CONFIRM(LINE, COND)                                                                    \
     JUT_SET_CONFIRM(LINE, COND)
-
 #else
 #define JUT_ASSERT(...) (void)0;
 #define JUT_ASSERT_MSG(...) (void)0;

--- a/include/dolphin/os.h
+++ b/include/dolphin/os.h
@@ -306,6 +306,8 @@ extern int __OSInIPL;
 #endif
 
 #if DEBUG
+#if __MWERKS__
+
 #define ASSERTLINE(line, cond) \
     ((cond) || (OSPanic(__FILE__, line, "Failed assertion " #cond), 0))
 
@@ -320,6 +322,25 @@ extern int __OSInIPL;
 
 #define ASSERTMSGLINEV(line, cond, ...) \
     ((cond) || (OSPanic(__FILE__, line, __VA_ARGS__), 0))
+
+#else
+
+#define ASSERTLINE(line, cond) \
+    ((cond) || (OSPanic(__FILE__, __LINE__, "Failed assertion " #cond), 0))
+
+#define ASSERTMSGLINE(line, cond, msg) \
+    ((cond) || (OSPanic(__FILE__, __LINE__, msg), 0))
+
+    // This is dumb but we dont have a Metrowerks way to do variadic macros in the macro to make this done in a not scrubby way.
+#define ASSERTMSG1LINE(line, cond, msg, arg1) \
+    ((cond) || (OSPanic(__FILE__, __LINE__, msg, arg1), 0))
+#define ASSERTMSG2LINE(line, cond, msg, arg1, arg2) \
+    ((cond) || (OSPanic(__FILE__, __LINE__, msg, arg1, arg2), 0))
+
+#define ASSERTMSGLINEV(line, cond, ...) \
+    ((cond) || (OSPanic(__FILE__, __LINE__, __VA_ARGS__), 0))
+
+#endif
 
 #else
 #define ASSERTLINE(line, cond) (void)0


### PR DESCRIPTION
Redefine the macros to use `__LINE__`