### PR TITLE
Free Magic Armor

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -60,6 +60,7 @@ struct UserSettings {
         ConfigVar<bool> enableFastIronBoots;
         ConfigVar<bool> canTransformAnywhere;
         ConfigVar<bool> fastSpinner;
+        ConfigVar<bool> freeMagicArmor;
 
         // Technical
         ConfigVar<bool> restoreWiiGlitches;

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -12677,7 +12677,11 @@ void daAlink_c::setMagicArmorBrk(int i_status) {
 }
 
 BOOL daAlink_c::checkMagicArmorHeavy() const {
+#if TARGET_PC
+    return checkMagicArmorWearAbility() && (dComIfGs_getRupee() == 0 && !dusk::getSettings().game.freeMagicArmor);
+#else
     return checkMagicArmorWearAbility() && dComIfGs_getRupee() == 0;
+#endif
 }
 
 BOOL daAlink_c::checkBootsOrArmorHeavy() const {
@@ -18583,7 +18587,13 @@ int daAlink_c::execute() {
             field_0x372c = cXyz::Zero;
             field_0x2fb8 = 0;
 
+#if TARGET_PC
+            // This handles rupee drain and transitions between rupees/no rupees
+            // We can skip all of that if the magic armor doesn't use rupees
+            if (!dusk::getSettings().game.freeMagicArmor && checkMagicArmorWearAbility() && mClothesChangeWaitTimer == 0) {
+#else
             if (checkMagicArmorWearAbility() && mClothesChangeWaitTimer == 0) {
+#endif
                 if (checkMagicArmorNoDamage() && !checkEventRun()) {
                     if (field_0x2fc3 == 0) {
                         field_0x2fc3 = 10;

--- a/src/d/actor/d_a_alink_damage.inc
+++ b/src/d/actor/d_a_alink_damage.inc
@@ -187,6 +187,11 @@ int daAlink_c::setDamagePoint(int i_dmgAmount, BOOL i_checkZoraMag, BOOL i_setDm
     }
 
     if (checkMagicArmorNoDamage()) {
+#if TARGET_PC
+        if(dusk::getSettings().game.freeMagicArmor) {
+            i_dmgAmount = 0;
+        }
+#endif
         dComIfGp_setItemRupeeCount(-i_dmgAmount * 10);
     } else
     #if DEBUG

--- a/src/d/actor/d_a_alink_wolf.inc
+++ b/src/d/actor/d_a_alink_wolf.inc
@@ -313,7 +313,12 @@ void daAlink_c::changeLink(int param_0) {
         mpLinkHandModel =
             initModel(static_cast<J3DModelData*>(dComIfG_getObjectRes(l_mArcName, "al_hands.bmd")), 0);
 
-        if (dComIfGs_getRupee() != 0) {
+#if TARGET_PC
+        if (dComIfGs_getRupee() != 0 || dusk::getSettings().game.freeMagicArmor)
+#else
+        if (dComIfGs_getRupee() != 0)
+#endif
+        {
             setMagicArmorBrk(1);
         } else {
             setMagicArmorBrk(0);
@@ -398,7 +403,11 @@ void daAlink_c::changeLink(int param_0) {
         field_0x06ec = field_0x064C->getMaterialNodePointer(1)->getShape();
         field_0x06f0 = field_0x064C->getMaterialNodePointer(2)->getShape();
 
+#if TARGET_PC
+        if (dComIfGs_getRupee() != 0 || dusk::getSettings().game.freeMagicArmor) {
+#else
         if (dComIfGs_getRupee() != 0) {
+#endif
             var_r27 = 4;
         } else {
             var_r27 = 5;

--- a/src/dusk/imgui/ImGuiMenuEnhancements.cpp
+++ b/src/dusk/imgui/ImGuiMenuEnhancements.cpp
@@ -106,6 +106,11 @@ namespace dusk {
                     ImGui::SetTooltip("Speeds up Spinner movement when holding R.");
                 }
 
+                config::ImGuiCheckbox("Free Magic Armor", getSettings().game.freeMagicArmor);
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip("Makes the magic armor work without rupees.");
+                }
+
                 ImGui::EndMenu();
             }
 

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -48,6 +48,7 @@ UserSettings g_userSettings = {
         .enableFastIronBoots {"game.enableFastIronBoots", false},
         .canTransformAnywhere {"game.canTransformAnywhere", false},
         .fastSpinner {"game.fastSpinner", false},
+        .freeMagicArmor {"game.freeMagicArmor", false},
 
         // Technical
         .restoreWiiGlitches {"game.restoreWiiGlitches", false},
@@ -91,6 +92,7 @@ void registerSettings() {
     Register(g_userSettings.game.useWaterProjectionOffset);
     Register(g_userSettings.game.enableFastIronBoots);
     Register(g_userSettings.game.canTransformAnywhere);
+    Register(g_userSettings.game.freeMagicArmor);
     Register(g_userSettings.game.restoreWiiGlitches);
     Register(g_userSettings.game.noMissClimbing);
     Register(g_userSettings.game.noLowHpSound);


### PR DESCRIPTION
Adds a cheat to remove the rupee drain for using the magic armor. Currently blocks all damage like the original armor, but it could be changed to be purely cosmetic/double defense/only consume rupees on damage if one of those are a more interesting option.