### PR TITLE
Resize ImGui windows automatically + Move "Tools" menu after "Enhancements"

### DIFF
--- a/src/dusk/imgui/ImGuiCameraOverlay.cpp
+++ b/src/dusk/imgui/ImGuiCameraOverlay.cpp
@@ -26,8 +26,6 @@ namespace dusk {
         }
 
         ImGui::SetNextWindowBgAlpha(0.65f);
-        ImGui::SetNextWindowSizeConstraints(ImVec2(300.f * ImGuiScale(), 0),
-                                            ImVec2(FLT_MAX, FLT_MAX));
 
         if (!ImGui::Begin("Camera Debug", nullptr, windowFlags)) {
             ImGui::End();

--- a/src/dusk/imgui/ImGuiConsole.cpp
+++ b/src/dusk/imgui/ImGuiConsole.cpp
@@ -182,6 +182,17 @@ namespace dusk {
             m_isLaunchInitialized = true;
         }
 
+        if ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) &&
+            ImGui::IsKeyPressed(ImGuiKey_R))
+        {
+            JUTGamePad::C3ButtonReset::sResetSwitchPushing = true;
+        }
+
+        if (ImGui::IsKeyPressed(ImGuiKey_F11)) {
+            getSettings().video.enableFullscreen = !getSettings().video.enableFullscreen;
+            VISetWindowFullscreen(getSettings().video.enableFullscreen);
+        }
+
         if (CheckMenuViewToggle(ImGuiKey_F1, m_isHidden)) {
             ShowToasts();
             return;

--- a/src/dusk/imgui/ImGuiConsole.cpp
+++ b/src/dusk/imgui/ImGuiConsole.cpp
@@ -192,8 +192,10 @@ namespace dusk {
 
         if (ImGui::BeginMainMenuBar()) {
             m_menuGame.draw();
-            m_menuTools.draw();
             m_menuEnhancements.draw();
+
+            // Keep always last
+            m_menuTools.draw();
 
             ImGui::SetCursorPosX(ImGui::GetWindowWidth() - 80.0f * ImGuiScale());
             ImGuiIO& io = ImGui::GetIO();

--- a/src/dusk/imgui/ImGuiConsole.hpp
+++ b/src/dusk/imgui/ImGuiConsole.hpp
@@ -31,9 +31,12 @@ private:
     bool m_isHidden = true;
     bool m_isLaunchInitialized = false;
     std::deque<Toast> m_toasts;
+
     ImGuiMenuGame m_menuGame;
-    ImGuiMenuTools m_menuTools;
     ImGuiMenuEnhancements m_menuEnhancements;
+
+    // Keep always last
+    ImGuiMenuTools m_menuTools;
 
     void ShowToasts();
     void ShowPipelineProgress();

--- a/src/dusk/imgui/ImGuiMapLoader.cpp
+++ b/src/dusk/imgui/ImGuiMapLoader.cpp
@@ -17,8 +17,6 @@ namespace dusk {
             ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav;
     
         ImGui::SetNextWindowBgAlpha(0.65f);
-        ImGui::SetNextWindowSizeConstraints(ImVec2(300.f * ImGuiScale(), 0),
-                                            ImVec2(FLT_MAX, FLT_MAX));
     
         if (!ImGui::Begin("Map Loader", &m_showMapLoader, windowFlags)) {
             ImGui::End();

--- a/src/dusk/imgui/ImGuiMenuGame.cpp
+++ b/src/dusk/imgui/ImGuiMenuGame.cpp
@@ -73,15 +73,6 @@ namespace dusk {
 
         windowInputViewer();
         windowControllerConfig();
-
-        if ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) && ImGui::IsKeyPressed(ImGuiKey_R)) {
-            JUTGamePad::C3ButtonReset::sResetSwitchPushing = true;
-        }
-
-        if (ImGui::IsKeyPressed(ImGuiKey_F11)) {
-            getSettings().video.enableFullscreen = !getSettings().video.enableFullscreen;
-            VISetWindowFullscreen(getSettings().video.enableFullscreen);
-        }
     }
 
     static void drawVirtualStick(const char* id, const ImVec2& stick) {

--- a/src/dusk/imgui/ImGuiMenuGame.cpp
+++ b/src/dusk/imgui/ImGuiMenuGame.cpp
@@ -147,8 +147,6 @@ namespace dusk {
             ImGuiWindowFlags_AlwaysAutoResize;
 
         ImGui::SetNextWindowBgAlpha(0.65f);
-        ImGui::SetNextWindowSizeConstraints(ImVec2(850 * scale, 400 * scale),
-                                            ImVec2(850 * scale, 400 * scale));
 
         if (!ImGui::Begin("Controller Config", &m_showControllerConfig, windowFlags)) {
             ImGui::End();

--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -146,7 +146,8 @@ namespace dusk {
         }
 
         ImGuiIO& io = ImGui::GetIO();
-        ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoResize;
+        ImGuiWindowFlags windowFlags =
+            ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize;
 
         ImGui::SetNextWindowBgAlpha(0.65f);
 

--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -149,7 +149,6 @@ namespace dusk {
         ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoResize;
 
         ImGui::SetNextWindowBgAlpha(0.65f);
-        ImGui::SetNextWindowSizeConstraints(ImVec2(300, 200), ImVec2(300, 200));
 
         if (ImGui::Begin("Player Info", &m_showPlayerInfo, windowFlags)) {
             daAlink_c* player = (daAlink_c*)dComIfGp_getPlayer(0);

--- a/src/dusk/imgui/ImGuiSaveEditor.cpp
+++ b/src/dusk/imgui/ImGuiSaveEditor.cpp
@@ -284,10 +284,10 @@ namespace dusk {
 
     void ImGuiSaveEditor::draw(bool& open) {
         ImGuiIO& io = ImGui::GetIO();
-        ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoResize;
+        ImGuiWindowFlags windowFlags =
+            ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize;
 
         ImGui::SetNextWindowBgAlpha(0.65f);
-        ImGui::SetNextWindowSizeConstraints(ImVec2(600, 700), ImVec2(600, 700));
 
         if (ImGui::Begin("Save Editor", &open, windowFlags)) {
             if (ImGui::BeginTabBar("SaveEditorTabBar", ImGuiTabBarFlags_NoCloseWithMiddleMouseButton)) {


### PR DESCRIPTION
Made it so the windows in ImGui, like the Controller Configurator is always sized properly, even if we add things to it in the future.

Also moved "Tools" to the right of "Enhancements" as Debug features should be out of the way of the main features for the end-user.

Also fixes: #233 