### PR TITLE
cLib_offsetPos param aliasing fix

### DIFF
--- a/src/SSystem/SComponent/c_lib.cpp
+++ b/src/SSystem/SComponent/c_lib.cpp
@@ -468,9 +468,20 @@ s16 cLib_targetAngleX(cXyz const* lhs, cXyz const* rhs) {
 void cLib_offsetPos(cXyz* pdest, cXyz const* psrc, s16 angle, cXyz const* vec) {
     f32 cos = cM_scos(angle);
     f32 sin = cM_ssin(angle);
+    // MWCC loads vec members into registers before writing to pdest; other compilers may not,
+    // which corrupts results when pdest and vec alias the same memory.
+#if !__MWERKS__
+    f32 vx = vec->x;
+    f32 vy = vec->y;
+    f32 vz = vec->z;
+    pdest->x = psrc->x + (vx * cos + vz * sin);
+    pdest->y = psrc->y + vy;
+    pdest->z = psrc->z + (vz * cos - vx * sin);
+#else
     pdest->x = psrc->x + (vec->x * cos + vec->z * sin);
     pdest->y = psrc->y + vec->y;
     pdest->z = psrc->z + (vec->z * cos - vec->x * sin);
+#endif
 }
 
 /**


### PR DESCRIPTION
MWCC schedules vec members into registers before any stores to pdest. On PC pdest gets written to first which is an issue when pdest and vec are the same pointer (only happens in a few places). Storing them in temp variables first fixes this

Closes #537 

Also fixes an issue in the Argorok cutscene where the camera was in the wrong place when focusing on the jewel (happens at the start of phase 2)