### PR TITLE
Double heap sizes for various heaps (Midna eye)

### DIFF
--- a/libs/JSystem/src/J3DGraphLoader/J3DModelLoader.cpp
+++ b/libs/JSystem/src/J3DGraphLoader/J3DModelLoader.cpp
@@ -242,7 +242,7 @@ void J3DModelLoader::setupBBoardInfo() {
         J3DMaterial* mesh = mpModelData->getJointNodePointer(i)->getMesh();
         if (mesh != NULL) {
             u32 shape_index = mesh->getShape()->getIndex();
-            u16* index_table = JSUConvertOffsetToPtr<u16>(mpShapeBlock,
+            BE(u16)* index_table = JSUConvertOffsetToPtr<BE(u16)>(mpShapeBlock,
                                                           (uintptr_t)mpShapeBlock->mpIndexTable);
             J3DShapeInitData* shape_init_data =
                 JSUConvertOffsetToPtr<J3DShapeInitData>(mpShapeBlock,

--- a/src/d/actor/d_a_alink_swindow.inc
+++ b/src/d/actor/d_a_alink_swindow.inc
@@ -40,6 +40,9 @@ void daAlink_c::setOriginalHeap(JKRExpHeap** i_ppheap, u32 i_size) {
         u32 var_r29 = 0x90;
         u32 var_r28 = 0x10;
         u32 size = ROUND(i_size, 16);
+#if TARGET_PC
+        size *= 2;
+#endif
         JKRHeap* parent = mDoExt_getGameHeap();
 
         JKRExpHeap* heap = JKRExpHeap::create(size + (var_r29 + var_r28), parent, true);

--- a/src/d/actor/d_a_player.cpp
+++ b/src/d/actor/d_a_player.cpp
@@ -237,11 +237,7 @@ void* daPy_anmHeap_c::mallocBuffer() {
     return mBuffer;
 }
 
-#if TARGET_PC
 void daPy_anmHeap_c::createHeap(daPy_anmHeap_c::daAlinkHEAP_TYPE i_heapType, const char* name) {
-#else
-void daPy_anmHeap_c::createHeap(daPy_anmHeap_c::daAlinkHEAP_TYPE i_heapType, const char* name) {
-#endif
     u32 size;
 
     if (i_heapType == 4) {
@@ -255,6 +251,9 @@ void daPy_anmHeap_c::createHeap(daPy_anmHeap_c::daAlinkHEAP_TYPE i_heapType, con
     } else {
         size = 0xA0;
     }
+#if TARGET_PC
+    size *= 2;
+#endif
 
     char* tmpWork;
     mDoExt_transAnmBas* tmpTransBas;

--- a/src/d/d_k_wmark.cpp
+++ b/src/d/d_k_wmark.cpp
@@ -6,6 +6,7 @@
 #include "d/dolzel.h" // IWYU pragma: keep
 
 #include "d/d_k_wmark.h"
+#include "dusk/memory.h"
 #include "JSystem/J3DGraphBase/J3DMaterial.h"
 #include "SSystem/SComponent/c_math.h"
 #include "d/actor/d_a_player.h"
@@ -33,11 +34,7 @@ int dkWmark_c::create() {
         mColorType = this->parameters;
     }
 
-#if TARGET_PC
-    mpHeap = mDoExt_createSolidHeapFromGameToCurrent(0x1100, 0x20);
-#else
-    mpHeap = mDoExt_createSolidHeapFromGameToCurrent(0x880, 0x20);
-#endif
+    mpHeap = mDoExt_createSolidHeapFromGameToCurrent(HEAP_SIZE(0x880, 0x1100), 0x20);
     if (mpHeap != NULL) {
         JKRHEAP_NAME(mpHeap, "dkWmark_c::mpHeap");
         J3DModelData* modelData = (J3DModelData*)dComIfG_getObjectRes("Alink", 0x23);

--- a/src/d/d_k_wmark.cpp
+++ b/src/d/d_k_wmark.cpp
@@ -33,7 +33,11 @@ int dkWmark_c::create() {
         mColorType = this->parameters;
     }
 
+#if TARGET_PC
+    mpHeap = mDoExt_createSolidHeapFromGameToCurrent(0x1100, 0x20);
+#else
     mpHeap = mDoExt_createSolidHeapFromGameToCurrent(0x880, 0x20);
+#endif
     if (mpHeap != NULL) {
         JKRHEAP_NAME(mpHeap, "dkWmark_c::mpHeap");
         J3DModelData* modelData = (J3DModelData*)dComIfG_getObjectRes("Alink", 0x23);

--- a/src/d/d_kankyo.cpp
+++ b/src/d/d_kankyo.cpp
@@ -1175,7 +1175,11 @@ static void undwater_init() {
     J3DModelData* modelData2 = (J3DModelData*)dComIfG_getObjectRes("Always", 0x1D);
     JUT_ASSERT(1867, modelData2 != NULL);
 
+#if TARGET_PC
+    g_env_light.undwater_ef_heap = mDoExt_createSolidHeapFromGameToCurrent(0xC00, 0x20);
+#else
     g_env_light.undwater_ef_heap = mDoExt_createSolidHeapFromGameToCurrent(0x600, 0x20);
+#endif
     JKRHEAP_NAME(g_env_light.undwater_ef_heap, "g_env_light.undwater_ef_heap");
 
     if (g_env_light.undwater_ef_heap != NULL) {

--- a/src/d/d_kankyo.cpp
+++ b/src/d/d_kankyo.cpp
@@ -1,6 +1,7 @@
 #include "d/dolzel.h" // IWYU pragma: keep
 
 #include "d/d_kankyo.h"
+#include "dusk/memory.h"
 #ifdef __REVOLUTION_SDK__
 #include <revolution.h>
 #else
@@ -1175,11 +1176,7 @@ static void undwater_init() {
     J3DModelData* modelData2 = (J3DModelData*)dComIfG_getObjectRes("Always", 0x1D);
     JUT_ASSERT(1867, modelData2 != NULL);
 
-#if TARGET_PC
-    g_env_light.undwater_ef_heap = mDoExt_createSolidHeapFromGameToCurrent(0xC00, 0x20);
-#else
-    g_env_light.undwater_ef_heap = mDoExt_createSolidHeapFromGameToCurrent(0x600, 0x20);
-#endif
+    g_env_light.undwater_ef_heap = mDoExt_createSolidHeapFromGameToCurrent(HEAP_SIZE(0x600, 0xC00), 0x20);
     JKRHEAP_NAME(g_env_light.undwater_ef_heap, "g_env_light.undwater_ef_heap");
 
     if (g_env_light.undwater_ef_heap != NULL) {

--- a/src/d/d_menu_window.cpp
+++ b/src/d/d_menu_window.cpp
@@ -1507,7 +1507,11 @@ void dMw_c::checkMemSize() {
 
         OS_REPORT("memory check ===> diff ==> %d, start ==> %d, now ==> %d\n", diff, mMemSize, now_size);
 
+#if TARGET_PC
+        if (diff > 0x40) {
+#else
         if (diff > 0x20) {
+#endif
             OSReport_Error("memory free error!!\n");
         }
         mMemSize = 0;

--- a/src/d/d_stage.cpp
+++ b/src/d/d_stage.cpp
@@ -393,13 +393,7 @@ static void dummy1(dStage_roomControl_c* roomControl) {
 
 JKRExpHeap* dStage_roomControl_c::createMemoryBlock(int i_blockIdx, u32 i_heapSize) {
     #if TARGET_PC
-    // Cave of Ordeals crashes around floor 29 due to no free heap space
-    // Increasing the size here avoids that, though its ugly. maybe TODO a better fix
-    if (strcmp(dComIfGp_getStartStageName(), "D_SB01") == 0) {
-        u32 prev = i_heapSize;
-        i_heapSize *= 2;
-        DuskLog.warn("Doubling heap size for D_SB01... ({}) -> ({})", prev, i_heapSize);
-    }
+    i_heapSize *= 2;
     #endif
 
     if (mMemoryBlock[i_blockIdx] == NULL) {

--- a/src/f_op/f_op_actor_mng.cpp
+++ b/src/f_op/f_op_actor_mng.cpp
@@ -730,6 +730,9 @@ u8 var_r30 = fopAcM::HeapAdjustEntry;
 #endif
 
     u32 size = i_size & 0xFFFFFF;
+#if TARGET_PC
+    size *= 2;
+#endif
     bool result = fopAcM_entrySolidHeap_(i_actor, i_heapCallback, size);
 #if DEBUG
     fopAcM::HeapDummyCheck = var_r29;


### PR DESCRIPTION
Scale various hardcoded heap estimates 2x on TARGET_PC to account for 64 bit. Fixes Midna's eye. Fixes also various JKRHeap overflow fallbacks and a BE index table bug in setupBBoardInfo. ~~I feel like there are other places where heaps could be too small and I have tested not so much, so only Draft here~~. Also doubled the room heaps for `d_a_bg Anms`.