### PR TITLE
Fix memory card not properly attaching on init.

### DIFF
--- a/src/m_Do/m_Do_MemCard.cpp
+++ b/src/m_Do/m_Do_MemCard.cpp
@@ -84,11 +84,12 @@ void mDoMemCd_Ctrl_c::ThdInit() {
     mProbeStat = 2;
     mCardState = CARD_STATE_NO_CARD_e;
 
-    #if TARGET_PC
-    mCardState = CARD_STATE_READY_e;
-    #endif
-
+#if TARGET_PC
+    mCardCommand = COMM_ATTACH_e;
+#else
     mCardCommand = COMM_NONE_e;
+#endif
+
     mChannel = SLOT_A;
 
     OSInitMutex(&mMutex);


### PR DESCRIPTION
Previously the card status was forced to ready which caused quite a bit of default state not get set properly, reverting that and setting mCardCommand to `COMM_ATTACH_e` allows the memory card system to properly probe and detect the card status.

A companion fix in aurora addresses the "Memory Card corrupted" error message.