### PR TITLE
Re-equip Ordon Clothes Feature

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -51,6 +51,7 @@ struct UserSettings {
         // Preferences
         ConfigVar<bool> enableMirrorMode;
         ConfigVar<bool> invertCameraXAxis;
+        ConfigVar<bool> reEquipOrdonClothes;
 
         // Graphics
         ConfigVar<bool> enableBloom;

--- a/src/d/d_menu_collect.cpp
+++ b/src/d/d_menu_collect.cpp
@@ -486,7 +486,7 @@ void dMenu_Collect2D_c::screenSet() {
     field_0x22d[0][2] = 0;
     field_0x22d[1][2] = 0;
     field_0x22d[2][2] = 0;
-    if (dComIfGs_getSelectEquipClothes() == dItemNo_WEAR_CASUAL_e) {
+    if (dComIfGs_getSelectEquipClothes() == dItemNo_WEAR_CASUAL_e IF_DUSK(&& !dComIfGs_isItemFirstBit(0x2F))) {
         field_0x22d[3][2] = 0;
         field_0x22d[4][2] = 0;
         field_0x22d[5][2] = 0;
@@ -1209,6 +1209,15 @@ void dMenu_Collect2D_c::changeClothe() {
             Z2GetAudioMgr()->seStart(Z2SE_SY_ITEM_SET_X, NULL, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
             dMeter2Info_set2DVibration();
         }
+        #if TARGET_PC
+        else if (dusk::getSettings().game.reEquipOrdonClothes) {
+            dMeter2Info_setCloth(dItemNo_WEAR_CASUAL_e, false);
+            setEquipItemFrameColorClothes(3);
+            daPy_getPlayerActorClass()->setClothesChange(0);
+            Z2GetAudioMgr()->seStart(Z2SE_SY_ITEM_SET_X, NULL, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
+            dMeter2Info_set2DVibration();
+        }
+        #endif
         break;
     case 4:
         if (dComIfGs_getSelectEquipClothes() != dItemNo_WEAR_ZORA_e) {

--- a/src/dusk/imgui/ImGuiFirstRunPreset.cpp
+++ b/src/dusk/imgui/ImGuiFirstRunPreset.cpp
@@ -37,6 +37,7 @@ static void ApplyPresetDusk() {
     s.game.instantSaves.setValue(true);
     s.game.midnasLamentNonStop.setValue(true);
     s.game.enableFrameInterpolation.setValue(true);
+    s.game.reEquipOrdonClothes.setValue(true);
 }
 
 // =========================================================================

--- a/src/dusk/imgui/ImGuiMenuEnhancements.cpp
+++ b/src/dusk/imgui/ImGuiMenuEnhancements.cpp
@@ -74,6 +74,12 @@ namespace dusk {
 
                 config::ImGuiCheckbox("Invert Camera X Axis", getSettings().game.invertCameraXAxis);
 
+                config::ImGuiCheckbox("Re-Equip Ordon Clothes", getSettings().game.reEquipOrdonClothes);
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip("Allows re-equipping the Ordon Clothes by pressing A\n"
+                                      "on the Hero's Clothes in the Collection screen.");
+                }
+
                 ImGui::EndMenu();
             }
 

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -39,6 +39,7 @@ UserSettings g_userSettings = {
         // Preferences
         .enableMirrorMode {"game.enableMirrorMode", false},
         .invertCameraXAxis {"game.invertCameraXAxis", false},
+        .reEquipOrdonClothes {"game.reEquipOrdonClothes", false},
 
         // Graphics
         .enableBloom {"game.enableBloom", true},
@@ -113,6 +114,7 @@ void registerSettings() {
     Register(g_userSettings.game.instantSaves);
     Register(g_userSettings.game.enableMirrorMode);
     Register(g_userSettings.game.invertCameraXAxis);
+    Register(g_userSettings.game.reEquipOrdonClothes);
     Register(g_userSettings.game.enableBloom);
     Register(g_userSettings.game.enableWaterRefraction);
     Register(g_userSettings.game.shadowResolutionMultiplier);


### PR DESCRIPTION
The Ordon Clothes don't save in the save file!

I don't think it should anyway, because of the nature of Dusk, and being able to toggle Enhancements at runtime, we wouldn't want a specific Enhancement to be stored in the save file forever.