### PR TITLE
Prevent Epona minigame from crashing when Wolf Link (speedrun strat)

### DIFF
--- a/src/SSystem/SComponent/c_cc_d.cpp
+++ b/src/SSystem/SComponent/c_cc_d.cpp
@@ -65,9 +65,14 @@ void cCcD_DivideArea::CalcDivideInfo(cCcD_DivideInfo* pDivideInfo, const cM3dGAa
         if (!mXDiffIsZero) {
             s32 var1 = mInvScaledXDiff * (aab.GetMinP()->x - GetMinP()->x);
             s32 var3 = mInvScaledXDiff * (aab.GetMaxP()->x - GetMinP()->x);
+#if TARGET_PC
+            var1 = var1 < 0 ? 0 : var1 > 31 ? 31 : var1;
+            var3 = var3 < 0 ? 0 : var3 > 31 ? 31 : var3;
+#else
             if (31 < var3) {
                 var3 = 31;
             }
+#endif
 
             xDivInfo = l_base[var3];
             if (0 < var1) {
@@ -81,9 +86,14 @@ void cCcD_DivideArea::CalcDivideInfo(cCcD_DivideInfo* pDivideInfo, const cM3dGAa
         if (!mYDiffIsZero) {
             s32 var1 = mInvScaledYDiff * (aab.GetMinP()->y - GetMinP()->y);
             s32 var3 = mInvScaledYDiff * (aab.GetMaxP()->y - GetMinP()->y);
+#if TARGET_PC
+            var1 = var1 < 0 ? 0 : var1 > 31 ? 31 : var1;
+            var3 = var3 < 0 ? 0 : var3 > 31 ? 31 : var3;
+#else
             if (31 < var3) {
                 var3 = 31;
             }
+#endif
 
             yDivInfo = l_base[var3];
             if (0 < var1) {
@@ -97,9 +107,14 @@ void cCcD_DivideArea::CalcDivideInfo(cCcD_DivideInfo* pDivideInfo, const cM3dGAa
         if (!mZDiffIsZero) {
             s32 var1 = mInvScaledZDiff * (aab.GetMinP()->z - GetMinP()->z);
             s32 var3 = mInvScaledZDiff * (aab.GetMaxP()->z - GetMinP()->z);
+#if TARGET_PC
+            var1 = var1 < 0 ? 0 : var1 > 31 ? 31 : var1;
+            var3 = var3 < 0 ? 0 : var3 > 31 ? 31 : var3;
+#else
             if (31 < var3) {
                 var3 = 31;
             }
+#endif
 
             zDivInfo = l_base[var3];
             if (0 < var1) {

--- a/src/SSystem/SComponent/c_cc_d.cpp
+++ b/src/SSystem/SComponent/c_cc_d.cpp
@@ -6,6 +6,7 @@
 #include "SSystem/SComponent/c_cc_d.h"
 #include "JSystem/JUtility/JUTAssert.h"
 #include <cmath>
+#include "dusk/logging.h"
 
 #define CHECK_FLOAT_RANGE(line, x) JUT_ASSERT(line, -1.0e32f < x && x < 1.0e32f);
 
@@ -66,6 +67,15 @@ void cCcD_DivideArea::CalcDivideInfo(cCcD_DivideInfo* pDivideInfo, const cM3dGAa
             s32 var1 = mInvScaledXDiff * (aab.GetMinP()->x - GetMinP()->x);
             s32 var3 = mInvScaledXDiff * (aab.GetMaxP()->x - GetMinP()->x);
 #if TARGET_PC
+            // yDiv seems to be the problematic part here, but I clamped xDiv and zDiv too just in case.
+            // Unlike var1, var3 being greater than 31 isn't logged because it is every frame and the original code accounted for that.
+            // This goes for yDiv and zDiv as well.
+            if (var1 < 0 || var1 > 31) {
+                DuskLog.warn("CalcDivideInfo: xDiv var1 out of range: {}", var1);
+            }
+            if (var3 < 0) {
+                DuskLog.warn("CalcDivideInfo: xDiv var3 out of range: {}", var3);
+            }
             var1 = var1 < 0 ? 0 : var1 > 31 ? 31 : var1;
             var3 = var3 < 0 ? 0 : var3 > 31 ? 31 : var3;
 #else
@@ -87,6 +97,14 @@ void cCcD_DivideArea::CalcDivideInfo(cCcD_DivideInfo* pDivideInfo, const cM3dGAa
             s32 var1 = mInvScaledYDiff * (aab.GetMinP()->y - GetMinP()->y);
             s32 var3 = mInvScaledYDiff * (aab.GetMaxP()->y - GetMinP()->y);
 #if TARGET_PC
+            // When the Epona taming minigame starts as Wolf Link, yDiv var1 can be 32.
+            // When the Epona taming minigame ends, yDiv var1 and var3 can both be INT_MIN.
+            if (var1 < 0 || var1 > 31) {
+                DuskLog.warn("CalcDivideInfo: yDiv var1 out of range: {}", var1);
+            }
+            if (var3 < 0) {
+                DuskLog.warn("CalcDivideInfo: yDiv var3 out of range: {}", var3);
+            }
             var1 = var1 < 0 ? 0 : var1 > 31 ? 31 : var1;
             var3 = var3 < 0 ? 0 : var3 > 31 ? 31 : var3;
 #else
@@ -108,6 +126,12 @@ void cCcD_DivideArea::CalcDivideInfo(cCcD_DivideInfo* pDivideInfo, const cM3dGAa
             s32 var1 = mInvScaledZDiff * (aab.GetMinP()->z - GetMinP()->z);
             s32 var3 = mInvScaledZDiff * (aab.GetMaxP()->z - GetMinP()->z);
 #if TARGET_PC
+            if (var1 < 0 || var1 > 31) {
+                DuskLog.warn("CalcDivideInfo: zDiv var1 out of range: {}", var1);
+            }
+            if (var3 < 0) {
+                DuskLog.warn("CalcDivideInfo: zDiv var3 out of range: {}", var3);
+            }
             var1 = var1 < 0 ? 0 : var1 > 31 ? 31 : var1;
             var3 = var3 < 0 ? 0 : var3 > 31 ? 31 : var3;
 #else

--- a/src/SSystem/SComponent/c_math.cpp
+++ b/src/SSystem/SComponent/c_math.cpp
@@ -109,6 +109,9 @@ static u16 atntable[1025] = {
 
 u16 U_GetAtanTable(f32 f0, f32 f1) {
     int idx = f0 / f1 * 0x400;
+#if TARGET_PC
+    idx = idx < 0 ? 0 : idx > 0x400 ? 0x400 : idx;
+#endif
     return atntable[idx];
 }
 

--- a/src/SSystem/SComponent/c_math.cpp
+++ b/src/SSystem/SComponent/c_math.cpp
@@ -7,6 +7,7 @@
 #include "SSystem/SComponent/c_m3d.h"
 #include <cmath>
 #include <global.h>
+#include "dusk/logging.h"
 
 s16 cM_rad2s(f32 rad) {
     s32 s = (std::fmod(rad, 2 * M_PI) * (0x8000 / M_PI));
@@ -110,6 +111,10 @@ static u16 atntable[1025] = {
 u16 U_GetAtanTable(f32 f0, f32 f1) {
     int idx = f0 / f1 * 0x400;
 #if TARGET_PC
+    // When Wolf Link is playing a Human Link animation, idx can be INT_MIN every frame
+    if (idx < 0 || idx > 0x400) {
+        DuskLog.warn("U_GetAtanTable: idx out of range: {}", idx);
+    }
     idx = idx < 0 ? 0 : idx > 0x400 ? 0x400 : idx;
 #endif
     return atntable[idx];


### PR DESCRIPTION
Clamps some array lookup values that originally weren't