### PR TITLE
Move aurora_begin_frame/aurora_end_frame calls to main loop

### DIFF
--- a/libs/JSystem/src/JFramework/JFWDisplay.cpp
+++ b/libs/JSystem/src/JFramework/JFWDisplay.cpp
@@ -227,10 +227,6 @@ void JFWDisplay::endGX() {
 }
 
 void JFWDisplay::beginRender() {
-#if TARGET_PC
-    aurora_begin_frame();
-#endif
-
     if (field_0x40) {
         JUTProcBar::getManager()->wholeLoopEnd();
     }
@@ -342,10 +338,6 @@ void JFWDisplay::endFrame() {
         JUTProcBar::getManager()->setCostFrame(retrace_cnt - prevFrame);
         prevFrame = retrace_cnt;
     }
-
-#if TARGET_PC
-    aurora_end_frame();
-#endif
 }
 
 void JFWDisplay::waitBlanking(int param_0) {

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -172,18 +172,24 @@ void main01(void) {
 
         VIWaitForRetrace();
 
+#if TARGET_PC
+        if (!aurora_begin_frame()) {
+            DuskLog.debug("aurora_begin_frame returned false, skipping draw this frame");
+            continue;
+        }
+#endif
+
         // EXECUTE GAME LOGIC & RENDER
         // This calls mDoGph_Painter -> JFWDisplay -> GX Functions
         fapGm_Execute();
 
         mDoAud_Execute();
 
+        aurora_end_frame();
+
         #if TARGET_PC
         frameLimiter.Sleep(DUSK_FRAME_PERIOD);
         #endif
-
-        //aurora_end_frame();
-
     } while (true);
 
     exit:;


### PR DESCRIPTION
This fixes an issue when using SDL's X11 backend due to Dusk attempting to render ImGui menus without an active frame.