### PR TITLE
Frame Interp: d_menu_save and d_menu_fmap2D

### DIFF
--- a/src/d/d_menu_fmap2D.cpp
+++ b/src/d/d_menu_fmap2D.cpp
@@ -1769,14 +1769,19 @@ void dMenu_Fmap2DBack_c::calcBlink() {
                                  t * (g_fmapHIO.mMapBlink[i + 1].mUnselectedRegion.mBlinkSpeed -
                                       g_fmapHIO.mMapBlink[i].mUnselectedRegion.mBlinkSpeed);
 
-    field_0x1218++;
-    if (field_0x1218 >= selected_blink_speed) {
-        field_0x1218 = 0;
-    }
+#if TARGET_PC
+    if (dusk::frame_interp::get_ui_tick_pending())
+#endif
+    {
+        field_0x1218++;
+        if (field_0x1218 >= selected_blink_speed) {
+            field_0x1218 = 0;
+        }
 
-    field_0x121a++;
-    if (field_0x121a >= unselected_blink_speed) {
-        field_0x121a = 0;
+        field_0x121a++;
+        if (field_0x121a >= unselected_blink_speed) {
+            field_0x121a = 0;
+        }
     }
 
     f32 t_selected = 0.0f;

--- a/src/d/d_menu_save.cpp
+++ b/src/d/d_menu_save.cpp
@@ -18,6 +18,7 @@
 #include "m_Do/m_Do_controller_pad.h"
 #include "m_Do/m_Do_graphic.h"
 #include "d/d_msg_scrn_explain.h"
+#include "dusk/frame_interpolation.h"
 #include "dusk/settings.h"
 #include "JSystem/J2DGraph/J2DAnmLoader.h"
 #include "f_op/f_op_msg_mng.h"
@@ -715,7 +716,9 @@ void dMenu_save_c::_move() {
         }
 
         (this->*MenuSaveProc[mMenuProc])();
+#if !TARGET_PC
         saveSelAnm();
+#endif
 
         if (mWarning != NULL) {
             mWarning->_move();
@@ -732,36 +735,46 @@ void dMenu_save_c::saveSelAnm() {
 }
 
 void dMenu_save_c::selFileWakuAnm() {
-    mFileWakuAnmFrame += 2;
-    if (mFileWakuAnmFrame >= mpFileWakuAnm->getFrameMax()) {
-        mFileWakuAnmFrame -= mpFileWakuAnm->getFrameMax();
+#if TARGET_PC
+    if (dusk::frame_interp::get_ui_tick_pending())
+#endif
+    {
+        mFileWakuAnmFrame += 2;
+        if (mFileWakuAnmFrame >= mpFileWakuAnm->getFrameMax()) {
+            mFileWakuAnmFrame -= mpFileWakuAnm->getFrameMax();
+        }
+
+        mFileWakuRotAnmFrame += 2;
+        if (mFileWakuRotAnmFrame >= mpFileWakuRotAnm->getFrameMax()) {
+            mFileWakuRotAnmFrame -= mpFileWakuRotAnm->getFrameMax();
+        }
     }
     mpFileWakuAnm->setFrame(mFileWakuAnmFrame);
-
-    mFileWakuRotAnmFrame += 2;
-    if (mFileWakuRotAnmFrame >= mpFileWakuRotAnm->getFrameMax()) {
-        mFileWakuRotAnmFrame -= mpFileWakuRotAnm->getFrameMax();
-    }
     mpFileWakuRotAnm->setFrame(mFileWakuRotAnmFrame);
 }
 
 void dMenu_save_c::bookIconAnm() {
-    field_0x154 += 2;
-    if (field_0x154 >= field_0x150->getFrameMax()) {
-        field_0x154 -= field_0x150->getFrameMax();
+#if TARGET_PC
+    if (dusk::frame_interp::get_ui_tick_pending())
+#endif
+    {
+        field_0x154 += 2;
+        if (field_0x154 >= field_0x150->getFrameMax()) {
+            field_0x154 -= field_0x150->getFrameMax();
+        }
+
+        field_0x15c += 2;
+        if (field_0x15c >= field_0x158->getFrameMax()) {
+            field_0x15c -= field_0x158->getFrameMax();
+        }
+
+        field_0x164 += 2;
+        if (field_0x164 >= field_0x160->getFrameMax()) {
+            field_0x164 -= field_0x160->getFrameMax();
+        }
     }
     field_0x150->setFrame(field_0x154);
-
-    field_0x15c += 2;
-    if (field_0x15c >= field_0x158->getFrameMax()) {
-        field_0x15c -= field_0x158->getFrameMax();
-    }
     field_0x158->setFrame(field_0x15c);
-
-    field_0x164 += 2;
-    if (field_0x164 >= field_0x160->getFrameMax()) {
-        field_0x164 -= field_0x160->getFrameMax();
-    }
     field_0x160->setFrame(field_0x164);
 }
 
@@ -2812,6 +2825,9 @@ void dMenu_save_c::menuSaveWide() {
 
 void dMenu_save_c::_draw2() {
     if (field_0x21a1 == 0) {
+#if TARGET_PC
+        saveSelAnm();
+#endif
         if (mpScrnExplain != NULL) {
             dComIfGd_set2DOpa(&mMenuSaveExplain);
         }


### PR DESCRIPTION
d_menu_save - Fix the slow menu anims by moving `saveSelAnm()` from `_move()` to `_draw2()` and wrapping frame counters with `get_ui_tick_pending()`

d_menu_fmap2D - Wrap pulse timers for selected region with `get_ui_tick_pending()`