### PR TITLE
Don't allow quick transform while in the STAR tent

### DIFF
--- a/src/d/actor/d_a_alink_dusk.cpp
+++ b/src/d/actor/d_a_alink_dusk.cpp
@@ -9,11 +9,6 @@ void daAlink_c::handleQuickTransform() {
         return;
     }
 
-    // Ensure that link is not in a cutscene.
-    if (checkEventRun()) {
-        return;
-    }
-
     // Check to see if Link has the ability to transform.
     if (!dComIfGs_isEventBit(dSv_event_flag_c::M_077)) {
         return;
@@ -27,6 +22,12 @@ void daAlink_c::handleQuickTransform() {
 
     const auto meterDrawPtr = meterClassPtr->getMeterDrawPtr();
     if (!meterDrawPtr) {
+        return;
+    }
+
+    // Ensure that link is not in a cutscene.
+    if (checkEventRun()) {
+        Z2GetAudioMgr()->seStart(Z2SE_SYS_ERROR, NULL, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
         return;
     }
 

--- a/src/d/actor/d_a_alink_dusk.cpp
+++ b/src/d/actor/d_a_alink_dusk.cpp
@@ -32,6 +32,12 @@ void daAlink_c::handleQuickTransform() {
 
     mDoCPd_c::getCpadInfo(PAD_1).mPressedButtonFlags = 0;
 
+    // Don't allow quick transform while in the STAR tent.
+    if (checkStageName("R_SP161")) {
+        Z2GetAudioMgr()->seStart(Z2SE_SYS_ERROR, NULL, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
+        return;
+    }
+
     // Ensure that the Z Button is not dimmed
     if (meterDrawPtr->getButtonZAlpha() != 1.f) {
         Z2GetAudioMgr()->seStart(Z2SE_SYS_ERROR, NULL, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);


### PR DESCRIPTION
This is a vanilla check the game does to see if you can warp using Midna, so I included it to quick transform. Also prevents you from transforming while playing the star minigame.

Also added error SFX if you try to transform while in a cutscene or event.