### PR TITLE
Add tweak to enable/disable TV settings screen

### DIFF
--- a/include/d/d_s_name.h
+++ b/include/d/d_s_name.h
@@ -48,6 +48,7 @@ public:
     void FileSelectClose();
     void brightCheckOpen();
     void brightCheck();
+    void doPreLoadSetup();
     void changeGameScene();
 
     #if VERSION == VERSION_GCN_PAL
@@ -70,6 +71,9 @@ private:
     /* 0x41E */ u8 mWaitTimer;
     /* 0x41F */ u8 field_0x41f;
     /* 0x420 */ u8 field_0x420;
+#if TARGET_PC
+    bool mShowTvSettingsScreen;
+#endif
 };
 
 #endif /* D_S_D_S_NAME_H */

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -27,6 +27,7 @@ struct UserSettings {
     struct {
         // QoL
         bool enableQuickTransform;
+        bool hideTvSettingsScreen;
 
         // Preferences
         bool enableMirrorMode;

--- a/src/d/d_s_name.cpp
+++ b/src/d/d_s_name.cpp
@@ -18,6 +18,12 @@
 #include "f_op/f_op_overlap_mng.h"
 #include "dusk/memory.h"
 
+#if TARGET_PC
+#define SHOW_TV_SETTINGS_SCREEN (this->mShowTvSettingsScreen)
+#else
+#define SHOW_TV_SETTINGS_SCREEN (1)
+#endif
+
 static dSn_HIO_c g_snHIO;
 
 #if VERSION == VERSION_GCN_PAL
@@ -293,13 +299,27 @@ void dScnName_c::FileSelectMain() {
 }
 
 void dScnName_c::FileSelectMainNormal() {
+#if TARGET_PC
+    mShowTvSettingsScreen = !dusk::getSettings().game.hideTvSettingsScreen;
+#endif
+
     switch(dFs_c->isSelectEnd()) {
     case 1:
-        mWaitTimer = 15;
-        mDoGph_gInf_c::setFadeColor(*(JUtility::TColor*)&g_blackColor);
-        mDoGph_gInf_c::startFadeOut(15);
+        if (SHOW_TV_SETTINGS_SCREEN) {
+            mWaitTimer = 15;
+            mDoGph_gInf_c::setFadeColor(*(JUtility::TColor*)&g_blackColor);
+            mDoGph_gInf_c::startFadeOut(15);
+        } else {
+            mWaitTimer = 1;
+        }
+
         mProc = dScnName_PROC_FileSelectClose;
         field_0x420 = 1;
+
+        if (!SHOW_TV_SETTINGS_SCREEN) {
+            mDoAud_seStart(Z2SE_ENTER_GAME, NULL, 0, 0);
+        }
+
         break;
     }
 }
@@ -308,12 +328,17 @@ void dScnName_c::FileSelectClose() {
     mWaitTimer--;
 
     if (mWaitTimer == 0) {
-        mProc = dScnName_PROC_BrightCheckOpen;
-        mWaitTimer = 15;
-        mDrawProc = 1;
-        mDoGph_gInf_c::setFadeColor(*(JUtility::TColor*)&g_blackColor);
-        mDoGph_gInf_c::startFadeIn(15);
-        field_0x420 = 0;
+        if (SHOW_TV_SETTINGS_SCREEN) {
+            mProc = dScnName_PROC_BrightCheckOpen;
+            mWaitTimer = 15;
+            mDrawProc = 1;
+            mDoGph_gInf_c::setFadeColor(*(JUtility::TColor*)&g_blackColor);
+            mDoGph_gInf_c::startFadeIn(15);
+            field_0x420 = 0;
+        } else {
+            doPreLoadSetup();
+            field_0x420 = 0;
+        }
     }
 }
 
@@ -330,22 +355,26 @@ void dScnName_c::brightCheck() {
     mBrightCheck->_move();
 
     if (mBrightCheck->isEnd()) {
-        dComIfGs_setSaveTotalTime(dComIfGs_getTotalTime());
-        dComIfGs_setSaveStartTime(OSGetTime());
-        mDoAud_bgmStop(45);
-
-        field_0x41f = 0;
-        mProc = dScnName_PROC_ChangeGameScene;
-
-        // Reset rupee "first-time collection" flags so the collection cutscene will play again
-        dComIfGs_offItemFirstBit(dItemNo_GREEN_RUPEE_e);
-        dComIfGs_offItemFirstBit(dItemNo_BLUE_RUPEE_e);
-        dComIfGs_offItemFirstBit(dItemNo_YELLOW_RUPEE_e);
-        dComIfGs_offItemFirstBit(dItemNo_RED_RUPEE_e);
-        dComIfGs_offItemFirstBit(dItemNo_PURPLE_RUPEE_e);
-        dComIfGs_offItemFirstBit(dItemNo_ORANGE_RUPEE_e);
-        dComIfGs_offItemFirstBit(dItemNo_SILVER_RUPEE_e);
+        doPreLoadSetup();
     }
+}
+
+void dScnName_c::doPreLoadSetup() {
+    dComIfGs_setSaveTotalTime(dComIfGs_getTotalTime());
+    dComIfGs_setSaveStartTime(OSGetTime());
+    mDoAud_bgmStop(45);
+
+    field_0x41f = 0;
+    mProc = dScnName_PROC_ChangeGameScene;
+
+    // Reset rupee "first-time collection" flags so the collection cutscene will play again
+    dComIfGs_offItemFirstBit(dItemNo_GREEN_RUPEE_e);
+    dComIfGs_offItemFirstBit(dItemNo_BLUE_RUPEE_e);
+    dComIfGs_offItemFirstBit(dItemNo_YELLOW_RUPEE_e);
+    dComIfGs_offItemFirstBit(dItemNo_RED_RUPEE_e);
+    dComIfGs_offItemFirstBit(dItemNo_PURPLE_RUPEE_e);
+    dComIfGs_offItemFirstBit(dItemNo_ORANGE_RUPEE_e);
+    dComIfGs_offItemFirstBit(dItemNo_SILVER_RUPEE_e);
 }
 
 void dScnName_c::changeGameScene() {

--- a/src/dusk/imgui/ImGuiMenuEnhancements.cpp
+++ b/src/dusk/imgui/ImGuiMenuEnhancements.cpp
@@ -11,6 +11,10 @@ namespace dusk {
         if (ImGui::BeginMenu("Enhancements")) {
             if (ImGui::BeginMenu("Quality of Life")) {
                 ImGui::Checkbox("Quick Transform (R+Y)", &getSettings().game.enableQuickTransform);
+                ImGui::Checkbox("Hide TV Settings Screen", &getSettings().game.hideTvSettingsScreen);
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip("Hides the TV calibration screen shown when loading a save");
+                }
                 ImGui::EndMenu();
             }
 

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -23,6 +23,7 @@ UserSettings g_userSettings = {
     .game = {
         // Quality of Life
         .enableQuickTransform = false,
+        .hideTvSettingsScreen = false,
 
         // Preferences
         .enableMirrorMode = false,


### PR DESCRIPTION
This adds a new toggle to the QoL menu to enable or disable the TV settings screen.

~~I'm not sure whether this is something that we want to be implement at this stage (or at all), so this PR also serves to get feedback on that.~~

~~I'm slightly iffy on how the new `levers` interface is currently set up - ideally I think we should have a distinct interface separate from ImGui stuff for accessing tweak settings, but it gets a little weird since ImGui works with pointers rather than callbacks. We could maintain separate globals for both the public tweaks interface and the UI layer and update the interface values when something in the UI changes, but that's a lot of added complexity and (IMO) unnecessary redundancy.~~

~~That all said, I do also anticipate that we'll eventually have a more sophisticated UI in place so I'm ultimately not too concerned about the weirdness right now.~~