### PR TITLE
Fix Unloading Gates

### DIFF
--- a/src/d/actor/d_a_dshutter.cpp
+++ b/src/d/actor/d_a_dshutter.cpp
@@ -219,9 +219,10 @@ int daDsh_c::create() {
     const char* l_resName[] = {l_arcName[mType], ""};
 #else
     // !@bug By making this static, it is only initialized the first time it runs
-    // If gates that use other arcs are loaded later (without restarting the game)
+    // If gate types that use other arcs are loaded later (without reloading the code)
     // this array never gets updated and will load the incorrect arc
-    // That causes daDsh_c::CreateHeap to fail getting model data and the gate to never load
+    // On GC/Wii, REL loading causes this to reset/reinitialize so the bug is avoided
+    // but TPHD is all statically linked so daDsh_c::CreateHeap fails to get model data and the gate unloads
     static const char* l_resName[] = {l_arcName[mType], ""};
 #endif
 

--- a/src/d/actor/d_a_dshutter.cpp
+++ b/src/d/actor/d_a_dshutter.cpp
@@ -215,7 +215,15 @@ int daDsh_c::create() {
 
     mType = getType();
 
+#ifdef TARGET_PC
+    const char* l_resName[] = {l_arcName[mType], ""};
+#else
+    // !@bug By making this static, it is only initialized the first time it runs
+    // If gates that use other arcs are loaded later (without restarting the game)
+    // this array never gets updated and will load the incorrect arc
+    // That causes daDsh_c::CreateHeap to fail getting model data and the gate to never load
     static const char* l_resName[] = {l_arcName[mType], ""};
+#endif
 
     int phase = mResLoader.load(l_resName, NULL);
     if (phase == cPhs_COMPLEATE_e) {


### PR DESCRIPTION
Fixes CitS/Lakebed gate unloading (only present in TPHD because it doesn't have RELs), bug comment/brief actor description should be updated in decomp