### PR TITLE
Fix instant text clearing some shop dialogue too quickly

### DIFF
--- a/include/d/d_msg_object.h
+++ b/include/d/d_msg_object.h
@@ -67,6 +67,9 @@ public:
     bool isStaffMessage();
     bool isSaveMessage();
     bool isTalkMessage();
+#if TARGET_PC
+    bool isShopItemMessage();
+#endif
     const char* getSmellName();
     const char* getPortalName();
     const char* getBombName();

--- a/src/d/d_msg_class.cpp
+++ b/src/d/d_msg_class.cpp
@@ -1987,13 +1987,6 @@ bool jmessage_tSequenceProcessor::do_isReady() {
     }
     #endif
 
-#if TARGET_PC
-    if (dusk::getSettings().game.instantText && mDoCPd_c::getHoldB(0)) {
-        field_0xb2 = 1;
-        pReference->setSendTimer(0);
-    }
-#endif
-
     if (dComIfGp_checkMesgBgm()) {
         bool isItemMusicPlaying = true;
         if (mDoAud_checkPlayingSubBgmFlag() != Z2BGM_ITEM_GET &&
@@ -2066,7 +2059,7 @@ bool jmessage_tSequenceProcessor::do_isReady() {
             case 0:
             case 5:
             case 6:
-                if (mDoCPd_c::getTrigA(PAD_1) || field_0xb2 != 0) {
+                if (mDoCPd_c::getTrigA(PAD_1) || field_0xb2 != 0 IF_DUSK(|| (dusk::getSettings().game.instantText && mDoCPd_c::getHoldB(0)))) {
                     field_0xa4 = 0;
                     pReference->onBatchFlag();
                     pReference->setCharCnt(D_MSG_CLASS_CHAR_CNT_MAX);

--- a/src/d/d_msg_object.cpp
+++ b/src/d/d_msg_object.cpp
@@ -34,6 +34,7 @@
 #include "dusk/settings.h"
 #include <vector>
 #include <array>
+#include <algorithm>
 #endif
 
 static void dMsgObject_addFundRaising(s16 param_0);

--- a/src/d/d_msg_object.cpp
+++ b/src/d/d_msg_object.cpp
@@ -32,6 +32,8 @@
 
 #if TARGET_PC
 #include "dusk/settings.h"
+#include <vector>
+#include <array>
 #endif
 
 static void dMsgObject_addFundRaising(s16 param_0);
@@ -1594,7 +1596,7 @@ u8 dMsgObject_c::isSend() {
                 return 2;
             }
         } else {
-            if (IF_DUSK((dusk::getSettings().game.instantText && mDoCPd_c::getHoldB(0)) ||)
+            if (IF_DUSK((dusk::getSettings().game.instantText && mDoCPd_c::getHoldB(0) && !isShopItemMessage()) ||)
                 mDoCPd_c::getTrigA(0) != 0 || mDoCPd_c::getTrigB(0) != 0) {
                 return 2;
             }
@@ -1865,6 +1867,40 @@ bool dMsgObject_c::isTalkMessage() {
     }
     return true;
 }
+
+#if TARGET_PC
+bool dMsgObject_c::isShopItemMessage() {
+
+    // Probably a better way to do this than just listing every message id, but this works for now
+    // Note: Keep contents sorted so we can use binary search
+    const auto shopMsgIds = std::to_array<std::vector<s16>>({
+        {},
+        // zel_01.bmg - Seras Shop
+        {7001, 7003, 7004, 7005, 7006, 7007, 7008, 7009, 7010, 7013, 7014, 7022, 7023, 7028, 7029,
+            7044, 7045, 7053},
+        // zel_02.bmg - Kakariko Shops
+        {5251, 5253, 5254, 5256, 5258, 5259, 5653, 5654, 5656, 5660, 5661, 5664, 5665, 5697, 5698,
+            5699, 5803, 5804, 5806, 5810, 5811, 5812, 5814, 5821, 5823, 5824, 5987, 5988, 5989, 5990,
+            5991, 5992, 5993, 5994, 5995, 5996, 5997, 5998, 5999},
+        // zel_03.bmg - Death Mountain Shop
+        {5303, 5304, 5306, 5310, 5311, 5314, 5315, 5322, 5323, 5324, 5496, 5497, 5498, 5499},
+        // zel_04.bmg - Castle Town Shops
+        {5407, 5408, 5409, 5410, 5411, 5412, 5413, 5414, 5415, 5416, 5417, 5418, 5419, 5420, 5431,
+            5432, 5433, 5434, 5435, 5436, 5437, 5438, 5439, 5440, 5441, 5444, 5449, 5450, 5451, 5452,
+            5462},
+        // zel_05.bmg - Oocca Shop
+        {9428, 9429, 9430, 9431, 9432, 9437, 9443, 9448, 9449, 9451, 9459}
+    });
+
+    u16 id = mMessageID;
+    s16 group = dMsgObject_getGroupID();
+    if (group < shopMsgIds.size()) {
+        return std::ranges::binary_search(shopMsgIds[group], id);
+    }
+    return false;
+
+}
+#endif
 
 const char* dMsgObject_c::getSmellName() {
     JMSMesgInfo_c* info_header_p = (JMSMesgInfo_c*)((char*)mpMsgRes + 0x20);


### PR DESCRIPTION
Instant text would clear shop item descriptions too quickly. These specific textboxes now require pressing A or B to clear them instead of just holding B.