### PR TITLE
Find proper distance initialization for particles (fix for #207)

### DIFF
--- a/src/d/d_kankyo.cpp
+++ b/src/d/d_kankyo.cpp
@@ -9696,7 +9696,7 @@ void dKy_ParticleColor_get_base(cXyz* param_0, dKy_tevstr_c* param_1, GXColor* p
         f32 var_f31;
 
         #if AVOID_UB
-        var_f31 = 0;
+        var_f31 = 100000000.0f;
         #endif
 
         if (dKy_SunMoon_Light_Check() == TRUE && i <= 1) {


### PR DESCRIPTION
## Summary
Fix AVOID_UB initialization of `var_f31` in `dKy_ParticleColor_get_base()` from `0` to `100000000.0f`.
On GC, this variable is uninitialized when a light is skipped (zero color, not sun/moon). The garbage value prevents it from displacing real lights in the distance sort. Initializing to `0` made skipped lights appear as *closest* (distance 0), pushing real sun/moon lights out of the top-3 sorting - resulting in black particle colors. Using `100000000.0f` matches the `sp58[]` sentinel init value, ensuring skipped lights are never inserted.

Obviously I tested my old change very poorly but here I am again not 100% sure where to test this everywhere in the game.