### PR TITLE
Make JKRHeap::sCurrentHeap thread local

### DIFF
--- a/include/JSystem/JKernel/JKRHeap.h
+++ b/include/JSystem/JKernel/JKRHeap.h
@@ -169,9 +169,17 @@ public:
     static JKRHeap* getRootHeap2() { return sRootHeap2; }
 
     static JKRHeap* getSystemHeap() { return sSystemHeap; }
+#if TARGET_PC
+    static JKRHeap* getCurrentHeap();
+#else
     static JKRHeap* getCurrentHeap() { return sCurrentHeap; }
+#endif
     static void setSystemHeap(JKRHeap* heap) { sSystemHeap = heap; }
+#if TARGET_PC
+    static void setCurrentHeap(JKRHeap* heap);
+#else
     static void setCurrentHeap(JKRHeap* heap) { sCurrentHeap = heap; }
+#endif
 
     static void setState_u32ID_(TState* state, u32 id) { state->mId = id; }
     static void setState_uUsedSize_(TState* state, u32 usedSize) { state->mUsedSize = usedSize; }
@@ -195,7 +203,9 @@ public:
     static JKRHeap* sRootHeap2;
 
     static JKRHeap* sSystemHeap;
+#if !TARGET_PC // Hide sCurrentHeap, we need to make it thread local.
     static JKRHeap* sCurrentHeap;
+#endif
 
     static JKRErrorHandler mErrorHandler;
 };

--- a/src/JSystem/JKernel/JKRHeap.cpp
+++ b/src/JSystem/JKernel/JKRHeap.cpp
@@ -28,7 +28,13 @@ bool JKRHeap::sDefaultFillFlag = true;
 
 JKRHeap* JKRHeap::sSystemHeap;
 
+#if TARGET_PC
+// JSystem normally has a thread switch callback to track the correct heap.
+// We can't do this as we're (currently) using true OS threads. So use a true thread local.
+static thread_local JKRHeap* sCurrentHeap;
+#else
 JKRHeap* JKRHeap::sCurrentHeap;
+#endif
 
 JKRHeap* JKRHeap::sRootHeap;
 
@@ -498,7 +504,7 @@ void* operator new(size_t size) {
 }
 #else
 void* operator new(size_t size) {
-    if (JKRHeap::sCurrentHeap == NULL) {
+    if (sCurrentHeap == NULL) {
         return malloc(size);
     }
     void* mem = JKRHeap::alloc(size, alignof(max_align_t), NULL);
@@ -516,7 +522,7 @@ void* operator new(size_t size, int alignment) {
 }
 #else
 void* operator new(size_t size, int alignment) {
-    if (JKRHeap::sCurrentHeap == nullptr)
+    if (sCurrentHeap == nullptr)
         return _aligned_malloc(size, alignment);
     void* mem = JKRHeap::alloc(size, alignment, nullptr);
     if (mem == nullptr) {
@@ -537,7 +543,7 @@ void* operator new[](size_t size) {
 }
 #else
 void* operator new[](size_t size) {
-    if (JKRHeap::sCurrentHeap == NULL)
+    if (sCurrentHeap == NULL)
         return malloc(size);
     void* mem = JKRHeap::alloc(size, alignof(max_align_t), NULL);
     if (mem == NULL) {
@@ -553,7 +559,7 @@ void* operator new[](size_t size, int alignment) {
 }
 #else
 void* operator new[](size_t size, int alignment) {
-    if (JKRHeap::sCurrentHeap == nullptr)
+    if (sCurrentHeap == nullptr)
         return _aligned_malloc(size, alignment);
     void* mem = JKRHeap::alloc(size, alignment, nullptr);
     if (mem == nullptr)
@@ -630,3 +636,13 @@ s32 JKRHeap::do_changeGroupID(u8 param_0) {
 u8 JKRHeap::do_getCurrentGroupId() {
     return 0;
 }
+
+#if TARGET_PC
+void JKRHeap::setCurrentHeap(JKRHeap* heap) {
+    sCurrentHeap = heap;
+}
+
+JKRHeap* JKRHeap::getCurrentHeap() {
+    return sCurrentHeap;
+}
+#endif

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -285,7 +285,9 @@ void mDoGph_gInf_c::create() {
     VISetTrapFilter(0);
     #endif
 
-    #if PLATFORM_GCN
+    #if TARGET_PC
+    JFWDisplay::createManager(JKRHeap::getCurrentHeap(), JUTXfb::UNK_2, true);
+    #elif PLATFORM_GCN
     JFWDisplay::createManager(JKRHeap::sCurrentHeap, JUTXfb::UNK_2, true);
     #else
     JFWDisplay::createManager(JKRHeap::getRootHeap2(), JUTXfb::UNK_2, true);


### PR DESCRIPTION
Needed because we're using true OS threading, so we can't do the normal JSystem heap changing on thread change.

Requires encapsulating it (removing the public static field)