### PR TITLE
Update aurora & increase map resolution

### DIFF
--- a/src/d/d_drawlist.cpp
+++ b/src/d/d_drawlist.cpp
@@ -1403,8 +1403,7 @@ void dDlst_shadowControl_c::init() {
         u16 size = l_realImageSize[i];
 
 #ifdef TARGET_PC
-        // Don't need to allocate an actual texture buffer for aurora; only a placeholder
-        u32 buffer_size = 0x20;
+        u32 buffer_size = 0x20; // No need to allocate memory for texture
 #else
         u32 buffer_size = GXGetTexBufferSize(size, size, 5, GX_DISABLE, 0);
 #endif

--- a/src/d/d_map.cpp
+++ b/src/d/d_map.cpp
@@ -1097,7 +1097,7 @@ void dMap_c::resCopy() {
     }
 }
 
-dMap_c::dMap_c(int param_0, int param_1, int param_2, int param_3) {
+dMap_c::dMap_c(int width, int height, int param_2, int param_3) {
     m_res_src = NULL;
     m_res = NULL;
     mResTIMG = NULL;
@@ -1169,8 +1169,8 @@ dMap_c::dMap_c(int param_0, int param_1, int param_2, int param_3) {
 
     resCopy();
 
-    mTexSizeX = param_0;
-    mTexSizeY = param_1;
+    mTexSizeX = width;
+    mTexSizeY = height;
 
     if (dMap_HIO_prm_res_dst_s::m_res->field_0x1ae > 0) {
         field_0x74 = dMap_HIO_prm_res_dst_s::m_res->field_0x1b0 / 6;
@@ -1180,12 +1180,23 @@ dMap_c::dMap_c(int param_0, int param_1, int param_2, int param_3) {
     mImage_p = JKR_NEW_ARRAY_ARGS(u8, buffer_size, 0x20);
     JUT_ASSERT(2638, mImage_p != NULL);
 
+
+#ifdef TARGET_PC
+    // Increase map render resolution
+    renderingDAmap_c::init(mImage_p, mTexSizeX * 4, mTexSizeY * 4, mTexSizeX, mTexSizeY);
+#else
     renderingDAmap_c::init(mImage_p, mTexSizeX, mTexSizeY, mTexSizeX, mTexSizeY);
+#endif
 
     mResTIMG = JKR_NEW_ARGS (0x20) ResTIMG;
     JUT_ASSERT(2647, mResTIMG != NULL);
 
+#ifdef TARGET_PC
+    // Increase map render resolution
+    makeResTIMG(mResTIMG, mTexSizeX * 4, mTexSizeY * 4, mImage_p, (u8*)m_res, 0x33);
+#else
     makeResTIMG(mResTIMG, mTexSizeX, mTexSizeY, mImage_p, (u8*)m_res, 0x33);
+#endif
 }
 
 #if DEBUG

--- a/src/d/d_menu_dmap_map.cpp
+++ b/src/d/d_menu_dmap_map.cpp
@@ -300,16 +300,25 @@ void dMenu_DmapMap_c::_delete() {
     }
 }
 
-void dMenu_DmapMap_c::setTexture(u16 param_0, u16 param_1, u16 param_2, u16 param_3) {
+void dMenu_DmapMap_c::setTexture(u16 width, u16 height, u16 param_2, u16 param_3) {
+#ifdef TARGET_PC
+    // Increase map render resolution
+    width *= 4;
+    height *= 4;
+#endif
     for (int lp1 = 0; lp1 < 2; lp1++) {
-        u32 var_r27 = GXGetTexBufferSize(param_0, param_1, 9, 0, 0);
-        mMapImage_p[lp1] = JKR_NEW_ARRAY_ARGS(u8, var_r27, 0x20);
+#ifdef TARGET_PC
+        u32 sz = 0x20; // No need to allocate memory for texture
+#else
+        u32 sz = GXGetTexBufferSize(width, height, 9, 0, 0);
+#endif
+        mMapImage_p[lp1] = JKR_NEW_ARRAY_ARGS(u8, sz, 0x20);
         JUT_ASSERT(1672, mMapImage_p[lp1] != NULL);
-        mRend[lp1].init(mMapImage_p[lp1], param_0, param_1, param_2, param_3);
+        mRend[lp1].init(mMapImage_p[lp1], width, height, param_2, param_3);
 
         mResTIMG[lp1] = JKR_NEW_ARGS (0x20) ResTIMG;
         JUT_ASSERT(1687, mResTIMG[lp1] != NULL);
-        mRend[lp1].makeResTIMG(mResTIMG[lp1], param_0, param_1, mMapImage_p[lp1], (u8*)dMdm_HIO_prm_res_dst_s::m_res, 30);
+        mRend[lp1].makeResTIMG(mResTIMG[lp1], width, height, mMapImage_p[lp1], (u8*)dMdm_HIO_prm_res_dst_s::m_res, 30);
     }
 }
 
@@ -929,7 +938,7 @@ f32 dMenu_StageMapCtrl_c::m_zoomCenterMinZ;
 
 f32 dMenu_StageMapCtrl_c::m_zoomCenterMaxZ;
 
-void dMenu_StageMapCtrl_c::_create(u16 param_0, u16 param_1, u16 param_2, u16 param_3,
+void dMenu_StageMapCtrl_c::_create(u16 width, u16 height, u16 param_2, u16 param_3,
                                    s8 param_4, void* param_5) {
     field_0xe6 = dComIfGp_roomControl_getStayNo();
     field_0xe7 = param_4;
@@ -946,7 +955,7 @@ void dMenu_StageMapCtrl_c::_create(u16 param_0, u16 param_1, u16 param_2, u16 pa
     field_0x98 = param_3;
     f32 var_f26 = field_0x98 > field_0x94 ? field_0x98 : field_0x94;
 
-    dMenu_DmapMap_c::_create(param_0, param_1, param_2, param_3, param_5);
+    dMenu_DmapMap_c::_create(width, height, param_2, param_3, param_5);
     
     getInitDispCenter(&field_0x9c, &field_0xa0);
     field_0xa4 = field_0x9c;

--- a/src/d/d_menu_dmap_map.cpp
+++ b/src/d/d_menu_dmap_map.cpp
@@ -303,8 +303,8 @@ void dMenu_DmapMap_c::_delete() {
 void dMenu_DmapMap_c::setTexture(u16 width, u16 height, u16 param_2, u16 param_3) {
 #ifdef TARGET_PC
     // Increase map render resolution
-    width *= 4;
-    height *= 4;
+    width *= 2;
+    height *= 2;
 #endif
     for (int lp1 = 0; lp1 < 2; lp1++) {
 #ifdef TARGET_PC

--- a/src/d/d_menu_fmap_map.cpp
+++ b/src/d/d_menu_fmap_map.cpp
@@ -657,6 +657,12 @@ const GXColor* dMenu_FmapMap_c::getColor(int param_0) {
 }
 
 void dMenu_FmapMap_c::setTexture(u16 i_width, u16 i_height, u16 param_2, u16 param_3) {
+#ifdef TARGET_PC
+    // Increase map render resolution
+    i_width *= 2;
+    i_height *= 2;
+#endif
+
     mMapImage_p = NULL;
     mResTIMG = NULL;
 #ifdef TARGET_PC

--- a/src/d/d_menu_fmap_map.cpp
+++ b/src/d/d_menu_fmap_map.cpp
@@ -659,7 +659,11 @@ const GXColor* dMenu_FmapMap_c::getColor(int param_0) {
 void dMenu_FmapMap_c::setTexture(u16 i_width, u16 i_height, u16 param_2, u16 param_3) {
     mMapImage_p = NULL;
     mResTIMG = NULL;
+#ifdef TARGET_PC
+    int size = 0x20; // No need to allocate memory for texture
+#else
     int size = GXGetTexBufferSize(i_width, i_height, GX_TF_C8, 0, 0);
+#endif
     mMapImage_p = JKR_NEW_ARRAY_ARGS(u8, size, 0x20);
     init(mMapImage_p, i_width, i_height, param_2, param_3);
     mResTIMG = JKR_NEW_ARGS (0x20) ResTIMG;

--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -124,10 +124,13 @@ namespace dusk {
                 BytesToString(stats->lastIndexSize)));
             ImGuiStringViewText(fmt::format(FMT_STRING("Storage size:      {}\n"),
                 BytesToString(stats->lastStorageSize)));
+            ImGuiStringViewText(fmt::format(FMT_STRING("Tex upload size:   {}\n"),
+                BytesToString(stats->lastTextureUploadSize)));
             ImGuiStringViewText(fmt::format(
                 FMT_STRING("Total:             {}\n"),
                 BytesToString(stats->lastVertSize + stats->lastUniformSize +
-                    stats->lastIndexSize + stats->lastStorageSize)));
+                    stats->lastIndexSize + stats->lastStorageSize +
+                    stats->lastTextureUploadSize)));
         }
         ImGui::End();
     }

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -319,11 +319,11 @@ void mDoGph_gInf_c::create() {
     m_fullFrameBufferTex = (char*)m_fullFrameBufferTimg + sizeof(ResTIMG);
     #endif
 
-    mFrameBufferTimg = createTimg(FB_WIDTH / 2, FB_HEIGHT / 2, 6);
+    mFrameBufferTimg = createTimg(FB_WIDTH / 2, FB_HEIGHT / 2, GX_TF_RGBA8);
     JUT_ASSERT(374, mFrameBufferTimg != NULL);
     mFrameBufferTex = (char*)mFrameBufferTimg + sizeof(ResTIMG);
 
-    mZbufferTimg = createTimg(FB_WIDTH / 2, FB_HEIGHT / 2, 3);
+    mZbufferTimg = createTimg(FB_WIDTH / 2, FB_HEIGHT / 2, GX_TF_IA8);
     JUT_ASSERT(381, mZbufferTimg != NULL);
     mZbufferTex = (char*)mZbufferTimg + sizeof(ResTIMG);
 
@@ -1139,7 +1139,11 @@ void mDoGph_drawFilterQuad(s8 param_0, s8 param_1) {
 
 void mDoGph_gInf_c::bloom_c::create() {
     if (m_buffer == NULL) {
-        u32 size = GXGetTexBufferSize(FB_WIDTH / 2, FB_HEIGHT / 2, 6, GX_FALSE, 0);
+#ifdef TARGET_PC
+        u32 size = 0x20; // No need to allocate memory for texture
+#else
+        u32 size = GXGetTexBufferSize(FB_WIDTH / 2, FB_HEIGHT / 2, GX_TF_RGBA8, GX_FALSE, 0);
+#endif
         m_buffer = mDoExt_getArchiveHeap()->alloc(size, -32);
         JUT_ASSERT(1621, m_buffer != NULL);
 


### PR DESCRIPTION
- Updated aurora with a [texture handling overhaul](https://github.com/encounter/aurora/pull/78)
- Adds "Tex upload size" to debug overlay so it's easier to track down unnecessary texture recreation
  - Menus can get up to **13Mb** reuploaded per-frame!
- Map resolution set to 4x original
  - Aurora doesn't have perfect line size scaling yet, so lines and drop shadow appear smaller than they should

Note that the aurora overhaul touched a lot of stuff; there may be a few regressions here and there