### PR TITLE
Disable assert heap on DVD thread

### DIFF
--- a/src/m_Do/m_Do_dvd_thread.cpp
+++ b/src/m_Do/m_Do_dvd_thread.cpp
@@ -16,7 +16,13 @@
 
 s32 mDoDvdThd::main(void* param_0) {
     JKRThread(OSGetCurrentThread(), 0);
+#if TARGET_PC
+    // Disable assert heap, our DVD impl does allocs
+    // Can be turned back if we isolate the OS impl from game code properly.
+    JKRSetCurrentHeap(JKRHeap::getSystemHeap());
+#else
     JKRSetCurrentHeap(mDoExt_getAssertHeap());
+#endif
     mDoDvdThd_param_c* param = static_cast<mDoDvdThd_param_c*>(param_0);
     param->mainLoop();
     return 0;


### PR DESCRIPTION
Nintendo does this probably as a debugging aid. Problem is we allocate from our DVD driver implementation, so everything explodes.