### PR TITLE
Build "game" as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ add_custom_command(TARGET dusk POST_BUILD
 )
 
 include(extern/aurora/cmake/AuroraCopyRuntimeDLLs.cmake)
-aurora_copy_runtime_dlls(dusk game)
+aurora_copy_runtime_dlls(dusk)
 
 if (DUSK_SELECTED_OPT)
     if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,37 @@ message(STATUS "dusk: TP Version: ${DUSK_TP_VERSION}")
 source_group("dolzel" FILES ${DOLZEL_FILES} ${Z2AUDIOLIB_FILES} ${JSYSTEM_FILES} ${JSYSTEM_DEBUG_FILES} ${REL_FILES})
 source_group("dusk" FILES ${DUSK_FILES})
 
+set(GAME_COMPILE_DEFS TARGET_PC AVOID_UB=1 VERSION=0
+    DUSK_TP_VERSION="${DUSK_TP_VERSION}" DUSK_GAME_NAME="${DUSK_GAME_NAME}" DUSK_GAME_VERSION="${DUSK_GAME_VERSION}")
+
+set(GAME_INCLUDE_DIRS
+    include
+    src
+    assets/${DUSK_TP_VERSION}
+    libs/JSystem/include
+    libs
+    extern/aurora/include/dolphin
+    extern
+    ${CMAKE_SOURCE_DIR}/build/${DUSK_TP_VERSION}/include
+    build/${DUSK_TP_VERSION}/include)
+
+set(GAME_LIBS aurora::core aurora::gx aurora::gd aurora::si aurora::vi aurora::pad aurora::mtx aurora::os aurora::dvd
+    aurora::card freeverb cxxopts::cxxopts absl::flat_hash_map)
+
+if (DUSK_MOVIE_SUPPORT_REAL)
+  if (TARGET libjpeg-turbo::turbojpeg-static)
+    message(STATUS "dusk: Linking against libjpeg-turbo static library")
+    list(APPEND GAME_LIBS "libjpeg-turbo::turbojpeg-static")
+  else ()
+    message(STATUS "dusk: Linking against libjpeg-turbo shared library")
+    list(APPEND GAME_LIBS "libjpeg-turbo::turbojpeg")
+  endif ()
+  list(APPEND GAME_COMPILE_DEFS MOVIE_SUPPORT=1)
+endif ()
+
 # game_debug is for game code files that we know work when compiled with DEBUG=1
 # Of course, if building a release build, this distinction is irrelevant
-add_library(game_debug STATIC ${JSYSTEM_DEBUG_FILES} ${SSYSTEM_FILES}
+add_library(game_debug OBJECT ${JSYSTEM_DEBUG_FILES} ${SSYSTEM_FILES}
         src/dusk/audio/DuskAudioSystem.cpp
         src/dusk/audio/JASCriticalSection.cpp
         src/dusk/audio/DuskDsp.hpp
@@ -98,40 +126,33 @@ add_library(game_debug STATIC ${JSYSTEM_DEBUG_FILES} ${SSYSTEM_FILES}
         src/dusk/audio/Adpcm.cpp
         src/dusk/audio/Adpcm.hpp
         src/dusk/audio/DspStub.cpp)
-target_compile_definitions(game_debug PRIVATE TARGET_PC AVOID_UB=1 VERSION=0 $<$<CONFIG:Debug>:DEBUG=1>)
 
-# Make these properties PUBLIC so that the regular game target also sees them.
-target_include_directories(game_debug PUBLIC
-        include
-        src
-        assets/${DUSK_TP_VERSION}
-        libs/JSystem/include
-        libs
-        extern/aurora/include/dolphin
-        extern
-        ${CMAKE_SOURCE_DIR}/build/${DUSK_TP_VERSION}/include
-        build/${DUSK_TP_VERSION}/include)
-target_link_libraries(game_debug PUBLIC aurora::core aurora::gx aurora::gd aurora::si aurora::vi aurora::pad aurora::mtx aurora::os aurora::dvd aurora::card freeverb)
-
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-add_library(game SHARED ${DOLZEL_FILES} ${Z2AUDIOLIB_FILES} ${SSYSTEM_FILES} ${JSYSTEM_FILES} ${REL_FILES} ${DUSK_FILES} ${DOLPHIN_FILES}
+# game_base is for all other game code files
+add_library(game_base OBJECT ${DOLZEL_FILES} ${Z2AUDIOLIB_FILES} ${JSYSTEM_FILES} ${REL_FILES} ${DUSK_FILES}
+        ${DOLPHIN_FILES}
         src/dusk/imgui/ImGuiStubLog.cpp
         src/dusk/imgui/ImGuiAudio.cpp)
 
-target_link_libraries(game PRIVATE game_debug cxxopts::cxxopts absl::flat_hash_map freeverb)
-if (DUSK_MOVIE_SUPPORT_REAL)
-    if (TARGET libjpeg-turbo::turbojpeg-static)
-        message(STATUS "dusk: Linking against libjpeg-turbo static library")
-        target_link_libraries(game PRIVATE libjpeg-turbo::turbojpeg-static)
-    else ()
-        message(STATUS "dusk: Linking against libjpeg-turbo shared library")
-        target_link_libraries(game PRIVATE libjpeg-turbo::turbojpeg)
-    endif ()
-    target_compile_definitions(game PRIVATE MOVIE_SUPPORT=1)
-endif ()
-target_compile_definitions(game PRIVATE TARGET_PC AVOID_UB=1 VERSION=0 NDEBUG=1 NDEBUG_DEFINED=1 DEBUG_DEFINED=0
-        DUSK_TP_VERSION="${DUSK_TP_VERSION}" DUSK_GAME_NAME="${DUSK_GAME_NAME}" DUSK_GAME_VERSION="${DUSK_GAME_VERSION}")
-target_precompile_headers(game PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/include/dusk_pch.hpp>")
+target_compile_definitions(game_debug PRIVATE ${GAME_COMPILE_DEFS} $<$<CONFIG:Debug>:DEBUG=1>)
+target_compile_definitions(game_base PRIVATE ${GAME_COMPILE_DEFS} NDEBUG=1 NDEBUG_DEFINED=1 DEBUG_DEFINED=0)
+
+# only apply PCH to game_base since not all headers are necessarily validated with DEBUG=1
+target_precompile_headers(game_base PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/include/dusk_pch.hpp>")
+
+target_include_directories(game_debug PRIVATE ${GAME_INCLUDE_DIRS})
+target_include_directories(game_base PRIVATE ${GAME_INCLUDE_DIRS})
+
+# This implicitly pulls in the library include directories even though no
+# linking actually takes place for object libraries
+target_link_libraries(game_debug PRIVATE ${GAME_LIBS})
+target_link_libraries(game_base PRIVATE ${GAME_LIBS})
+
+# Combined game library
+add_library(game STATIC
+    $<TARGET_OBJECTS:game_base>
+    $<TARGET_OBJECTS:game_debug>)
+target_link_libraries(game PUBLIC ${GAME_LIBS})
+
 add_executable(dusk src/dusk/main.cpp)
 target_compile_definitions(dusk PRIVATE TARGET_PC AVOID_UB=1 VERSION=0)
 target_include_directories(dusk PRIVATE include)


### PR DESCRIPTION
This effectively renames the "game" lib to game_base, builds it and game_debug as object libraries, and links both into a single static library. There is also some refactoring done to remove the game_base's dependencies on game_debug's compile-time parameters which have now been moved into shared buildscript variables.