### PR TITLE
Use vendored SDL on ubuntu for libusb

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -358,7 +358,10 @@
       "inherits": [
         "relwithdebinfo",
         "ci"
-      ]
+      ],
+      "cacheVariables": {
+        "AURORA_SDL3_PROVIDER": "vendor"
+      }
     },
     {
       "name": "x-linux-ci-gcc",


### PR DESCRIPTION
Stock SDL on ubuntu does not have libusb enabled, use the vendored version instead.