### PR TITLE
No Climbing Miss Animation toggle, similar to TPHD

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -35,6 +35,7 @@ struct UserSettings {
         int damageMultiplier;
         bool instantDeath;
         bool fastClimbing;
+        bool noMissClimbing;
         bool fastTears;
 
         // Preferences

--- a/src/d/actor/d_a_alink_hang.inc
+++ b/src/d/actor/d_a_alink_hang.inc
@@ -285,7 +285,11 @@ int daAlink_c::procHangStartInit() {
     offNoResetFlg2(FLG2_UNK_2000);
 
     if (checkHangFootWall()) {
+        #if TARGET_PC
+        if (!is_prev_hangReady && cM_rnd() < 0.7f && !dusk::getSettings().game.noMissClimbing) {
+        #else
         if (!is_prev_hangReady && cM_rnd() < 0.7f) {
+        #endif
             setSingleAnimeParam(ANM_CLIMB_HANG_MISS, &mpHIO->mLadder.m.mWallAttachMissAnm);
             field_0x3478 = mpHIO->mLadder.m.mWallAttachMissAnm.mCancelFrame;
             voiceStart(Z2SE_AL_V_FOOT_MISS);
@@ -2084,7 +2088,11 @@ int daAlink_c::procClimbUpStartInit(int param_0) {
     speed.y = 0.0f;
     mNormalSpeed = 0.0f;
 
+    #if TARGET_PC
+    if (param_0 || var_r29 || cM_rnd() < 0.3f || dusk::getSettings().game.noMissClimbing) {
+    #else
     if (param_0 || var_r29 || cM_rnd() < 0.3f) {
+    #endif
         setSingleAnimeParam(ANM_CLIMB_HANG, &mpHIO->mLadder.m.mWallAttachAnm);
         field_0x3478 = mpHIO->mLadder.m.mWallAttachAnm.mCancelFrame;
         voiceStart(Z2SE_AL_V_JUMP_HANG);
@@ -2161,7 +2169,11 @@ int daAlink_c::procClimbDownStartInit(s16 param_0) {
 
     deleteEquipItem(TRUE, FALSE);
 
+    #if TARGET_PC
+    if (cM_rnd() < 0.7f || dusk::getSettings().game.noMissClimbing) {
+    #else
     if (cM_rnd() < 0.7f) {
+    #endif
         setSingleAnimeParam(ANM_CLIMB_HANG, &mpHIO->mLadder.m.mWallAttachAnm);
         field_0x3478 = mpHIO->mLadder.m.mWallAttachAnm.mCancelFrame;
         mProcVar0.field_0x3008 = 0;

--- a/src/dusk/imgui/ImGuiMenuEnhancements.cpp
+++ b/src/dusk/imgui/ImGuiMenuEnhancements.cpp
@@ -37,6 +37,12 @@ namespace dusk {
                     ImGui::SetTooltip("Quicker climbing on ladders and vines like the HD version");
                 }
 
+                ImGui::Checkbox("No Climbing Miss Animation", &getSettings().game.noMissClimbing);
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip("Prevents Link from playing a struggle animation\n"
+                                      "when using the Clawshot on vines at a weird angle.");
+                }
+
                 ImGui::Checkbox("Faster Tears of Light", &getSettings().game.fastTears);
                 if (ImGui::IsItemHovered()) {
                     ImGui::SetTooltip("Tears of Light dropped by Shadow Insects pop out faster like the HD version");

--- a/src/dusk/imgui/ImGuiMenuEnhancements.cpp
+++ b/src/dusk/imgui/ImGuiMenuEnhancements.cpp
@@ -40,7 +40,7 @@ namespace dusk {
                 ImGui::Checkbox("No Climbing Miss Animation", &getSettings().game.noMissClimbing);
                 if (ImGui::IsItemHovered()) {
                     ImGui::SetTooltip("Prevents Link from playing a struggle animation\n"
-                                      "when using the Clawshot on vines at a weird angle.");
+                                      "when using the Clawshot on vines at a weird angle");
                 }
 
                 ImGui::Checkbox("Faster Tears of Light", &getSettings().game.fastTears);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -31,6 +31,7 @@ UserSettings g_userSettings = {
         .damageMultiplier = 1,
         .instantDeath = false,
         .fastClimbing = false,
+        .noMissClimbing = false,
         .fastTears = false,
 
         // Preferences


### PR DESCRIPTION
Prevents Link from playing a struggle animation when using the Clawshot on vines at a weird angle.