### PR TITLE
Fix d_meter_button flashing

### DIFF
--- a/include/d/d_meter_button.h
+++ b/include/d/d_meter_button.h
@@ -343,6 +343,11 @@ public:
     /* 0x624 */ f32 mMidonaPosX;
     /* 0x628 */ f32 mMidonaPosY;
     /* 0x62C */ f32 mMidonaScale;
+
+#ifdef TARGET_PC
+    bool mWasListen[2];
+    bool mWasRepeat[2];
+#endif
 };
 
 #endif /* D_METER_D_METER_BUTTON_H */

--- a/src/d/d_meter_button.cpp
+++ b/src/d/d_meter_button.cpp
@@ -368,8 +368,22 @@ void dMeterButton_c::draw() {
             }
 
             if (var_r3) {
+#ifdef TARGET_PC
+                if (dusk::frame_interp::get_ui_tick_pending()) {
+                    mWasListen[i] = var_r22;
+                    mWasRepeat[i] = var_r23;
+                } else {
+                    var_r22 = mWasListen[i];
+                    var_r23 = mWasRepeat[i];
+                }
+#endif
                 if (var_r22) {
-                    if (field_0x2e8[i] == 18.0f) {
+#ifdef TARGET_PC
+                    if (field_0x2e8[i] == 18.0f && dusk::frame_interp::get_ui_tick_pending())
+#else
+                    if (field_0x2e8[i] == 18.0f)
+#endif
+                    {
                         mDoAud_seStart(Z2SE_SY_HINT_BUTTON_BLINK, NULL, 0, 0);
                     }
 


### PR DESCRIPTION
Caching var_r22/var_r23 across frames prevents resetBlinkButton() from hiding the pikari effect on interp frames which was causing excessive flashing on the A button prompt

Closes #531 