### PR TITLE
JAUSoundTable-related crash fix

### DIFF
--- a/libs/JSystem/src/JAudio2/JAUSoundTable.cpp
+++ b/libs/JSystem/src/JAudio2/JAUSoundTable.cpp
@@ -15,7 +15,7 @@ void JAUSoundTable::init(void const* param_0) {
 }
 
 u8 JAUSoundTable::getTypeID(JAISoundID param_0) const {
-#if TARGET_PC
+#if DUSK_AUDIO_DISABLED
     if (this == NULL) {
         return 0xff;
     }
@@ -35,7 +35,7 @@ u8 JAUSoundTable::getTypeID(JAISoundID param_0) const {
 }
 
 JAUSoundTableItem* JAUSoundTable::getData(JAISoundID param_0) const {
-#if TARGET_PC
+#if DUSK_AUDIO_DISABLED
     if (this == NULL) {
         return NULL;
     }

--- a/libs/JSystem/src/JAudio2/JAUSoundTable.cpp
+++ b/libs/JSystem/src/JAudio2/JAUSoundTable.cpp
@@ -15,6 +15,11 @@ void JAUSoundTable::init(void const* param_0) {
 }
 
 u8 JAUSoundTable::getTypeID(JAISoundID param_0) const {
+#if TARGET_PC
+    if (this == NULL) {
+        return 0xff;
+    }
+#endif
     if (param_0.isAnonymous()) {
         return 0xff;
     }
@@ -30,6 +35,11 @@ u8 JAUSoundTable::getTypeID(JAISoundID param_0) const {
 }
 
 JAUSoundTableItem* JAUSoundTable::getData(JAISoundID param_0) const {
+#if TARGET_PC
+    if (this == NULL) {
+        return NULL;
+    }
+#endif
     if (param_0.isAnonymous()) {
         return NULL;
     }

--- a/src/Z2AudioLib/Z2SceneMgr.cpp
+++ b/src/Z2AudioLib/Z2SceneMgr.cpp
@@ -1718,11 +1718,16 @@ void Z2SceneMgr::setSceneName(char* spot, s32 room, s32 layer) {
 
     if (Z2GetSoundMgr()->getStreamMgr()->isActive()) {
         JAUSoundTable* sound_table = JAUSoundTable::getInstance();
-        JSUList<JAIStream>* stream_list = Z2GetSoundMgr()->getStreamMgr()->getStreamList();
-        JSULink<JAIStream>* stream;
-        for (stream = stream_list->getFirst(); stream != NULL; stream = stream->getNext()) {
-            if (bVar2 || sound_table->getTypeID(stream->getObject()->getID()) != 0x71) {
-                stream->getObject()->stop(Z2Param::SCENE_CHANGE_BGM_FADEOUT_TIME);
+#if TARGET_PC
+        if (sound_table->isValid())
+#endif
+        {
+            JSUList<JAIStream>* stream_list = Z2GetSoundMgr()->getStreamMgr()->getStreamList();
+            JSULink<JAIStream>* stream;
+            for (stream = stream_list->getFirst(); stream != NULL; stream = stream->getNext()) {
+                if (bVar2 || sound_table->getTypeID(stream->getObject()->getID()) != 0x71) {
+                    stream->getObject()->stop(Z2Param::SCENE_CHANGE_BGM_FADEOUT_TIME);
+                }
             }
         }
     }

--- a/src/Z2AudioLib/Z2SceneMgr.cpp
+++ b/src/Z2AudioLib/Z2SceneMgr.cpp
@@ -1718,7 +1718,7 @@ void Z2SceneMgr::setSceneName(char* spot, s32 room, s32 layer) {
 
     if (Z2GetSoundMgr()->getStreamMgr()->isActive()) {
         JAUSoundTable* sound_table = JAUSoundTable::getInstance();
-#if TARGET_PC
+#if DUSK_AUDIO_DISABLED
         if (sound_table->isValid())
 #endif
         {


### PR DESCRIPTION
Allows loading into more areas, tested using the Lanayru Fishing Pond. Does not resolve the underlying issue of why these things are NULL, so that should be looked into further.