### PR TITLE
Auto-Hide Cursor

### DIFF
--- a/src/dusk/imgui/ImGuiConsole.cpp
+++ b/src/dusk/imgui/ImGuiConsole.cpp
@@ -368,10 +368,16 @@ namespace dusk {
         m_menuTools.ShowStateShare();
         DuskDebugPad(); // temporary, remove later
 
-        // Only show cursor when menu or any windows are open
-        if (showMenu || ImGui::GetIO().MetricsRenderWindows > 0) {
-            ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange;
-            // Imgui will re-show cursor.
+        // Hide mouse cursor if the F1 menu is not open and the cursor is idle for 3 seconds.
+        ImGuiIO& io = ImGui::GetIO();
+        if (showMenu) {
+            mouseHideTimer = 0.0f;
+            ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange; // Imgui will re-show cursor.
+        } else if (io.MouseDelta.x != 0.0f || io.MouseDelta.y != 0.0f) {
+            mouseHideTimer = 0.0f;
+            ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange; // Imgui will re-show cursor.
+        } else if (mouseHideTimer <= 3.0f) {
+            mouseHideTimer += ImGui::GetIO().DeltaTime;
         } else {
             ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
             SDL_HideCursor();

--- a/src/dusk/imgui/ImGuiConsole.hpp
+++ b/src/dusk/imgui/ImGuiConsole.hpp
@@ -38,6 +38,8 @@ private:
                                                               remain(duration) {}
     };
 
+    float mouseHideTimer = 0.0f;
+
     bool m_isHidden = true;
     bool m_isLaunchInitialized = false;
     bool m_touchTapActive = false;


### PR DESCRIPTION
Hides the mouse cursor if the F1 menu is not open and the cursor is idle for 3 seconds.
Having the F1 menu open will always display the mouse cursor.