### PR TITLE
Fix file select fade not rendering with frame interpolation

### DIFF
--- a/include/d/d_file_select.h
+++ b/include/d/d_file_select.h
@@ -10,6 +10,7 @@
 #include "JSystem/J3DGraphLoader/J3DAnmLoader.h"
 
 class dFile_info_c;
+class J2DPicture;
 
 class dDlst_FileSel_c : public dDlst_base_c {
 public:
@@ -111,6 +112,14 @@ public:
     virtual ~dDlst_FileSel3m_c() { JKR_DELETE(Scr3m); }
 
     /* 0x04 */ J2DScreen* Scr3m;
+};
+
+class dDlst_FileSelFade_c : public dDlst_base_c {
+public:
+    void draw();
+    virtual ~dDlst_FileSelFade_c() {}
+
+    /* 0x04 */ J2DPicture* mpPict;
 };
 
 class dFs_HIO_c : public JORReflexible {
@@ -676,6 +685,9 @@ public:
     #if PLATFORM_GCN
     /* 0x2378 */ J2DPicture* mpFadePict;
     #endif
+#ifdef TARGET_PC
+    dDlst_FileSelFade_c mFadeDlst;
+#endif
 
     #if PLATFORM_WII || PLATFORM_SHIELD
     /* 0x2376 */ u8 field_0x2376[SAVEFILE_SIZE];
@@ -684,6 +696,10 @@ public:
     #endif
 };
 
+#ifdef TARGET_PC
+STATIC_ASSERT(sizeof(dFile_select_c) == 0x237C + sizeof(dDlst_FileSelFade_c));
+#else
 STATIC_ASSERT(sizeof(dFile_select_c) == 0x237C);
+#endif
 
 #endif /* D_FILE_D_FILE_SELECT_H */

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3204,6 +3204,9 @@ void dFile_select_c::screenSet() {
                                 timg, NULL);
     mpFadePict->setBlackWhite(black, white);
     mpFadePict->setAlpha(0);
+#ifdef TARGET_PC
+    mFadeDlst.mpPict = mpFadePict;
+#endif
     #endif
 }
 
@@ -3870,9 +3873,13 @@ void dFile_select_c::_draw() {
         dComIfGd_set2DOpa(mSelIcon2);
 
         #if PLATFORM_GCN
+        #if TARGET_PC
+        dComIfGd_set2DOpaTop(&mFadeDlst);
+        #else
         mpFadePict->draw(mDoGph_gInf_c::getMinXF(), mDoGph_gInf_c::getMinYF(),
                            mDoGph_gInf_c::getWidthF(), mDoGph_gInf_c::getHeightF(), false, false,
                            false);
+        #endif
         #endif
     }
 }
@@ -3916,6 +3923,13 @@ void dDlst_FileSel3m_c::draw() {
     J2DGrafContext* graf = dComIfGp_getCurrentGrafPort();
     Scr3m->draw(0.0f, 0.0f, graf);
 }
+
+#ifdef TARGET_PC
+void dDlst_FileSelFade_c::draw() {
+    mpPict->draw(mDoGph_gInf_c::getMinXF(), mDoGph_gInf_c::getMinYF(),
+                 mDoGph_gInf_c::getWidthF(), mDoGph_gInf_c::getHeightF(), false, false, false);
+}
+#endif
 
 void dFile_select_c::errorMoveAnmInitSet(int param_1, int param_2) {
     mErrorMsgPane->setAnimation(field_0x0090);


### PR DESCRIPTION
mpFadePict on dFile_select_c is drawn directly rather than through the display list system. Since interpolation defers cAPIGph_Painter's execution to after process draws, the direct draw gets wiped when the painter clears the framebuffer, and the fade transition between file naming screens never appears. Adding a new dDlst_FileSelFade_c wrapper that inherits from dDlst_base_c so the fade is drawn through the display list and survives the deferred painter