### PR TITLE
Disable suspicious assert causing cutscene crashes

### DIFF
--- a/libs/JSystem/src/JStudio/JStudio_JAudio2/object-sound.cpp
+++ b/libs/JSystem/src/JStudio/JStudio_JAudio2/object-sound.cpp
@@ -225,7 +225,9 @@ void JStudio_JAudio2::TAdaptor_sound::adaptor_do_PARENT_NODE(JStudio::data::TEOp
 	case JStudio::data::UNK_0x18:
 		if (field_0x13c != NULL) {
             JUT_ASSERT(431, pContent!=NULL);
+#if DUSK_SUSPICIOUS_ASSERTS
             JUT_ASSERT(432, uSize==0);
+#endif
 			field_0x140 = field_0x13c->JSGFindNodeID((char*)pContent);
 			if (field_0x140 == -1) {
 				return;


### PR DESCRIPTION
From my reading of the code this assert is likely incorrect. This throws on cases where usize has a sane-looking value (the length of the pContent null-terminated string), and from my understanding of how the data is parsed, this length is needed to figure out the location of the next "paragraph".