### PR TITLE
Remove post-trim scissor

### DIFF
--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1237,8 +1237,10 @@ static void trimming(view_class* param_0, view_port_class* param_1) {
 
         GXEnd();
     }
+#ifndef TARGET_PC
     GXSetScissor(param_1->scissor.x_orig, param_1->scissor.y_orig, param_1->scissor.width,
                  param_1->scissor.height);
+#endif
 }
 
 #if !PLATFORM_WII && !TARGET_PC

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1238,6 +1238,8 @@ static void trimming(view_class* param_0, view_port_class* param_1) {
         GXEnd();
     }
 #ifndef TARGET_PC
+    // due to rounding, the scaled scissor region doesn't align with the untrimmed area
+    // this creates a gap when drawing the flipped image for mirror mode
     GXSetScissor(param_1->scissor.x_orig, param_1->scissor.y_orig, param_1->scissor.width,
                  param_1->scissor.height);
 #endif


### PR DESCRIPTION
Fixes #679.

There doesn't seem to be anything drawn after the trim that relies on the scissor it sets, except for `calcFade` (which ends up overriding scissor on `TARGET_PC` anyway?).