### PR TITLE
Fix draw crash with Super Clawshot enabled

### DIFF
--- a/src/d/actor/d_a_alink_hook.inc
+++ b/src/d/actor/d_a_alink_hook.inc
@@ -18,6 +18,10 @@ enum {
 };
 
 void daAlink_c::hsChainShape_c::draw() {
+    if (dusk::getSettings().game.superClawshot) {
+        return;
+    }
+
     static const int dummy = 0;
 
     daAlink_c* alink = (daAlink_c*)getUserArea();


### PR DESCRIPTION
Simply by removing the draw of the chain if Super Clawshot is enabled.