### PR TITLE
Restore Warning Screen behind Toggle

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -35,6 +35,7 @@ struct UserSettings {
         // QoL
         ConfigVar<bool> enableQuickTransform;
         ConfigVar<bool> hideTvSettingsScreen;
+        ConfigVar<bool> skipWarningScreen;
         ConfigVar<bool> biggerWallets;
         ConfigVar<bool> noReturnRupees;
         ConfigVar<bool> disableRupeeCutscenes;

--- a/src/d/d_s_logo.cpp
+++ b/src/d/d_s_logo.cpp
@@ -480,7 +480,13 @@ void dScnLogo_c::warningInDraw() {
 
     if (mTimer == 0) {
         mExecCommand = EXEC_WARNING_DISP;
+
+        #if TARGET_PC && TEMP_DEBUG_TEST
         mTimer = 30;
+        #else
+        mTimer = 3510;
+        #endif
+
         field_0x20e = 30;
         field_0x210 = field_0x20e;
         field_0x212 = 1;
@@ -547,7 +553,13 @@ void dScnLogo_c::nintendoOutDraw() {
 
     if (mTimer == 0) {
         mExecCommand = EXEC_DOLBY_IN;
+
+        #if TARGET_PC && TEMP_DEBUG_TEST
         mTimer = 30;
+        #else
+        mTimer = 90;
+        #endif
+
         mDoGph_gInf_c::startFadeIn(30);
     }
 }
@@ -1104,10 +1116,14 @@ int dScnLogo_c::create() {
     checkProgSelect();
     if (field_0x20a != 0) {
         mExecCommand = EXEC_PROG_IN;
+        #if TARGET_PC && TEMP_DEBUG_TEST
         mTimer = 1;
+        #else
+        mTimer = 30;
+        #endif
         field_0x218 = getProgressiveMode();
     } else {
-        #if TARGET_PC
+        #if TARGET_PC && TEMP_DEBUG_TEST
         mTimer = 0; // Possibly unnecessary but just in case
         mExecCommand = EXEC_DVD_WAIT;
         #else

--- a/src/d/d_s_logo.cpp
+++ b/src/d/d_s_logo.cpp
@@ -481,8 +481,8 @@ void dScnLogo_c::warningInDraw() {
     if (mTimer == 0) {
         mExecCommand = EXEC_WARNING_DISP;
 
-        #if TARGET_PC && TEMP_DEBUG_TEST
-        mTimer = 30;
+        #if TARGET_PC
+        mTimer = dusk::getSettings().game.skipWarningScreen ? 30 : 3510;
         #else
         mTimer = 3510;
         #endif
@@ -554,8 +554,8 @@ void dScnLogo_c::nintendoOutDraw() {
     if (mTimer == 0) {
         mExecCommand = EXEC_DOLBY_IN;
 
-        #if TARGET_PC && TEMP_DEBUG_TEST
-        mTimer = 30;
+        #if TARGET_PC
+        mTimer = dusk::getSettings().game.skipWarningScreen ? 30 : 90;
         #else
         mTimer = 90;
         #endif
@@ -1116,16 +1116,26 @@ int dScnLogo_c::create() {
     checkProgSelect();
     if (field_0x20a != 0) {
         mExecCommand = EXEC_PROG_IN;
-        #if TARGET_PC && TEMP_DEBUG_TEST
-        mTimer = 1;
+        #if TARGET_PC
+        mTimer = dusk::getSettings().game.skipWarningScreen ? 1 : 30;
         #else
         mTimer = 30;
         #endif
         field_0x218 = getProgressiveMode();
     } else {
-        #if TARGET_PC && TEMP_DEBUG_TEST
-        mTimer = 0; // Possibly unnecessary but just in case
-        mExecCommand = EXEC_DVD_WAIT;
+        #if TARGET_PC
+        if (dusk::getSettings().game.skipWarningScreen) {
+            mTimer = 0;  // Possibly unnecessary but just in case
+            mExecCommand = EXEC_DVD_WAIT;
+        } else {
+            if (mDoRst::getWarningDispFlag()) {
+                mTimer = 90;
+                mExecCommand = EXEC_NINTENDO_IN;
+            } else {
+                mTimer = 120;
+                mExecCommand = EXEC_WARNING_IN;
+            }
+        }
         #else
         if (mDoRst::getWarningDispFlag()) {
             mTimer = 90;

--- a/src/d/d_s_logo.cpp
+++ b/src/d/d_s_logo.cpp
@@ -480,13 +480,7 @@ void dScnLogo_c::warningInDraw() {
 
     if (mTimer == 0) {
         mExecCommand = EXEC_WARNING_DISP;
-
-        #if TARGET_PC
-        mTimer = dusk::getSettings().game.skipWarningScreen ? 30 : 3510;
-        #else
         mTimer = 3510;
-        #endif
-
         field_0x20e = 30;
         field_0x210 = field_0x20e;
         field_0x212 = 1;
@@ -553,13 +547,7 @@ void dScnLogo_c::nintendoOutDraw() {
 
     if (mTimer == 0) {
         mExecCommand = EXEC_DOLBY_IN;
-
-        #if TARGET_PC
-        mTimer = dusk::getSettings().game.skipWarningScreen ? 30 : 90;
-        #else
         mTimer = 90;
-        #endif
-
         mDoGph_gInf_c::startFadeIn(30);
     }
 }

--- a/src/dusk/imgui/ImGuiFirstRunPreset.cpp
+++ b/src/dusk/imgui/ImGuiFirstRunPreset.cpp
@@ -18,6 +18,7 @@ static void ApplyPresetClassic() {
 static void ApplyPresetHD() {
     auto& s = getSettings();
     s.game.hideTvSettingsScreen.setValue(true);
+    s.game.skipWarningScreen.setValue(true);
     s.game.noReturnRupees.setValue(true);
     s.game.disableRupeeCutscenes.setValue(true);
     s.game.noSwordRecoil.setValue(true);

--- a/src/dusk/imgui/ImGuiMenuEnhancements.cpp
+++ b/src/dusk/imgui/ImGuiMenuEnhancements.cpp
@@ -53,6 +53,11 @@ namespace dusk {
                     ImGui::SetTooltip("Hides the TV calibration screen shown when loading a save.");
                 }
 
+                config::ImGuiCheckbox("Skip Warning Screen", getSettings().game.skipWarningScreen);
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip("Skips the warning screen shown when loading the game.");
+                }
+
                 config::ImGuiCheckbox("Instant Saves", getSettings().game.instantSaves);
                 if (ImGui::IsItemHovered()) {
                     ImGui::SetTooltip("Skip the delay when writing to the Memory Card.");

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -23,6 +23,7 @@ UserSettings g_userSettings = {
         // Quality of Life
         .enableQuickTransform {"game.enableQuickTransform", false},
         .hideTvSettingsScreen {"game.hideTvSettingsScreen", false},
+        .skipWarningScreen {"game.skipWarningScreen", false},
         .biggerWallets {"game.biggerWallets", false},
         .noReturnRupees {"game.noReturnRupees", false},
         .disableRupeeCutscenes {"game.disableRupeeCutscenes", false},
@@ -91,6 +92,7 @@ void registerSettings() {
     // Game
     Register(g_userSettings.game.enableQuickTransform);
     Register(g_userSettings.game.hideTvSettingsScreen);
+    Register(g_userSettings.game.skipWarningScreen);
     Register(g_userSettings.game.biggerWallets);
     Register(g_userSettings.game.noReturnRupees);
     Register(g_userSettings.game.disableRupeeCutscenes);


### PR DESCRIPTION
We originally modified the logo screen without adding defines around the changes, so this restores the original values.