### PR TITLE
Revert Classic Bloom Hack

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -10,7 +10,8 @@ using namespace config;
 enum class BloomMode : int {
     Off = 0,
     Classic = 1,
-    Dusk = 2,
+    HD = 2,
+    Dusk = 3,
 };
 
 namespace config {

--- a/src/dusk/imgui/ImGuiFirstRunPreset.cpp
+++ b/src/dusk/imgui/ImGuiFirstRunPreset.cpp
@@ -18,7 +18,7 @@ static void ApplyPresetClassic() {
 
 static void ApplyPresetHD() {
     auto& s = getSettings();
-    s.game.bloomMode.setValue(BloomMode::Classic);
+    s.game.bloomMode.setValue(BloomMode::HD);
     s.game.hideTvSettingsScreen.setValue(true);
     s.game.skipWarningScreen.setValue(true);
     s.game.noReturnRupees.setValue(true);

--- a/src/dusk/imgui/ImGuiMenuGame.cpp
+++ b/src/dusk/imgui/ImGuiMenuGame.cpp
@@ -62,7 +62,7 @@ namespace dusk {
                     config::Save();
                 }
 
-                constexpr const char* bloomModeNames[] = {"Off", "Classic", "Dusk"};
+                constexpr const char* bloomModeNames[] = {"Off", "Classic", "HD", "Dusk"};
                 int bloomMode = static_cast<int>(getSettings().game.bloomMode.getValue());
                 if (ImGui::BeginCombo("Bloom", bloomModeNames[bloomMode])) {
                     for (int i = 0; i < IM_ARRAYSIZE(bloomModeNames); i++) {

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1628,11 +1628,7 @@ void mDoGph_gInf_c::bloom_c::draw() {
             for (int texCoord = (int)GX_TEXCOORD1; texCoord < (int)GX_MAX_TEXCOORD; texCoord++) {
                 GXSetTexCoordGen((GXTexCoordID)texCoord, GX_TG_MTX2x4, GX_TG_TEX0, texMtxID);
                 
-                #if TARGET_PC
-                f32 dVar15 = mBlureSize * ((448.0f / height) / 6400.0f);
-                #else
                 f32 dVar15 = mBlureSize * (1.0f / 6400.0f);
-                #endif
 
                 mDoMtx_stack_c::transS((dVar15 * cM_scos(angle)) * getInvScale(),
                                        dVar15 * cM_ssin(angle), 0.0f);

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1628,7 +1628,11 @@ void mDoGph_gInf_c::bloom_c::draw() {
             for (int texCoord = (int)GX_TEXCOORD1; texCoord < (int)GX_MAX_TEXCOORD; texCoord++) {
                 GXSetTexCoordGen((GXTexCoordID)texCoord, GX_TG_MTX2x4, GX_TG_TEX0, texMtxID);
                 
+                #if 0
+                f32 dVar15 = mBlureSize * ((448.0f / height) / 6400.0f);
+                #else
                 f32 dVar15 = mBlureSize * (1.0f / 6400.0f);
+                #endif
 
                 mDoMtx_stack_c::transS((dVar15 * cM_scos(angle)) * getInvScale(),
                                        dVar15 * cM_ssin(angle), 0.0f);

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1505,7 +1505,9 @@ void mDoGph_gInf_c::bloom_c::draw() {
         draw2();
         return;
     }
-    if (dusk::getSettings().game.bloomMode.getValue() != dusk::BloomMode::Classic) {
+    if (dusk::getSettings().game.bloomMode.getValue() != dusk::BloomMode::Classic &&
+        dusk::getSettings().game.bloomMode.getValue() != dusk::BloomMode::HD)
+    {
         return;
     }
 
@@ -1628,8 +1630,13 @@ void mDoGph_gInf_c::bloom_c::draw() {
             for (int texCoord = (int)GX_TEXCOORD1; texCoord < (int)GX_MAX_TEXCOORD; texCoord++) {
                 GXSetTexCoordGen((GXTexCoordID)texCoord, GX_TG_MTX2x4, GX_TG_TEX0, texMtxID);
                 
-                #if 0
-                f32 dVar15 = mBlureSize * ((448.0f / height) / 6400.0f);
+                #if TARGET_PC
+                f32 dVar15 = mBlureSize;
+                if (dusk::getSettings().game.bloomMode.getValue() == dusk::BloomMode::HD) {
+                    dVar15 *= ((448.0f / height) / 6400.0f);
+                } else {
+                    dVar15 *= (1.0f / 6400.0f);
+                }
                 #else
                 f32 dVar15 = mBlureSize * (1.0f / 6400.0f);
                 #endif


### PR DESCRIPTION
Feel free to discuss about this, but I think we should keep the Classic bloom as it is on GameCube without any hacks. Then we can have the HD/Dusk presets set the bloom to Enhanced by default.