### PR TITLE
Toggle bloom from graphics menu

### DIFF
--- a/src/dusk/imgui/ImGuiConsole.hpp
+++ b/src/dusk/imgui/ImGuiConsole.hpp
@@ -13,6 +13,7 @@ namespace dusk {
 	public:
 		ImGuiConsole();
 		void draw();
+        bool isBloomEnabled() { return m_menuGame.isBloomEnabled(); }
 
 		static bool CheckMenuViewToggle(ImGuiKey key, bool& active);
 

--- a/src/dusk/imgui/ImGuiMenuGame.cpp
+++ b/src/dusk/imgui/ImGuiMenuGame.cpp
@@ -22,6 +22,7 @@ namespace dusk {
             ImGui::Separator();
 
             if (ImGui::BeginMenu("Graphics")) {
+                ImGui::Checkbox("Native Bloom", &m_graphicsSettings.m_enableBloom);
                 ImGui::EndMenu();
             }
 

--- a/src/dusk/imgui/ImGuiMenuGame.hpp
+++ b/src/dusk/imgui/ImGuiMenuGame.hpp
@@ -12,6 +12,7 @@ namespace dusk {
     public:
         ImGuiMenuGame();
         void draw();
+        bool isBloomEnabled() { return m_graphicsSettings.m_enableBloom; }
 
         void windowInputViewer();
         void windowControllerConfig();
@@ -31,6 +32,10 @@ namespace dusk {
             PADButtonMapping* m_pendingMapping = nullptr;
             int m_pendingPort = -1;
         } m_controllerConfig;
+
+        struct {
+            bool m_enableBloom = 1;
+        } m_graphicsSettings;
 
         bool m_showControllerConfig = false;
 

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1135,6 +1135,11 @@ void mDoGph_gInf_c::bloom_c::remove() {
 }
 
 void mDoGph_gInf_c::bloom_c::draw() {
+#if TARGET_PC
+    if (!dusk::g_imguiConsole.isBloomEnabled()) {
+        return;
+    }
+#endif
     bool enabled = mEnable && m_buffer != NULL;
     if (mMonoColor.a != 0 || enabled) {
 #if TARGET_PC


### PR DESCRIPTION
Felt a little sad seeing the graphics menu empty, so here's a bloom toggle. Might be worth offering if people want to pair Dusk with ReShade down the line.

This may be a bad way to implement this but it's what seemed to fit in with the existing codebase. I am a newbie so absolutely correct me if so.