### PR TITLE
Use PCH to massively speed up compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 if (APPLE)
     project(dusk LANGUAGES C CXX OBJC OBJCXX)
 else ()
@@ -110,6 +110,7 @@ add_library(game SHARED ${DOLZEL_FILES} ${Z2AUDIOLIB_FILES} ${SSYSTEM_FILES} ${J
 target_link_libraries(game PRIVATE game_debug cxxopts::cxxopts)
 target_compile_definitions(game PRIVATE TARGET_PC AVOID_UB=1 VERSION=0 NDEBUG=1 NDEBUG_DEFINED=1 DEBUG_DEFINED=0
         DUSK_TP_VERSION="${DUSK_TP_VERSION}" DUSK_GAME_NAME="${DUSK_GAME_NAME}" DUSK_GAME_VERSION="${DUSK_GAME_VERSION}")
+target_precompile_headers(game PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/include/d/dusk_pch.hpp>")
 add_executable(dusk src/dusk/main.cpp)
 target_compile_definitions(dusk PRIVATE TARGET_PC AVOID_UB=1 VERSION=0)
 target_include_directories(dusk PRIVATE include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ add_library(game SHARED ${DOLZEL_FILES} ${Z2AUDIOLIB_FILES} ${SSYSTEM_FILES} ${J
 target_link_libraries(game PRIVATE game_debug cxxopts::cxxopts)
 target_compile_definitions(game PRIVATE TARGET_PC AVOID_UB=1 VERSION=0 NDEBUG=1 NDEBUG_DEFINED=1 DEBUG_DEFINED=0
         DUSK_TP_VERSION="${DUSK_TP_VERSION}" DUSK_GAME_NAME="${DUSK_GAME_NAME}" DUSK_GAME_VERSION="${DUSK_GAME_VERSION}")
-target_precompile_headers(game PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/include/d/dusk_pch.hpp>")
+target_precompile_headers(game PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/include/dusk_pch.hpp>")
 add_executable(dusk src/dusk/main.cpp)
 target_compile_definitions(dusk PRIVATE TARGET_PC AVOID_UB=1 VERSION=0)
 target_include_directories(dusk PRIVATE include)

--- a/include/d/dusk_pch.hpp
+++ b/include/d/dusk_pch.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#define PROCS_DUMP_NAMES 1
+
+#include "dolzel_rel.pch"
+#include "dolzel.pch"
+#include "dolzel_base.pch"

--- a/include/d/dusk_pch.hpp
+++ b/include/d/dusk_pch.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#define PROCS_DUMP_NAMES 1
-
-#include "dolzel_rel.pch"
-#include "dolzel.pch"
-#include "dolzel_base.pch"

--- a/include/dusk_pch.hpp
+++ b/include/dusk_pch.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#define PROCS_DUMP_NAMES 1
+
+#include "d/dolzel.pch"
+#include "d/dolzel_base.pch"
+#include "d/dolzel_rel.pch"


### PR DESCRIPTION
A change to a common header goes from 90s to 20s on my system. Crazy.