### PR TITLE
Sync up the Ordon Spring kidnapping cutscene music

### DIFF
--- a/src/d/actor/d_a_demo00.cpp
+++ b/src/d/actor/d_a_demo00.cpp
@@ -85,6 +85,12 @@ static void dummy() {
 }
 
 inline int daDemo00_c::create() {
+    #if TARGET_PC
+    if (g_dComIfG_gameInfo.play.getEvent()->mEventId == 0x903) {
+        mDoGph_gInf_c::setTickRate(OS_TIMER_CLOCK / 27);
+    }
+    #endif
+
     dKy_tevstr_init(&tevStr, dComIfGp_roomControl_getStayNo(), 0xFF);
     tevStr.field_0x384 = 1;
     mSound.init(&eyePos, NULL, 10, 1);


### PR DESCRIPTION
Dusk runs too fast compared to gamecube, and the music doesn't have time to finish since the video is super early.

This lowers the framerate during the cutscene to make the music work in sync with the video.

This whole problem is similar to Majora's Mask, where the cutscene with the 4 giants is faster on the Wii U version, and the music doesn't have time to end.

Ideally this is only temporary until we can figure out how to edit cutscenes and shorten some timings.