### PR TITLE
add uninitialized variable fix

### DIFF
--- a/src/d/actor/d_a_npc_inko.cpp
+++ b/src/d/actor/d_a_npc_inko.cpp
@@ -111,7 +111,7 @@ static int daNpc_Inko_Execute(npc_inko_class* i_this) {
 
     f32 var_f31;
     
-    #if TARGET_PC
+    #if AVOID_UB
     var_f31 = 0.0f;
     #endif
     if (i_this->field_0x598 == 0) {

--- a/src/d/actor/d_a_npc_inko.cpp
+++ b/src/d/actor/d_a_npc_inko.cpp
@@ -110,6 +110,10 @@ static int daNpc_Inko_Execute(npc_inko_class* i_this) {
     }
 
     f32 var_f31;
+    
+    #if TARGET_PC
+    var_f31 = 0.0f;
+    #endif
     if (i_this->field_0x598 == 0) {
         if (i_this->field_0x59c[1] == 0) {
             i_this->field_0x59c[1] = 30.0f + cM_rndF(70.0f);


### PR DESCRIPTION
Initializes an uninitialized local variable. This variable is added as an offset for a translation matrix, so setting it to zero seems like a reasonable value for that purpose.