### PR TITLE
Refactor Dusk settings out to common interface used by game and UI code

### DIFF
--- a/files.cmake
+++ b/files.cmake
@@ -1341,6 +1341,7 @@ set(DUSK_FILES
         src/dusk/extras.c
         src/dusk/extras.cpp
         src/dusk/globals.cpp
+        src/dusk/settings.cpp
         #src/dusk/m_Do_ext_dusk.cpp
         src/dusk/imgui/ImGuiConsole.hpp
         src/dusk/imgui/ImGuiConsole.cpp

--- a/include/dusk/hotkeys.h
+++ b/include/dusk/hotkeys.h
@@ -1,0 +1,19 @@
+#ifndef DUSK_HOTKEYS_H
+#define DUSK_HOTKEYS_H
+
+namespace dusk::hotkeys {
+
+constexpr const char* DO_RESET = "Ctrl+R";
+
+constexpr const char* TOGGLE_FULLSCREEN = "F11";
+
+constexpr const char* SHOW_PROCESS_MANAGEMENT = "F2";
+constexpr const char* SHOW_DEBUG_OVERLAY = "F3";
+constexpr const char* SHOW_HEAP_VIEWER = "F4";
+constexpr const char* SHOW_STUB_LOG = "F5";
+constexpr const char* SHOW_CAMERA_DEBUG = "F6";
+constexpr const char* SHOW_AUDIO_DEBUG = "F7";
+
+}
+
+#endif // DUSK_HOTKEYS_H

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -1,0 +1,71 @@
+#ifndef DUSK_CONFIG_H
+#define DUSK_CONFIG_H
+
+namespace dusk {
+
+// Persistent user settings
+
+struct UserSettings {
+    // Program settings
+
+    struct {
+        // Video
+        bool enableFullscreen;
+    } video;
+
+    struct {
+        // Audio
+        float masterVolume;
+        float mainMusicVolume;
+        float subMusicVolume;
+        float soundEffectsVolume;
+        float fanfareVolume;
+    } audio;
+
+    // Game settings
+
+    struct {
+        // QoL
+        bool enableQuickTransform;
+
+        // Preferences
+        bool enableMirrorMode;
+        bool invertCameraXAxis;
+
+        // Graphics
+        bool enableBloom;
+        bool useWaterProjectionOffset;
+
+        // Cheats
+        bool enableFastIronBoots;
+
+        // Technical
+        bool restoreWiiGlitches;
+    } game;
+};
+
+UserSettings& getSettings();
+
+// Transient settings
+
+struct CollisionViewSettings {
+    bool enableTerrainView;
+    bool enableWireframe;
+    bool enableAtView;
+    bool enableTgView;
+    bool enableCoView;
+    float terrainViewOpacity;
+    float colliderViewOpacity;
+    float drawRange;
+};
+
+struct TransientSettings {
+    CollisionViewSettings collisionView;
+};
+
+TransientSettings& getTransientSettings();
+
+}
+
+#endif // DUSK_CONFIG_H
+

--- a/include/m_Do/m_Do_controller_pad.h
+++ b/include/m_Do/m_Do_controller_pad.h
@@ -3,8 +3,7 @@
 
 #include "JSystem/JUtility/JUTGamePad.h"
 #include "SSystem/SComponent/c_API_controller_pad.h"
-
-#include "dusk/imgui/ImGuiMenuEnhancements.hpp"
+#include "dusk/settings.h"
 
 // Controller Ports 1 - 4
 enum { PAD_1, PAD_2, PAD_3, PAD_4 };
@@ -57,7 +56,7 @@ public:
 
     static s16 getStickAngle3D(u32 pad) {
         #if TARGET_PC
-        if (dusk::ImGuiMenuEnhancements::m_enhancements.mirrorMode) {
+        if (dusk::getSettings().game.enableMirrorMode) {
             return -getCpadInfo(pad).mMainStickAngle;
         } else {
             return getCpadInfo(pad).mMainStickAngle;
@@ -69,7 +68,7 @@ public:
 
     static f32 getSubStickX3D(u32 pad) {
         #if TARGET_PC
-        if (dusk::ImGuiMenuEnhancements::m_enhancements.mirrorMode) {
+        if (dusk::getSettings().game.enableMirrorMode) {
             return -getCpadInfo(pad).mCStickPosX;
         } else {
             return getCpadInfo(pad).mCStickPosX;

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -7510,7 +7510,7 @@ void daAlink_c::setBlendMoveAnime(f32 i_morf) {
     BOOL sp24 = checkEventRun();
     BOOL sp20 = checkBootsMoveAnime(1);
 #if TARGET_PC
-    if (dusk::ImGuiMenuEnhancements::m_enhancements.fastIronBoots) {
+    if (dusk::getSettings().game.enableFastIronBoots) {
         sp20 = FALSE;
     }
 #endif
@@ -9475,7 +9475,7 @@ void daAlink_c::setStickData() {
                 mHeavySpeedMultiplier = mpHIO->mItem.mIronBoots.m.mInputFactor;
             }
 #if TARGET_PC
-            if (dusk::ImGuiMenuEnhancements::m_enhancements.fastIronBoots) {
+            if (dusk::getSettings().game.enableFastIronBoots) {
                 mHeavySpeedMultiplier = 1.0f;
             }
 #endif
@@ -9487,7 +9487,7 @@ void daAlink_c::setStickData() {
                 mHeavySpeedMultiplier = mpHIO->mItem.mIronBoots.m.mWaterInputFactor;
             }
 #if TARGET_PC
-            if (dusk::ImGuiMenuEnhancements::m_enhancements.fastIronBoots) {
+            if (dusk::getSettings().game.enableFastIronBoots) {
                 mHeavySpeedMultiplier = 1.0f;
             }
 #endif

--- a/src/d/actor/d_a_alink_demo.inc
+++ b/src/d/actor/d_a_alink_demo.inc
@@ -23,8 +23,6 @@
 #include "d/actor/d_a_npc_tkc.h"
 #include <cstring>
 
-#include "dusk/imgui/ImGuiMenuEnhancements.hpp"
-
 BOOL daAlink_c::checkEventRun() const {
     return dComIfGp_event_runCheck() || checkPlayerDemoMode();
 }
@@ -4301,7 +4299,7 @@ bool daAlink_c::checkAcceptWarp() {
      */
     if (mLinkAcch.ChkGroundHit() && !checkModeFlg(MODE_PLAYER_FLY)
         #if TARGET_PC
-        && (dusk::ImGuiMenuEnhancements::m_enhancements.restoreWiiGlitches || !checkNoResetFlg0(FLG0_WATER_IN_MOVE))
+        && (dusk::getSettings().game.restoreWiiGlitches || !checkNoResetFlg0(FLG0_WATER_IN_MOVE))
         #elif VERSION != VERSION_WII_USA_R0
         && !checkNoResetFlg0(FLG0_WATER_IN_MOVE)
         #endif
@@ -4312,7 +4310,7 @@ bool daAlink_c::checkAcceptWarp() {
          */
         if (
             #if TARGET_PC
-            (dusk::ImGuiMenuEnhancements::m_enhancements.restoreWiiGlitches || !getSlidePolygon(&plane)) &&
+            (dusk::getSettings().game.restoreWiiGlitches || !getSlidePolygon(&plane)) &&
             #elif VERSION != VERSION_WII_USA_R0
             !getSlidePolygon(&plane) &&
             #endif

--- a/src/d/actor/d_a_alink_dusk.cpp
+++ b/src/d/actor/d_a_alink_dusk.cpp
@@ -3,10 +3,9 @@
 #include "d/d_meter2.h"
 #include "d/d_meter2_draw.h"
 #include "d/d_meter2_info.h"
-#include "dusk/imgui/ImGuiMenuEnhancements.hpp"
 
 void daAlink_c::handleQuickTransform() {
-    if (!dusk::ImGuiMenuEnhancements::m_enhancements.quickTransform) {
+    if (!dusk::getSettings().game.enableQuickTransform) {
         return;
     }
 

--- a/src/d/actor/d_a_alink_hvyboots.inc
+++ b/src/d/actor/d_a_alink_hvyboots.inc
@@ -6,8 +6,6 @@
 #include "d/actor/d_a_alink.h"
 #include "d/actor/d_a_tag_magne.h"
 
-#include "dusk/imgui/ImGuiMenuEnhancements.hpp"
-
 void daAlink_c::concatMagneBootMtx() {
     if (checkMagneBootsOn()) {
         mDoMtx_stack_c::concat(mMagneBootMtx);
@@ -351,7 +349,7 @@ int daAlink_c::procMagneBootsFly() {
      */
     if (dComIfG_Bgsp().ChkPolySafe(mPolyInfo2)
         #if TARGET_PC
-        && (dusk::ImGuiMenuEnhancements::m_enhancements.restoreWiiGlitches || checkEquipHeavyBoots())
+        && (dusk::getSettings().game.restoreWiiGlitches || checkEquipHeavyBoots())
         #elif PLATFORM_GCN || VERSION == VERSION_WII_KOR
         && checkEquipHeavyBoots()
         #endif

--- a/src/d/d_bg_s.cpp
+++ b/src/d/d_bg_s.cpp
@@ -10,12 +10,14 @@
 #include "d/d_bg_w.h"
 #include "d/d_com_inf_game.h"
 #include "f_op/f_op_actor_mng.h"
-#include "dusk/offset_ptr.h"
 
 #include "d/d_debug_viewer.h"
 #include "d/d_bg_s_capt_poly.h"
 
-#include "dusk/imgui/ImGuiConsole.hpp"
+#if TARGET_PC
+#include "dusk/offset_ptr.h"
+#include "dusk/settings.h"
+#endif
 
 #if DEBUG
 int g_ground_counter;
@@ -619,8 +621,8 @@ static int poly_draw(dBgS_CaptPoly* capt, cBgD_Vtx_t* vtxList, int v0, int v1, i
     GXColor wall_color = {0, 0xFF, 0, 0xFF};
 
 #if TARGET_PC
-    dusk::ImGuiMenuTools::CollisionViewSettings collisionViewSettings = dusk::g_imguiConsole.getCollisionViewSettings();
-    f32 view_opacity = 255 * (collisionViewSettings.m_terrainViewOpacity / 100.0f);
+    const auto& collisionViewSettings = dusk::getTransientSettings().collisionView;
+    f32 view_opacity = 255 * (collisionViewSettings.terrainViewOpacity / 100.0f);
     ground_color.a = view_opacity;
     roof_color.a = view_opacity;
     wall_color.a = view_opacity;
@@ -658,16 +660,16 @@ void dBgS::Draw() {
     cBgS::Draw();
 
 #if TARGET_PC
-    #define IMGUI_TOGGLE_HIO_FLAG(status, flag) \
+    #define DUSK_TOGGLE_HIO_FLAG(status, flag) \
         if (status) { \
             s_InsideHio.m_flags |= flag; \
         } else { \
             s_InsideHio.m_flags &= ~flag; \
         }
 
-    dusk::ImGuiMenuTools::CollisionViewSettings collisionViewSettings = dusk::g_imguiConsole.getCollisionViewSettings();
-    IMGUI_TOGGLE_HIO_FLAG(collisionViewSettings.m_enableTerrainView, dBgS_InsideHIO::FLAG_DISP_POLY_e);
-    IMGUI_TOGGLE_HIO_FLAG(collisionViewSettings.m_enableWireframe, dBgS_InsideHIO::FLAG_WHITE_WIRE_e);
+    const auto& collisionViewSettings = dusk::getTransientSettings().collisionView;
+    DUSK_TOGGLE_HIO_FLAG(collisionViewSettings.enableTerrainView, dBgS_InsideHIO::FLAG_DISP_POLY_e);
+    DUSK_TOGGLE_HIO_FLAG(collisionViewSettings.enableWireframe, dBgS_InsideHIO::FLAG_WHITE_WIRE_e);
 #endif
 
     if (s_InsideHio.ChkDispPoly()) {
@@ -680,8 +682,7 @@ void dBgS::Draw() {
             f32 var_f31 = fabsf(s_InsideHio.m_p0.x);
 
 #if TARGET_PC
-            dusk::ImGuiMenuTools::CollisionViewSettings collisionViewSettings = dusk::g_imguiConsole.getCollisionViewSettings();
-            var_f31 = collisionViewSettings.m_drawRange;
+            var_f31 = collisionViewSettings.drawRange;
 #endif
 
             min.x = player->current.pos.x - var_f31;

--- a/src/d/d_camera.cpp
+++ b/src/d/d_camera.cpp
@@ -28,8 +28,6 @@
 #include "d/d_debug_camera.h"
 #endif
 
-#include "dusk/imgui/ImGuiMenuEnhancements.hpp"
-
 namespace {
 
 static f32 limitf(f32 value, f32 min, f32 max) {
@@ -766,7 +764,7 @@ void dCamera_c::updatePad() {
         var_f31 = mDoCPd_c::getSubStickX3D(mPadID);
 
         #if TARGET_PC
-        if (dusk::ImGuiMenuEnhancements::m_enhancements.invertCameraXAxis) {
+        if (dusk::getSettings().game.invertCameraXAxis) {
             var_f31 *= -1.0f;
         }
         #endif

--- a/src/d/d_cc_s.cpp
+++ b/src/d/d_cc_s.cpp
@@ -9,8 +9,9 @@
 #include "d/d_com_inf_game.h"
 #include "d/d_jnt_col.h"
 #include "f_op/f_op_actor_mng.h"
-
-#include "dusk/imgui/ImGuiConsole.hpp"
+#if TARGET_PC
+#include "dusk/settings.h"
+#endif
 
 class dCcS_HIO : public JORReflexible {
 public:
@@ -770,19 +771,19 @@ void dCcS::Draw() {
     #endif
 
 #if TARGET_PC
-#define IMGUI_TOGGLE_HIO_FLAG(status, flag) \
+#define DUSK_TOGGLE_HIO_FLAG(status, flag) \
         if (status) { \
             s_Hio.m_flags |= flag; \
         } else { \
             s_Hio.m_flags &= ~flag; \
         }
 
-    dusk::ImGuiMenuTools::CollisionViewSettings collisionViewSettings = dusk::g_imguiConsole.getCollisionViewSettings();
-    IMGUI_TOGGLE_HIO_FLAG(collisionViewSettings.m_enableAtView, dCcS_HIO::FLAG_AT_ON_e);
-    IMGUI_TOGGLE_HIO_FLAG(collisionViewSettings.m_enableTgView, dCcS_HIO::FLAG_TG_ON_e);
-    IMGUI_TOGGLE_HIO_FLAG(collisionViewSettings.m_enableCoView, dCcS_HIO::FLAG_CO_ON_e);
+    const auto& collisionViewSettings = dusk::getTransientSettings().collisionView;
+    DUSK_TOGGLE_HIO_FLAG(collisionViewSettings.enableAtView, dCcS_HIO::FLAG_AT_ON_e);
+    DUSK_TOGGLE_HIO_FLAG(collisionViewSettings.enableTgView, dCcS_HIO::FLAG_TG_ON_e);
+    DUSK_TOGGLE_HIO_FLAG(collisionViewSettings.enableCoView, dCcS_HIO::FLAG_CO_ON_e);
 
-    f32 view_opacity = 255 * (collisionViewSettings.m_colliderViewOpacity / 100.0f);
+    f32 view_opacity = 255 * (collisionViewSettings.colliderViewOpacity / 100.0f);
 #endif
 
     if (s_Hio.CheckAtOn()) {

--- a/src/d/d_kankyo.cpp
+++ b/src/d/d_kankyo.cpp
@@ -32,7 +32,7 @@
 #include <cstdlib>
 #include <cstring>
 #if TARGET_PC
-#include "dusk/imgui/ImGuiConsole.hpp"
+#include "dusk/settings.h"
 #endif
 
 static void GxXFog_set();
@@ -11381,7 +11381,7 @@ void dKy_bg_MAxx_proc(void* bg_model_p) {
                                 C_MTXLightPerspective(sp1D8, dComIfGd_getView()->fovy,
                                                       camera_p->view.aspect, 1.0f, 1.0f,
 #if TARGET_PC
-                                                      dusk::ImGuiMenuEnhancements::m_enhancements.useWaterProjectionOffset ? -0.01f : 0.0f, 0.0f);
+                                                      dusk::getSettings().game.useWaterProjectionOffset ? -0.01f : 0.0f, 0.0f);
 #else
                                                       -0.01f, 0.0f);
 #endif

--- a/src/dusk/imgui/ImGuiConsole.hpp
+++ b/src/dusk/imgui/ImGuiConsole.hpp
@@ -17,11 +17,7 @@ public:
     void PreDraw();
     void PostDraw();
 
-    ImGuiMenuTools::CollisionViewSettings& getCollisionViewSettings() {
-        return m_menuTools.getCollisionViewSettings();
-    }
-
-    static bool CheckMenuViewToggle(ImGuiKey key, bool& active);
+	static bool CheckMenuViewToggle(ImGuiKey key, bool& active);
 
 private:
     struct Toast {

--- a/src/dusk/imgui/ImGuiMenuEnhancements.cpp
+++ b/src/dusk/imgui/ImGuiMenuEnhancements.cpp
@@ -1,54 +1,49 @@
-#include "fmt/format.h"
 #include "imgui.h"
-#include "aurora/gfx.h"
 
-#include "ImGuiConsole.hpp"
 #include "ImGuiMenuEnhancements.hpp"
-#include <imgui_internal.h>
+
+#include "dusk/settings.h"
 
 namespace dusk {
-    EnhancementsSettings ImGuiMenuEnhancements::m_enhancements = {
-        .fastIronBoots = false,
-        .invertCameraXAxis = false,
-        .restoreWiiGlitches = false,
-        .enableBloom = true,
-        .useWaterProjectionOffset = false,
-        .mirrorMode = false,
-    };
-
     ImGuiMenuEnhancements::ImGuiMenuEnhancements() {}
 
     void ImGuiMenuEnhancements::draw() {
         if (ImGui::BeginMenu("Enhancements")) {
             if (ImGui::BeginMenu("Quality of Life")) {
-                ImGui::Checkbox("Fast Iron Boots", &m_enhancements.fastIronBoots);
-                ImGui::Checkbox("Invert Camera X Axis", &m_enhancements.invertCameraXAxis);
-                ImGui::Checkbox("Quick Transform (R+Y)", &m_enhancements.quickTransform);
+                ImGui::Checkbox("Quick Transform (R+Y)", &getSettings().game.enableQuickTransform);
+                ImGui::EndMenu();
+            }
+
+            if (ImGui::BeginMenu("Preferences")) {
+                ImGui::Checkbox("Mirror Mode", &getSettings().game.enableMirrorMode);
+                ImGui::Checkbox("Invert Camera X Axis", &getSettings().game.invertCameraXAxis);
+
                 ImGui::EndMenu();
             }
 
             if (ImGui::BeginMenu("Graphics")) {
-                ImGui::Checkbox("Native Bloom", &m_enhancements.enableBloom);
-                ImGui::Checkbox("Water Projection Offset", &m_enhancements.useWaterProjectionOffset);
+                ImGui::Checkbox("Native Bloom", &getSettings().game.enableBloom);
+                ImGui::Checkbox("Water Projection Offset", &getSettings().game.useWaterProjectionOffset);
                 if (ImGui::IsItemHovered()) {
                     ImGui::SetTooltip("Adds GC-specific -0.01 transS offset\n"
                         "that causes ~6px ghost artifacts in water reflections");
-                }
-                ImGui::Checkbox("Mirror Mode", &m_enhancements.mirrorMode);
-
-                ImGui::EndMenu();
-            }
-
-            if (ImGui::BeginMenu("Restorations")) {
-                ImGui::Checkbox("Restore Wii 1.0 Glitches", &m_enhancements.restoreWiiGlitches);
-                if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip("Restores patched glitches from Wii USA 1.0, the first released version");
                 }
 
                 ImGui::EndMenu();
             }
 
             if (ImGui::BeginMenu("Cheats")) {
+                ImGui::Checkbox("Fast Iron Boots", &getSettings().game.enableFastIronBoots);
+
+                ImGui::EndMenu();
+            }
+
+            if (ImGui::BeginMenu("Technical")) {
+                ImGui::Checkbox("Restore Wii 1.0 Glitches", &getSettings().game.restoreWiiGlitches);
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip("Restores patched glitches from Wii USA 1.0, the first released version");
+                }
+
                 ImGui::EndMenu();
             }
 

--- a/src/dusk/imgui/ImGuiMenuEnhancements.hpp
+++ b/src/dusk/imgui/ImGuiMenuEnhancements.hpp
@@ -8,22 +8,10 @@
 #include "imgui.h"
 
 namespace dusk {
-    struct EnhancementsSettings {
-        bool fastIronBoots;
-        bool invertCameraXAxis;
-        bool quickTransform;
-        bool restoreWiiGlitches;
-        bool enableBloom;
-        bool useWaterProjectionOffset;
-        bool mirrorMode;
-    };
-
     class ImGuiMenuEnhancements {
     public:
         ImGuiMenuEnhancements();
         void draw();
-
-        static EnhancementsSettings m_enhancements;
     };
 }
 

--- a/src/dusk/imgui/ImGuiMenuGame.cpp
+++ b/src/dusk/imgui/ImGuiMenuGame.cpp
@@ -1,15 +1,13 @@
 #include "fmt/format.h"
 #include "imgui.h"
-#include "aurora/gfx.h"
 
 #include "ImGuiConsole.hpp"
 #include "ImGuiMenuGame.hpp"
 #include <imgui_internal.h>
 
 #include "JSystem/JUtility/JUTGamePad.h"
-#include "d/actor/d_a_alink.h"
 #include "dusk/audio/DuskAudioSystem.h"
-#include "m_Do/m_Do_audio.h"
+#include "dusk/settings.h"
 #include "m_Do/m_Do_controller_pad.h"
 
 namespace dusk {
@@ -25,8 +23,8 @@ namespace dusk {
 
             if (ImGui::BeginMenu("Graphics")) {
                 if (ImGui::MenuItem("Toggle Fullscreen", "F11")) {
-                    m_fullscreen = !m_fullscreen;
-                    VISetWindowFullscreen(m_fullscreen);
+                    getSettings().video.enableFullscreen = !getSettings().video.enableFullscreen;
+                    VISetWindowFullscreen(getSettings().video.enableFullscreen);
                 }
 
                 ImGui::EndMenu();
@@ -34,28 +32,28 @@ namespace dusk {
 
             if (ImGui::BeginMenu("Audio")) {
                 ImGui::Text("Master Volume");
-                ImGui::SliderFloat("##m_masterVolume", &m_audioSettings.m_masterVolume, 0.0f, 1.0f, "");
+                ImGui::SliderFloat("##masterVolume", &getSettings().audio.masterVolume, 0.0f, 1.0f, "");
 
                 /*
                 // TODO: implement additional settings
                 ImGui::Text("Main Music Volume");
-                ImGui::SliderFloat("##m_mainMusicVolume", &m_audioSettings.m_mainMusicVolume, 0.0f, 1.0f, "");
+                ImGui::SliderFloat("##mainMusicVolume", &getSettings().audio.mainMusicVolume, 0.0f, 1.0f, "");
 
                 ImGui::Text("Sub Music Volume");
-                ImGui::SliderFloat("##m_subMusicVolume", &m_audioSettings.m_subMusicVolume, 0.0f, 1.0f, "");
+                ImGui::SliderFloat("##subMusicVolume", &getSettings().audio.subMusicVolume, 0.0f, 1.0f, "");
 
                 ImGui::Text("Sound Effects Volume");
-                ImGui::SliderFloat("##m_soundEffectsVolume", &m_audioSettings.m_soundEffectsVolume, 0.0f, 1.0f, "");
+                ImGui::SliderFloat("##soundEffectsVolume", &getSettings().audio.soundEffectsVolume, 0.0f, 1.0f, "");
 
                 ImGui::Text("Fanfare Volume");
-                ImGui::SliderFloat("##m_fanfareVolume", &m_audioSettings.m_fanfareVolume, 0.0f, 1.0f, "");
+                ImGui::SliderFloat("##fanfareVolume", &getSettings().audio.fanfareVolume, 0.0f, 1.0f, "");
 
                 Z2AudioMgr* audioMgr = Z2AudioMgr::getInterface();
                 if (audioMgr != nullptr) {
                 }
                 */
 
-                audio::SetMasterVolume(m_audioSettings.m_masterVolume);
+                audio::SetMasterVolume(getSettings().audio.masterVolume);
 
                 ImGui::EndMenu();
             }
@@ -78,8 +76,8 @@ namespace dusk {
         }
 
         if (ImGui::IsKeyPressed(ImGuiKey_F11)) {
-            m_fullscreen = !m_fullscreen;
-            VISetWindowFullscreen(m_fullscreen);
+            getSettings().video.enableFullscreen = !getSettings().video.enableFullscreen;
+            VISetWindowFullscreen(getSettings().video.enableFullscreen);
         }
     }
 

--- a/src/dusk/imgui/ImGuiMenuGame.cpp
+++ b/src/dusk/imgui/ImGuiMenuGame.cpp
@@ -7,6 +7,7 @@
 
 #include "JSystem/JUtility/JUTGamePad.h"
 #include "dusk/audio/DuskAudioSystem.h"
+#include "dusk/hotkeys.h"
 #include "dusk/settings.h"
 #include "m_Do/m_Do_controller_pad.h"
 
@@ -15,14 +16,14 @@ namespace dusk {
 
     void ImGuiMenuGame::draw() {
         if (ImGui::BeginMenu("Game")) {
-            if (ImGui::MenuItem("Reset", "Ctrl+R")) {
+            if (ImGui::MenuItem("Reset", hotkeys::DO_RESET)) {
                 JUTGamePad::C3ButtonReset::sResetSwitchPushing = true;
             }
 
             ImGui::Separator();
 
             if (ImGui::BeginMenu("Graphics")) {
-                if (ImGui::MenuItem("Toggle Fullscreen", "F11")) {
+                if (ImGui::MenuItem("Toggle Fullscreen", hotkeys::TOGGLE_FULLSCREEN)) {
                     getSettings().video.enableFullscreen = !getSettings().video.enableFullscreen;
                     VISetWindowFullscreen(getSettings().video.enableFullscreen);
                 }

--- a/src/dusk/imgui/ImGuiMenuGame.hpp
+++ b/src/dusk/imgui/ImGuiMenuGame.hpp
@@ -18,22 +18,12 @@ namespace dusk {
 
     private:
         struct {
-            float m_masterVolume = 1.0f;
-            float m_mainMusicVolume = 1.0f;
-            float m_subMusicVolume = 1.0f;
-            float m_soundEffectsVolume = 1.0f;
-            float m_fanfareVolume = 1.0f;
-        } m_audioSettings;
-
-        struct {
             int m_selectedPort = 0;
             bool m_isReading = false;
             PADButtonMapping* m_pendingButtonMapping = nullptr;
             PADAxisMapping* m_pendingAxisMapping = nullptr;
             int m_pendingPort = -1;
         } m_controllerConfig;
-
-        bool m_fullscreen = false;
 
         bool m_showControllerConfig = false;
 

--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -2,6 +2,7 @@
 #include "imgui.h"
 #include "aurora/gfx.h"
 
+#include "dusk/hotkeys.h"
 #include "ImGuiConsole.hpp"
 #include "ImGuiMenuTools.hpp"
 
@@ -37,15 +38,15 @@ namespace dusk {
                 ImGui::EndMenu();
             }
 
-            ImGui::MenuItem("Process Management", "F2", &m_showProcessManagement);
-            ImGui::MenuItem("Debug Overlay", "F3", &m_showDebugOverlay);
-            ImGui::MenuItem("Heap Viewer", "F4", &m_showHeapOverlay);
-            ImGui::MenuItem("Stub Log", "F5", &m_showStubLog);
-            ImGui::MenuItem("Debug Camera", "F6", &m_showCameraOverlay);
+            ImGui::MenuItem("Process Management", hotkeys::SHOW_PROCESS_MANAGEMENT, &m_showProcessManagement);
+            ImGui::MenuItem("Debug Overlay", hotkeys::SHOW_DEBUG_OVERLAY, &m_showDebugOverlay);
+            ImGui::MenuItem("Heap Viewer", hotkeys::SHOW_HEAP_VIEWER, &m_showHeapOverlay);
+            ImGui::MenuItem("Stub Log", hotkeys::SHOW_STUB_LOG, &m_showStubLog);
+            ImGui::MenuItem("Debug Camera", hotkeys::SHOW_CAMERA_DEBUG, &m_showCameraOverlay);
             ImGui::MenuItem("Map Loader", nullptr, &m_showMapLoader);
             ImGui::MenuItem("Player Info", nullptr, &m_showPlayerInfo);
             ImGui::MenuItem("Save Editor", nullptr, &m_showSaveEditor);
-            ImGui::MenuItem("Audio Debug", "F7", &m_showAudioDebug);
+            ImGui::MenuItem("Audio Debug", hotkeys::SHOW_AUDIO_DEBUG, &m_showAudioDebug);
             ImGui::MenuItem("OSReport Force", nullptr, &OSReportReallyForceEnable);
             ImGui::EndMenu();
         }

--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -23,16 +23,17 @@ namespace dusk {
 
             ImGui::Separator();
 
+            auto& collisionView = getTransientSettings().collisionView;
             if (ImGui::BeginMenu("Collision View")) {
-                ImGui::Checkbox("Enable Terrain view", &m_collisionViewSettings.m_enableTerrainView);
-                ImGui::Checkbox("Enable wireframe view", &m_collisionViewSettings.m_enableWireframe);
-                ImGui::SliderFloat("Opacity##terrain", &m_collisionViewSettings.m_terrainViewOpacity, 0.0f, 100.0f);
-                ImGui::SliderFloat("Draw Range", &m_collisionViewSettings.m_drawRange, 0.0f, 1000.0f);
+                ImGui::Checkbox("Enable Terrain view", &collisionView.enableTerrainView);
+                ImGui::Checkbox("Enable wireframe view", &collisionView.enableWireframe);
+                ImGui::SliderFloat("Opacity##terrain", &collisionView.terrainViewOpacity, 0.0f, 100.0f);
+                ImGui::SliderFloat("Draw Range", &collisionView.drawRange, 0.0f, 1000.0f);
                 ImGui::Separator();
-                ImGui::Checkbox("Enable Attack Collider view", &m_collisionViewSettings.m_enableAtView);
-                ImGui::Checkbox("Enable Target Collider view", &m_collisionViewSettings.m_enableTgView);
-                ImGui::Checkbox("Enable Push Collider view", &m_collisionViewSettings.m_enableCoView);
-                ImGui::SliderFloat("Opacity##colliders", &m_collisionViewSettings.m_colliderViewOpacity, 0.0f, 100.0f);
+                ImGui::Checkbox("Enable Attack Collider view", &collisionView.enableAtView);
+                ImGui::Checkbox("Enable Target Collider view", &collisionView.enableTgView);
+                ImGui::Checkbox("Enable Push Collider view", &collisionView.enableCoView);
+                ImGui::SliderFloat("Opacity##colliders", &collisionView.colliderViewOpacity, 0.0f, 100.0f);
                 ImGui::EndMenu();
             }
 

--- a/src/dusk/imgui/ImGuiMenuTools.hpp
+++ b/src/dusk/imgui/ImGuiMenuTools.hpp
@@ -10,17 +10,6 @@
 namespace dusk {
     class ImGuiMenuTools {
     public:
-		struct CollisionViewSettings {
-			bool m_enableTerrainView = false;
-			bool m_enableWireframe = false;
-			bool m_enableAtView = false;
-			bool m_enableTgView = false;
-			bool m_enableCoView = false;
-			float m_terrainViewOpacity = 50.0f;
-			float m_colliderViewOpacity = 50.0f;
-			float m_drawRange = 100.0f;
-		};
-
         ImGuiMenuTools();
         void draw();
         void afterDraw();
@@ -33,8 +22,6 @@ namespace dusk {
 		void ShowMapLoader();
         void ShowPlayerInfo();
         void ShowAudioDebug();
-
-        CollisionViewSettings& getCollisionViewSettings() { return m_collisionViewSettings; }
 
     private:
 		bool m_showDebugOverlay = false;
@@ -66,8 +53,6 @@ namespace dusk {
 
 		bool m_isDevelopmentMode = false;
 		bool m_showPlayerInfo = false;
-
-		CollisionViewSettings m_collisionViewSettings;
 
 		bool m_showSaveEditor = false;
         ImGuiSaveEditor m_saveEditor;

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -1,0 +1,66 @@
+#include "dusk/settings.h"
+
+namespace dusk {
+
+UserSettings g_userSettings = {
+    // Program settings
+
+    // Video
+    .video = {
+        .enableFullscreen = false,
+    },
+
+    // Audio
+    .audio = {
+        .masterVolume = 1.0f,
+        .mainMusicVolume = 1.0f,
+        .subMusicVolume = 1.0f,
+        .soundEffectsVolume = 1.0f,
+        .fanfareVolume = 1.0f,
+    },
+
+    // Game settings
+    .game = {
+        // Quality of Life
+        .enableQuickTransform = false,
+
+        // Preferences
+        .enableMirrorMode = false,
+        .invertCameraXAxis = false,
+
+        // Graphics
+        .enableBloom = true,
+        .useWaterProjectionOffset = false,
+
+        // Cheats
+        .enableFastIronBoots = false,
+
+        // Technical
+        .restoreWiiGlitches = false,
+    }
+};
+
+UserSettings& getSettings() {
+    return g_userSettings;
+}
+
+// Transient settings
+
+static TransientSettings g_transientSettings = {
+    .collisionView = {
+        .enableTerrainView = false,
+        .enableWireframe = false,
+        .enableAtView = false,
+        .enableTgView = false,
+        .enableCoView = false,
+        .terrainViewOpacity = 50.0f,
+        .colliderViewOpacity = 50.0f,
+        .drawRange = 100.0f,
+    },
+};
+
+TransientSettings& getTransientSettings() {
+    return g_transientSettings;
+}
+
+}

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1163,7 +1163,7 @@ void mDoGph_gInf_c::bloom_c::remove() {
 
 void mDoGph_gInf_c::bloom_c::draw() {
 #if TARGET_PC
-    if (!dusk::ImGuiMenuEnhancements::m_enhancements.enableBloom) {
+    if (!dusk::getSettings().game.enableBloom) {
         return;
     }
 #endif
@@ -2117,7 +2117,7 @@ int mDoGph_Painter() {
     #endif
 
     #if TARGET_PC
-    if (dusk::ImGuiMenuEnhancements::m_enhancements.mirrorMode)
+    if (dusk::getSettings().game.enableMirrorMode)
     #elif PLATFORM_WII
     if (data_8053a730)
     #endif


### PR DESCRIPTION
This moves the settings variables out from the ImGui TUs to a common interface which can be included independent of any UI code. I'm not super content with how everything is named/categorized atm, but I'm also not quite sure what it _should_ look like and we can always iterate on that as we add more settings.

This interface can also be used to expose functions for saving/loading persistent settings in the (hopefully near) future.

This PR also includes changes to move hotkey definitions to a separate header so that they're all defined in the same place, rather than wherever their respective menu items happen to be defined.