### PR TITLE
Fix daE_FB_c::mKeys array size

### DIFF
--- a/include/d/actor/d_a_e_fb.h
+++ b/include/d/actor/d_a_e_fb.h
@@ -71,10 +71,16 @@ private:
     /* 0xA30 */ dCcD_Sph mSphere2;
     /* 0xB68 */ dCcD_Sph mAtSph;
     /* 0xCA0 */ dCcU_AtInfo mAtInfo;
+#if AVOID_UB
+    /* 0xCC4 */ u32 mKeys[8];
+    /* 0xCE4 */ u8 mHIOInit;
+    /* 0xCE5 */ u8 field_0xce5[0xCE8 - 0xCE5];
+#else
     // !@bug Seems that the orig developers didn't size mKeys correctly, as ideally it should be len=8, not len=7:
     /* 0xCC4 */ u32 mKeys[7];
     /* 0xCE0 */ u8 mHIOInit;
     /* 0xCE1 */ u8 field_0xce1[0xCE8 - 0xCE1];
+#endif
 };
 
 STATIC_ASSERT(sizeof(daE_FB_c) == 0xce8);


### PR DESCRIPTION
Fixes the snowpeak ruins crashes on Linux