### PR TITLE
Update aurora for prebuilt packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,3 +112,6 @@ add_executable(dusk src/dusk/main.cpp)
 target_compile_definitions(dusk PRIVATE TARGET_PC AVOID_UB=1 VERSION=0)
 target_include_directories(dusk PRIVATE include)
 target_link_libraries(dusk PRIVATE game aurora::main)
+
+include(extern/aurora/cmake/AuroraCopyRuntimeDLLs.cmake)
+aurora_copy_runtime_dlls(dusk game)


### PR DESCRIPTION
By default, Dawn, SDL3 and nod are fetched as prebuilt packages when available for the current platform.  This behavior can be controlled via `AURORA_DAWN_PROVIDER`, `AURORA_DAWN_LINKAGE`, etc. See aurora's CMakeLists.txt for more info. (For example, one could configure release CI builds to build everything as a vendored static library, so that distribution is easier.)

Additionally, on Windows, Dawn, SDL3 and nod are all built as DLLs and copied into the target directory via `aurora_copy_runtime_dlls`.