### PR TITLE
Use int for audio sliders, show current value

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -15,11 +15,11 @@ struct UserSettings {
 
     struct {
         // Audio
-        float masterVolume;
-        float mainMusicVolume;
-        float subMusicVolume;
-        float soundEffectsVolume;
-        float fanfareVolume;
+        int masterVolume;
+        int mainMusicVolume;
+        int subMusicVolume;
+        int soundEffectsVolume;
+        int fanfareVolume;
         bool enableReverb;
     } audio;
 

--- a/src/dusk/imgui/ImGuiMenuGame.cpp
+++ b/src/dusk/imgui/ImGuiMenuGame.cpp
@@ -34,28 +34,29 @@ namespace dusk {
 
             if (ImGui::BeginMenu("Audio")) {
                 ImGui::Text("Master Volume");
-                ImGui::SliderFloat("##masterVolume", &getSettings().audio.masterVolume, 0.0f, 1.0f, "");
+                ImGui::SliderInt("##masterVolume", &getSettings().audio.masterVolume, 0, 100);
                 ImGui::Checkbox("Enable Reverb", &getSettings().audio.enableReverb);
+
                 /*
-                // TODO: implement additional settings
+                // TODO: Implement additional settings
                 ImGui::Text("Main Music Volume");
-                ImGui::SliderFloat("##mainMusicVolume", &getSettings().audio.mainMusicVolume, 0.0f, 1.0f, "");
+                ImGui::SliderFloat("##mainMusicVolume", &getSettings().audio.mainMusicVolume, 0, 100);
 
                 ImGui::Text("Sub Music Volume");
-                ImGui::SliderFloat("##subMusicVolume", &getSettings().audio.subMusicVolume, 0.0f, 1.0f, "");
+                ImGui::SliderFloat("##subMusicVolume", &getSettings().audio.subMusicVolume, 0, 100);
 
                 ImGui::Text("Sound Effects Volume");
-                ImGui::SliderFloat("##soundEffectsVolume", &getSettings().audio.soundEffectsVolume, 0.0f, 1.0f, "");
+                ImGui::SliderFloat("##soundEffectsVolume", &getSettings().audio.soundEffectsVolume, 0, 100);
 
                 ImGui::Text("Fanfare Volume");
-                ImGui::SliderFloat("##fanfareVolume", &getSettings().audio.fanfareVolume, 0.0f, 1.0f, "");
+                ImGui::SliderFloat("##fanfareVolume", &getSettings().audio.fanfareVolume, 0, 100);
 
                 Z2AudioMgr* audioMgr = Z2AudioMgr::getInterface();
                 if (audioMgr != nullptr) {
                 }
                 */
 
-                audio::SetMasterVolume(getSettings().audio.masterVolume);
+                audio::SetMasterVolume(getSettings().audio.masterVolume / 100.0f);
                 audio::EnableReverb = getSettings().audio.enableReverb;
 
                 ImGui::EndMenu();

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -12,11 +12,11 @@ UserSettings g_userSettings = {
 
     // Audio
     .audio = {
-        .masterVolume = 0.8f,
-        .mainMusicVolume = 1.0f,
-        .subMusicVolume = 1.0f,
-        .soundEffectsVolume = 1.0f,
-        .fanfareVolume = 1.0f,
+        .masterVolume = 80,
+        .mainMusicVolume = 100,
+        .subMusicVolume = 100,
+        .soundEffectsVolume = 100,
+        .fanfareVolume = 100,
         .enableReverb = true
     },
 


### PR DESCRIPTION
Because who has ever wanted to set their volume to 0.657? PR switches audio controls to int with the standard 0-100 range, and also show the current value in the slider.

<img width="292" height="132" alt="image" src="https://github.com/user-attachments/assets/3115348b-622c-4f06-8ef4-e7b3b26a7cb3" />