### PR TITLE
Per-Axis Gyro Sensitivity

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -64,7 +64,8 @@ struct UserSettings {
 
         // Input
         ConfigVar<bool> enableGyroAim;
-        ConfigVar<float> gyroAimSensitivity;
+        ConfigVar<float> gyroAimSensitivityX;
+        ConfigVar<float> gyroAimSensitivityY;
         ConfigVar<bool> gyroAimInvertPitch;
         ConfigVar<bool> gyroAimInvertYaw;
 

--- a/src/dusk/gyro_aim.cpp
+++ b/src/dusk/gyro_aim.cpp
@@ -61,9 +61,8 @@ void read(float dt, bool context_active) {
     float yaw_rate = apply_deadband(s_smooth_gy);
     float pitch_rate = apply_deadband(s_smooth_gx);
 
-    const float sens = dusk::getSettings().game.gyroAimSensitivity;
-    s_pending_yaw_rad += yaw_rate * dt * sens;
-    s_pending_pitch_rad += pitch_rate * dt * sens;
+    s_pending_yaw_rad += yaw_rate * dt * dusk::getSettings().game.gyroAimSensitivityX;
+    s_pending_pitch_rad += pitch_rate * dt * dusk::getSettings().game.gyroAimSensitivityY;
 }
 
 void consumeAimDeltas(float& out_yaw_rad, float& out_pitch_rad) {

--- a/src/dusk/imgui/ImGuiMenuEnhancements.cpp
+++ b/src/dusk/imgui/ImGuiMenuEnhancements.cpp
@@ -119,7 +119,8 @@ namespace dusk {
                                       "Slingshot, Gale Boomerang, Hero's Bow, Clawshot(s), Ball and Chain, and Dominion Rod.");
                 }
 
-                config::ImGuiSliderFloat("Gyro Sensitivity", getSettings().game.gyroAimSensitivity, 0.25f, 4.0f, "%.2f");
+                config::ImGuiSliderFloat("Gyro Pitch Sensitivity", getSettings().game.gyroAimSensitivityY, 0.25f, 4.0f, "%.2f");
+                config::ImGuiSliderFloat("Gyro Yaw Sensitivity", getSettings().game.gyroAimSensitivityX, 0.25f, 4.0f, "%.2f");
                 config::ImGuiCheckbox("Invert Gyro Pitch", getSettings().game.gyroAimInvertPitch);
                 config::ImGuiCheckbox("Invert Gyro Yaw", getSettings().game.gyroAimInvertYaw);
 

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -52,7 +52,8 @@ UserSettings g_userSettings = {
 
         // Input
         .enableGyroAim {"game.enableGyroAim", false},
-        .gyroAimSensitivity {"game.gyroAimSensitivity", 1.0f},
+        .gyroAimSensitivityX {"game.gyroAimSensitivityX", 1.0f},
+        .gyroAimSensitivityY {"game.gyroAimSensitivityY", 1.0f},
         .gyroAimInvertPitch {"game.gyroAimInvertPitch", false},
         .gyroAimInvertYaw {"game.gyroAimInvertYaw", false},
 
@@ -126,7 +127,8 @@ void registerSettings() {
     Register(g_userSettings.game.fastSpinner);
     Register(g_userSettings.game.enableFrameInterpolation);
     Register(g_userSettings.game.enableGyroAim);
-    Register(g_userSettings.game.gyroAimSensitivity);
+    Register(g_userSettings.game.gyroAimSensitivityX);
+    Register(g_userSettings.game.gyroAimSensitivityY);
     Register(g_userSettings.game.gyroAimInvertPitch);
     Register(g_userSettings.game.gyroAimInvertYaw);
 


### PR DESCRIPTION
Split the option into horizontal/vertical sensitivity to give more freedom to tune it for different controllers (e.g. felt better with a higher horizontal sensitivity on my DS4 controller with vertical still at 1x)