### PR TITLE
Fix THP shutdown crash

### DIFF
--- a/include/d/actor/d_a_movie_player.h
+++ b/include/d/actor/d_a_movie_player.h
@@ -94,6 +94,12 @@ static void __THPAudioInitialize(THPAudioDecodeInfo* info, u8* ptr);
 #define THP_TEXTURE_SET_COUNT  3
 #endif
 
+#if TARGET_PC
+namespace dusk {
+    void MoviePlayerShutdown();
+}
+#endif
+
 struct daMP_THPPlayer {
     /* 0x000 */ DVDFileInfo fileInfo;
 	/* 0x03C */ THPHeader header;

--- a/src/d/actor/d_a_movie_player.cpp
+++ b/src/d/actor/d_a_movie_player.cpp
@@ -4580,3 +4580,12 @@ actor_process_profile_definition g_profile_MOVIE_PLAYER = {
 };
 
 AUDIO_INSTANCES;
+
+#if TARGET_PC
+void dusk::MoviePlayerShutdown() {
+    // We need to cleanly shut down the threads to avoid crashes on shutdown.
+    if (daMP_c::m_myObj) {
+        daMP_c::m_myObj->daMP_c_Finish();
+    }
+}
+#endif

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -66,13 +66,15 @@
 
 #include "SDL3/SDL_filesystem.h"
 #include "cxxopts.hpp"
+#include "d/actor/d_a_movie_player.h"
 #include "dusk/audio/DuskAudioSystem.h"
 #include "dusk/config.hpp"
-#include "dusk/settings.h"
 #include "dusk/imgui/ImGuiConsole.hpp"
+#include "dusk/settings.h"
 #include "dusk/discord_presence.hpp"
 #include "tracy/Tracy.hpp"
 #include "f_pc/f_pc_draw.h"
+#include "tracy/Tracy.hpp"
 
 // --- GLOBALS ---
 s8 mDoMain::developmentMode = -1;
@@ -613,6 +615,8 @@ int game_main(int argc, char* argv[]) {
 
 
     main01();
+
+    dusk::MoviePlayerShutdown();
 
     dusk::ShutdownCrashReporting();
     dusk::ShutdownFileLogging();


### PR DESCRIPTION
Cleanly shut down movie player threads on exit.

Fixes #385

I'm not 100% fond of having to manually insert a call like this into the shutdown logic, but the other solution is shutting down all processes and that's likely to result in causing more crashes.