### PR TITLE
Stub out most of DynamicLink.cpp and more of c_dylink.cpp

### DIFF
--- a/src/DynamicLink.cpp
+++ b/src/DynamicLink.cpp
@@ -14,6 +14,7 @@
 #include "os_report.h"
 #include "dusk/logging.h"
 
+#if !TARGET_PC
 DynamicModuleControlBase* DynamicModuleControlBase::mFirst;
 
 DynamicModuleControlBase* DynamicModuleControlBase::mLast;
@@ -139,6 +140,7 @@ DynamicModuleControl::DynamicModuleControl(char const* name) {
     mSize = 0;
     mAsyncLoadCallback = NULL;
 }
+#endif
 
 u32 DynamicModuleControl::sAllocBytes;
 
@@ -169,6 +171,7 @@ bool DynamicModuleControl::initialize() {
     return true;
 }
 
+#if !TARGET_PC
 bool DynamicModuleControl::callback(void* moduleControlPtr) {
     DynamicModuleControl* moduleControl = (DynamicModuleControl*)moduleControlPtr;
     return moduleControl->do_load();
@@ -484,3 +487,5 @@ extern "C" void ModuleDestructorsX(void (*const *dtors)()) {
         dtors++;
     }
 }
+
+#endif

--- a/src/c/c_dylink.cpp
+++ b/src/c/c_dylink.cpp
@@ -898,6 +898,9 @@ BOOL cDyl_IsLinked(s16 i_ProfName) {
 }
 
 BOOL cDyl_Unlink(s16 i_ProfName) {
+#if TARGET_PC
+    return FALSE;
+#else
     #if DEBUG
     cCc_Check();
     #endif
@@ -911,9 +914,13 @@ BOOL cDyl_Unlink(s16 i_ProfName) {
     }
 
     return FALSE;
+#endif
 }
 
 int cDyl_LinkASync(s16 i_ProfName) {
+#if TARGET_PC
+    return cPhs_COMPLEATE_e;
+#else
     #if DEBUG
     cCc_Check();
     #endif
@@ -953,6 +960,7 @@ int cDyl_LinkASync(s16 i_ProfName) {
     }
 
     return cPhs_COMPLEATE_e;
+#endif
 }
 
 static int cDyl_InitCallback(void* param_0) {


### PR DESCRIPTION
This code wasn't used (no dynamic linking) and was causing various compiler warnings that don't make sense to clean up. Get rid of it.