### PR TITLE
Clear statics in trill's destroy call

### DIFF
--- a/src/d/actor/d_a_myna.cpp
+++ b/src/d/actor/d_a_myna.cpp
@@ -363,6 +363,18 @@ int daMyna_c::destroy() {
         mpMorf->stopZelAnime();
     }
 
+#ifdef TARGET_PC
+    // !@bug d_a_myna.rel unload used to zero these file-statics; with static linking they dangle across scenes.
+    daMyna_LightActor = NULL;
+    daMyna_evtTagActor0 = NULL;
+    daMyna_evtTagActor1 = NULL;
+    daMyna_actor_count = 0;
+    for (int i = 0; i < 10; i++) {
+        daMyna_targetActor[i] = NULL;
+        daMyna_subActor[i] = NULL;
+    }
+#endif
+
 #if DEBUG
     l_HOSTIO.removeHIO();
 #endif


### PR DESCRIPTION
Fixes #302 

The lantern refill bit I mentioned was just me being a dumb speedrunner, but there was another issue where trill attempted to scoot toward a stale daMyna_LightActor pointer that was now at 0,0,0, resulting in her scooting in mid air off her post. 

On GC/Wii presumably the REL unload resets them so we don't see the issue there