### PR TITLE
Thinner map lines at higher resolution

### DIFF
--- a/src/d/d_map_path.cpp
+++ b/src/d/d_map_path.cpp
@@ -237,6 +237,13 @@ void dDrawPath_c::rendering(dDrawPath_c::line_class const* p_line) {
     if (isDrawType(p_line->field_0x0)) {
         int width = getLineWidth(p_line->field_0x1);
 
+        #if TARGET_PC
+        f32 height = JUTVideo::getManager()->getRenderHeight() / 448.0f;
+        if (height > 1.0f) {
+            width /= 2;
+        }
+        #endif
+
         if (width > 0 && p_line->mDataNum >= 2) {
             GXSetLineWidth(width, GX_TO_ZERO);
             GXSetTevColor(GX_TEVREG0, *getLineColor(p_line->field_0x0 & 0x3F, p_line->field_0x1));


### PR DESCRIPTION
Affects both the Map Menu and the Mini-Map, but only if the IR is superior to 1x.

Before:
<img width="723" height="459" alt="image" src="https://github.com/user-attachments/assets/2a3ed3cb-ff27-462b-bf80-36ddf6798892" />

After:
<img width="761" height="495" alt="image" src="https://github.com/user-attachments/assets/db5e4e9a-371b-4c9a-ae0c-4067029dfd67" />
