### PR TITLE
Update aurora & use new frame buffer API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,13 @@ add_library(game SHARED ${DOLZEL_FILES} ${Z2AUDIOLIB_FILES} ${SSYSTEM_FILES} ${J
 
 target_link_libraries(game PRIVATE game_debug cxxopts::cxxopts absl::flat_hash_map)
 if (DUSK_MOVIE_SUPPORT_REAL)
-    target_link_libraries(game PRIVATE libjpeg-turbo::turbojpeg-static)
+    if (TARGET libjpeg-turbo::turbojpeg-static)
+        message(STATUS "dusk: Linking against libjpeg-turbo static library")
+        target_link_libraries(game PRIVATE libjpeg-turbo::turbojpeg-static)
+    else ()
+        message(STATUS "dusk: Linking against libjpeg-turbo shared library")
+        target_link_libraries(game PRIVATE libjpeg-turbo::turbojpeg)
+    endif ()
     target_compile_definitions(game PRIVATE MOVIE_SUPPORT=1)
 endif ()
 target_compile_definitions(game PRIVATE TARGET_PC AVOID_UB=1 VERSION=0 NDEBUG=1 NDEBUG_DEFINED=1 DEBUG_DEFINED=0

--- a/src/d/d_drawlist.cpp
+++ b/src/d/d_drawlist.cpp
@@ -1398,7 +1398,12 @@ void dDlst_shadowSimple_c::set(cXyz* param_0, f32 param_1, f32 param_2, cXyz* pa
 }
 
 void dDlst_shadowControl_c::init() {
+#if TARGET_PC
+    // Increase shadow map resolution
+    static u16 l_realImageSize[2] = {1024, 512};
+#else
     static u16 l_realImageSize[2] = {192, 64};
+#endif
     for (int i = 0; i < 2; i++) {
         u16 size = l_realImageSize[i];
 
@@ -1471,11 +1476,18 @@ void dDlst_shadowControl_c::imageDraw(Mtx param_0) {
     int tex = 0;
     u16 r27;
     u16 r26;
+#ifdef TARGET_PC
+    bool needsRestore = false;
+#endif
     for (; shadowReal; shadowReal = shadowReal->getZsortNext()) {
         if (shadowReal->isUse()) {
             if (r29 == 0) {
                 r27 = GXGetTexObjWidth(field_0x15eb0 + tex);
                 r26 = r27 * 2;
+#ifdef TARGET_PC
+                GXCreateFrameBuffer(r26, r26);
+                needsRestore = true;
+#endif
                 GXSetViewport(0.0f, 0.0f, r26, r26, 0.0f, 1.0f);
                 GXSetScissor(0, 0, r26, r26);
             }
@@ -1503,6 +1515,11 @@ void dDlst_shadowControl_c::imageDraw(Mtx param_0) {
         GXPixModeSync();
         GXSetAlphaUpdate(GX_DISABLE);
     }
+#ifdef TARGET_PC
+    if (needsRestore) {
+        GXRestoreFrameBuffer();
+    }
+#endif
     GXSetClipMode(GX_CLIP_ENABLE);
     GXSetDither(GX_TRUE);
 }

--- a/src/d/d_error_msg.cpp
+++ b/src/d/d_error_msg.cpp
@@ -240,8 +240,13 @@ static void drawCapture(u8 alpha) {
     static bool l_texCopied = false;
 
     if (!l_texCopied) {
+#if TARGET_PC
+        GXSetTexCopySrc(0, 0, mDoGph_gInf_c::getWidth(), mDoGph_gInf_c::getHeight());
+        GXSetTexCopyDst(mDoGph_gInf_c::getWidth(), mDoGph_gInf_c::getHeight(), (GXTexFmt)mDoGph_gInf_c::getFrameBufferTimg()->format, GX_TRUE);
+#else
         GXSetTexCopySrc(0, 0, FB_WIDTH, FB_HEIGHT);
         GXSetTexCopyDst(FB_WIDTH / 2, FB_HEIGHT / 2, (GXTexFmt)mDoGph_gInf_c::getFrameBufferTimg()->format, GX_TRUE);
+#endif
         GXCopyTex(mDoGph_gInf_c::getFrameBufferTex(), GX_FALSE);
         l_texCopied = true;
     }

--- a/src/d/d_gameover.cpp
+++ b/src/d/d_gameover.cpp
@@ -37,8 +37,13 @@ void dDlst_Gameover_CAPTURE_c::draw() {
     TGXTexObj tex_obj;
     Mtx44 m;
 
+#if TARGET_PC
+    GXSetTexCopySrc(0, 0, mDoGph_gInf_c::getWidth(), mDoGph_gInf_c::getHeight());
+    GXSetTexCopyDst(mDoGph_gInf_c::getWidth(), mDoGph_gInf_c::getHeight(), GX_TF_RGB565, GX_TRUE);
+#else
     GXSetTexCopySrc(0, 0, FB_WIDTH, FB_HEIGHT);
-    GXSetTexCopyDst(FB_WIDTH / 2, FB_HEIGHT / 2, GX_TF_RGB565, 1);
+    GXSetTexCopyDst(FB_WIDTH / 2, FB_HEIGHT / 2, GX_TF_RGB565, GX_TRUE);
+#endif
     GXCopyTex(mDoGph_gInf_c::mZbufferTex, 0);
     GXPixModeSync();
     GXInitTexObj(&tex_obj, mDoGph_gInf_c::mFrameBufferTex, FB_WIDTH / 2, FB_HEIGHT / 2,

--- a/src/d/d_map.cpp
+++ b/src/d/d_map.cpp
@@ -1180,23 +1180,12 @@ dMap_c::dMap_c(int width, int height, int param_2, int param_3) {
     mImage_p = JKR_NEW_ARRAY_ARGS(u8, buffer_size, 0x20);
     JUT_ASSERT(2638, mImage_p != NULL);
 
-
-#ifdef TARGET_PC
-    // Increase map render resolution
-    renderingDAmap_c::init(mImage_p, mTexSizeX * 4, mTexSizeY * 4, mTexSizeX, mTexSizeY);
-#else
     renderingDAmap_c::init(mImage_p, mTexSizeX, mTexSizeY, mTexSizeX, mTexSizeY);
-#endif
 
     mResTIMG = JKR_NEW_ARGS (0x20) ResTIMG;
     JUT_ASSERT(2647, mResTIMG != NULL);
 
-#ifdef TARGET_PC
-    // Increase map render resolution
-    makeResTIMG(mResTIMG, mTexSizeX * 4, mTexSizeY * 4, mImage_p, (u8*)m_res, 0x33);
-#else
     makeResTIMG(mResTIMG, mTexSizeX, mTexSizeY, mImage_p, (u8*)m_res, 0x33);
-#endif
 }
 
 #if DEBUG

--- a/src/d/d_map_path.cpp
+++ b/src/d/d_map_path.cpp
@@ -14,6 +14,14 @@
 #include "m_Do/m_Do_lib.h"
 #include <cstring>
 
+#ifdef TARGET_PC
+constexpr u16 kMapResolutionMultiplier = 4;
+// Line widths are relative to the framebuffer size. Since we're rendering to a separate
+// framebuffer, we have to scale them accordingly. The original game used about half of the
+// EFB for the map rendering, so this is a reasonable approximation.
+constexpr u8 kMapLineWidthMultiplier = 2;
+#endif
+
 void dMpath_n::dTexObjAggregate_c::create() {
     static int const data[7] = {
         79, 80, 77, 78, 76, 81, 82,
@@ -234,7 +242,11 @@ void dDrawPath_c::rendering(dDrawPath_c::line_class const* p_line) {
         int width = getLineWidth(p_line->field_0x1);
 
         if (width > 0 && p_line->mDataNum >= 2) {
-            GXSetLineWidth(width, GX_TO_ZERO);
+#ifdef TARGET_PC
+            GXSetLineWidth(width * kMapLineWidthMultiplier, GX_TO_ZERO);
+#else
+            GXSetLineWidth(width * 2, GX_TO_ZERO);
+#endif
             GXSetTevColor(GX_TEVREG0, *getLineColor(p_line->field_0x0 & 0x3F, p_line->field_0x1));
             GXBegin(GX_LINESTRIP, GX_VTXFMT0, p_line->mDataNum);
 
@@ -333,8 +345,14 @@ void dRenderingMap_c::makeResTIMG(ResTIMG* p_image, u16 width, u16 height, u8* p
                                   u8* p_palette, u16 param_5) const {
     p_image->format = GX_TF_C8;
     p_image->alphaEnabled = 2;
+#ifdef TARGET_PC
+    // Increase map render resolution
+    p_image->width = width * kMapResolutionMultiplier;
+    p_image->height = height * kMapResolutionMultiplier;
+#else
     p_image->width = width;
     p_image->height = height;
+#endif
     p_image->wrapS = GX_CLAMP;
     p_image->wrapT = GX_CLAMP;
     p_image->indexTexture = true;
@@ -412,8 +430,17 @@ void dRenderingFDAmap_c::drawBack() const {
 }
 
 void dRenderingFDAmap_c::preRenderingMap() {
+#ifdef TARGET_PC
+    // Increase map render resolution
+    const u16 w = mTexWidth * kMapResolutionMultiplier;
+    const u16 h = mTexHeight * kMapResolutionMultiplier;
+    GXCreateFrameBuffer(w, h);
+    GXSetViewport(0.0f, 0.0f, w, h, 0.0f, 1.0f);
+    GXSetScissor(0, 0, w, h);
+#else
     GXSetViewport(0.0f, 0.0f, mTexWidth, mTexHeight, 0.0f, 1.0f);
     GXSetScissor(0, 0, mTexWidth, mTexHeight);
+#endif
     GXSetNumChans(1);
     GXSetNumTevStages(1);
     GXSetChanCtrl(GX_COLOR0A0, GX_FALSE, GX_SRC_REG, GX_SRC_REG, GX_LIGHT_NULL, GX_DF_NONE,
@@ -440,9 +467,19 @@ void dRenderingFDAmap_c::preRenderingMap() {
 
 void dRenderingFDAmap_c::postRenderingMap() {
     GXSetCopyFilter(GX_FALSE, NULL, GX_FALSE, NULL);
+#ifdef TARGET_PC
+    // Increase map render resolution
+    const u16 w = mTexWidth * kMapResolutionMultiplier;
+    const u16 h = mTexHeight * kMapResolutionMultiplier;
+    GXSetTexCopySrc(0, 0, w, h);
+    GXSetTexCopyDst(w, h, GX_CTF_R8, GX_FALSE);
+    GXCopyTex(field_0x4, GX_TRUE);
+    GXRestoreFrameBuffer();
+#else
     GXSetTexCopySrc(0, 0, mTexWidth, mTexHeight);
     GXSetTexCopyDst(mTexWidth, mTexHeight, GX_CTF_R8, GX_FALSE);
     GXCopyTex(field_0x4, GX_TRUE);
+#endif
     GXPixModeSync();
     GXSetClipMode(GX_CLIP_ENABLE);
     GXSetDither(GX_TRUE);
@@ -474,8 +511,13 @@ void dRenderingFDAmap_c::renderingDecoration(dDrawPath_c::line_class const* p_li
 
     BE(u16)* data_p = p_line->mpData;
     s32 data_num = p_line->mDataNum;
+#ifdef TARGET_PC
+    GXSetLineWidth(width * kMapLineWidthMultiplier, GX_TO_ZERO);
+    GXSetPointSize(width * kMapLineWidthMultiplier, GX_TO_ONE);
+#else
     GXSetLineWidth(width, GX_TO_ONE);
     GXSetPointSize(width, GX_TO_ONE);
+#endif
     GXColor lineColor = *getDecoLineColor(p_line->field_0x0 & 0x3f, p_line->field_0x1);
     GXSetTevColor(GX_TEVREG0, lineColor);
     lineColor.r = lineColor.r - 4;

--- a/src/d/d_menu_dmap_map.cpp
+++ b/src/d/d_menu_dmap_map.cpp
@@ -301,11 +301,6 @@ void dMenu_DmapMap_c::_delete() {
 }
 
 void dMenu_DmapMap_c::setTexture(u16 width, u16 height, u16 param_2, u16 param_3) {
-#ifdef TARGET_PC
-    // Increase map render resolution
-    width *= 2;
-    height *= 2;
-#endif
     for (int lp1 = 0; lp1 < 2; lp1++) {
 #ifdef TARGET_PC
         u32 sz = 0x20; // No need to allocate memory for texture

--- a/src/d/d_menu_fmap_map.cpp
+++ b/src/d/d_menu_fmap_map.cpp
@@ -657,12 +657,6 @@ const GXColor* dMenu_FmapMap_c::getColor(int param_0) {
 }
 
 void dMenu_FmapMap_c::setTexture(u16 i_width, u16 i_height, u16 param_2, u16 param_3) {
-#ifdef TARGET_PC
-    // Increase map render resolution
-    i_width *= 2;
-    i_height *= 2;
-#endif
-
     mMapImage_p = NULL;
     mResTIMG = NULL;
 #ifdef TARGET_PC

--- a/src/d/d_menu_window.cpp
+++ b/src/d/d_menu_window.cpp
@@ -39,13 +39,22 @@ public:
             GXSetTexCopySrc(0, 0, FB_WIDTH, FB_HEIGHT);
             #endif
 
+#if TARGET_PC
+            GXSetTexCopyDst(mDoGph_gInf_c::getWidth(), mDoGph_gInf_c::getHeight(), (GXTexFmt)mDoGph_gInf_c::getFrameBufferTimg()->format, GX_ENABLE);
+#else
             GXSetTexCopyDst(FB_WIDTH / 2, FB_HEIGHT / 2, (GXTexFmt)mDoGph_gInf_c::getFrameBufferTimg()->format, GX_ENABLE);
+#endif
             GXCopyTex(mDoGph_gInf_c::getFrameBufferTex(), GX_FALSE);
             GXPixModeSync();
         } else {
             TGXTexObj tex;
+#if TARGET_PC
+            GXInitTexObj(&tex, mDoGph_gInf_c::getFrameBufferTex(), mDoGph_gInf_c::getWidth(), mDoGph_gInf_c::getHeight(),
+                        (GXTexFmt)mDoGph_gInf_c::getFrameBufferTimg()->format, GX_CLAMP, GX_CLAMP, GX_FALSE);
+#else
             GXInitTexObj(&tex, mDoGph_gInf_c::getFrameBufferTex(), FB_WIDTH / 2, FB_HEIGHT / 2,
                         (GXTexFmt)mDoGph_gInf_c::getFrameBufferTimg()->format, GX_CLAMP, GX_CLAMP, GX_FALSE);
+#endif
             GXInitTexObjLOD(&tex, GX_LINEAR, GX_LINEAR, 0.0f, 0.0f, 0.0f, GX_FALSE, GX_FALSE, GX_ANISO_1);
             GXLoadTexObj(&tex, GX_TEXMAP0);
             GXSetNumChans(0);

--- a/src/d/d_ovlp_fade3.cpp
+++ b/src/d/d_ovlp_fade3.cpp
@@ -13,12 +13,13 @@
 #include "m_Do/m_Do_graphic.h"
 
 void dDlst_snapShot_c::draw() {
-    #if TARGET_PC
+#if TARGET_PC
     GXSetTexCopySrc(0, 0, mDoGph_gInf_c::getWidth(), mDoGph_gInf_c::getHeight());
-    #else
+    GXSetTexCopyDst(mDoGph_gInf_c::getWidth(), mDoGph_gInf_c::getHeight(), GX_TF_RGBA8, GX_TRUE);
+#else
     GXSetTexCopySrc(0, 0, FB_WIDTH, FB_HEIGHT);
-    #endif
     GXSetTexCopyDst(FB_WIDTH / 2, FB_HEIGHT / 2, GX_TF_RGBA8, GX_TRUE);
+#endif
     GXCopyTex(mDoGph_gInf_c::getFrameBufferTex(), GX_FALSE);
     GXPixModeSync();
 }

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1224,10 +1224,14 @@ void mDoGph_gInf_c::bloom_c::draw() {
             mDoGph_drawFilterQuad(4, 4);
         }
         if (enabled) {
+#ifdef TARGET_PC
+            GXCreateFrameBuffer(width, height);
+#else
             // Store off m_buffer to copy over again at the end.
             GXSetTexCopySrc(0, 0, width / 2, height / 2);
             GXSetTexCopyDst(width / 2, height / 2, GX_TF_RGBA8, 0);
             GXCopyTex(m_buffer, 0);
+#endif
 
             GXSetNumTevStages(3);
             GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR_NULL);
@@ -1351,6 +1355,9 @@ void mDoGph_gInf_c::bloom_c::draw() {
             GXSetTexCopyDst(width / 4, height / 4, GX_TF_RGBA8, GX_FALSE);
             GXCopyTex(zBufferTex, GX_FALSE);
 
+#ifdef TARGET_PC
+            GXRestoreFrameBuffer();
+#else
             // Copy back m_buffer to screen.
             GXInitTexObj(&tmp_tex2, m_buffer, width / 2, height / 2, GX_TF_RGBA8, GX_CLAMP, GX_CLAMP,
                          GX_FALSE);
@@ -1369,6 +1376,7 @@ void mDoGph_gInf_c::bloom_c::draw() {
                             GX_TEVPREV);
             GXSetBlendMode(GX_BM_NONE, GX_BL_ONE, GX_BL_ONE, GX_LO_OR);
             mDoGph_drawFilterQuad(2, 2);
+#endif
 
             // Now blend our bloom into the real FB.
             GXLoadTexObj(&tmp_tex1, GX_TEXMAP0);
@@ -1414,7 +1422,11 @@ static void retry_captue_frame(view_class* param_0, view_port_class* param_1, in
         var_r24 = width >> 1;
         var_r23 = height >> 1;
         GXSetTexCopySrc(x_orig, y_orig_pos, width, height);
+#ifdef TARGET_PC
+        GXSetTexCopyDst(width, height, (GXTexFmt)mDoGph_gInf_c::getFrameBufferTimg()->format, GX_TRUE);
+#else
         GXSetTexCopyDst(var_r24, var_r23, (GXTexFmt)mDoGph_gInf_c::getFrameBufferTimg()->format, GX_TRUE);
+#endif
         GXCopyTex(tex, GX_FALSE);
         GXPixModeSync();
         GXInvalidateTexAll();


### PR DESCRIPTION
- Uses aurora's new frame buffer API to optimize shadows, map and bloom
- Implements high res shadow maps
- Fixes high res map line width
- Fixes `GXSetTexCopyDst` usages since aurora now respects it