### PR TITLE
Correct JPADrawInfo proj matrix on widescreen

### DIFF
--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -2146,6 +2146,7 @@ int mDoGph_Painter() {
             // FRAME INTERP NOTE: Call setViewMtx earlier so that it's interpolated in time for draw_info to use it
             j3dSys.setViewMtx(camera_p->view.viewMtx);
             JPADrawInfo draw_info(j3dSys.getViewMtx(), camera_p->view.fovy, camera_p->view.aspect);
+            mDoGph_gInf_c::setWideZoomLightProjection(draw_info.mPrjMtx);
 #else
             JPADrawInfo draw_info(camera_p->view.viewMtx, camera_p->view.fovy, camera_p->view.aspect);
 #endif


### PR DESCRIPTION
Fixes #337.

<img width="1787" height="653" alt="image" src="https://github.com/user-attachments/assets/5489b828-833d-4c3c-96ea-a7f490058c39" />
