### PR TITLE
Reset title screen instead of softlocking when movies are unsupported

### DIFF
--- a/src/d/actor/d_a_demo00.cpp
+++ b/src/d/actor/d_a_demo00.cpp
@@ -1096,8 +1096,14 @@ inline int daDemo00_c::execute() {
                         case 2: {
                             u16 sp0A = sp0E & 0x3FFF;
                             if ((sp0E & 0xC000) == 0) {
+#if !MOVIE_SUPPORT
+                                // If movie support isn't available, automatically reset.
+                                // TPHD-esque. Maybe not the best solution, but it works.
+                                dComIfGp_event_reset();
+#else
                                 fopAcM_create(fpcNm_MOVIE_PLAYER_e, sp0A, NULL, fopAcM_GetRoomNo(this), NULL, NULL, 0xFF);
                                 mDoGph_gInf_c::fadeOut(1.0f);
+#endif
                             } else {
                                 switch (sp0A) {
                                     case 0:


### PR DESCRIPTION
Currently, the game softlocks when the title screen tries to transition to the movie player when Dusk is compiled without support for it. This change makes the title screen automatically reload in that scenario, instead of requiring the user to trigger a reset themselves. TPHD-esque behavior.

Doing this as a PR since I can't be bothered to get libjpeg-turbo and confirm the movie player still works when Dusk is compiled with support.