### PR TITLE
Advanced Settings

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -169,6 +169,7 @@ struct UserSettings {
         ConfigVar<bool> wasPresetChosen;
         ConfigVar<bool> enableCrashReporting;
         ConfigVar<int> cardFileType;
+        ConfigVar<bool> enableAdvancedSettings;
     } backend;
 };
 

--- a/src/dusk/imgui/ImGuiAudio.cpp
+++ b/src/dusk/imgui/ImGuiAudio.cpp
@@ -282,7 +282,9 @@ static void ShowAllJAISeqs() {
 }
 
 void dusk::ImGuiMenuTools::ShowAudioDebug() {
-    if (!ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F10, m_showAudioDebug)) {
+    if (!getSettings().backend.enableAdvancedSettings ||
+        !ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F10, m_showAudioDebug))
+    {
         return;
     }
 
@@ -328,7 +330,9 @@ void dusk::ImGuiMenuTools::ShowAudioDebug() {
 }
 
 void dusk::ImGuiMenuTools::ShowSaveEditor() {
-    if (!ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F6, m_showSaveEditor)) {
+    if (!getSettings().backend.enableAdvancedSettings ||
+        !ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F6, m_showSaveEditor))
+    {
         return;
     }
     m_saveEditor.draw(m_showSaveEditor);

--- a/src/dusk/imgui/ImGuiCameraOverlay.cpp
+++ b/src/dusk/imgui/ImGuiCameraOverlay.cpp
@@ -10,7 +10,9 @@
 
 namespace dusk {
     void ImGuiMenuTools::ShowCameraOverlay() {
-        if (!ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F9, m_showCameraOverlay)) {
+        if (!getSettings().backend.enableAdvancedSettings ||
+            !ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F9, m_showCameraOverlay))
+        {
             return;
         }
 

--- a/src/dusk/imgui/ImGuiConsole.cpp
+++ b/src/dusk/imgui/ImGuiConsole.cpp
@@ -265,7 +265,11 @@ namespace dusk {
         }
 
         if (ImGui::GetIO().KeyShift && ImGui::IsKeyPressed(ImGuiKey_F1)) {
-            m_isHidden = !m_isHidden;
+            if (getSettings().backend.enableAdvancedSettings) {
+                m_isHidden = !m_isHidden;
+            } else {
+                m_isHidden = true;
+            }
         }
         bool showMenu = !m_isHidden;
 

--- a/src/dusk/imgui/ImGuiHeapOverlay.cpp
+++ b/src/dusk/imgui/ImGuiHeapOverlay.cpp
@@ -22,7 +22,9 @@ namespace dusk {
     void ShowHeapDetailed(JKRHeap* heap, OpenHeapData& data, bool& open);
 
     void ImGuiMenuTools::ShowHeapOverlay() {
-        if (!ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F4, m_showHeapOverlay)) {
+        if (!getSettings().backend.enableAdvancedSettings ||
+            !ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F4, m_showHeapOverlay))
+        {
             return;
         }
 

--- a/src/dusk/imgui/ImGuiMapLoader.cpp
+++ b/src/dusk/imgui/ImGuiMapLoader.cpp
@@ -9,7 +9,9 @@
 
 namespace dusk {
     void ImGuiMenuTools::ShowMapLoader() {
-        if (!ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F7, m_showMapLoader)) {
+    if (!getSettings().backend.enableAdvancedSettings ||
+        !ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F7, m_showMapLoader))
+    {
             return;
         }
 

--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -119,7 +119,9 @@ namespace dusk {
     }
 
     void ImGuiMenuTools::ShowDebugOverlay() {
-        if (!ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F3, m_showDebugOverlay)) {
+        if (!getSettings().backend.enableAdvancedSettings ||
+            !ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F3, m_showDebugOverlay))
+        {
             return;
         }
 
@@ -183,7 +185,9 @@ namespace dusk {
     }
 
     void ImGuiMenuTools::ShowPlayerInfo() {
-        if (!ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F5, m_showPlayerInfo)) {
+        if (!getSettings().backend.enableAdvancedSettings ||
+            !ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F5, m_showPlayerInfo))
+        {
             return;
         }
 

--- a/src/dusk/imgui/ImGuiProcessOverlay.cpp
+++ b/src/dusk/imgui/ImGuiProcessOverlay.cpp
@@ -126,7 +126,9 @@ namespace dusk {
     }
 
     void ImGuiMenuTools::ShowProcessManager() {
-        if (!ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F2, m_showProcessManagement)) {
+        if (!getSettings().backend.enableAdvancedSettings ||
+            !ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F2, m_showProcessManagement))
+        {
             return;
         }
 

--- a/src/dusk/imgui/ImGuiStateShare.cpp
+++ b/src/dusk/imgui/ImGuiStateShare.cpp
@@ -417,7 +417,9 @@ void ImGuiStateShare::draw(bool& open) {
 }
 
 void ImGuiMenuTools::ShowStateShare() {
-    if (!ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F8, m_showStateShare)) {
+    if (!getSettings().backend.enableAdvancedSettings ||
+        !ImGuiConsole::CheckMenuViewToggle(ImGuiKey_F8, m_showStateShare))
+    {
         return;
     }
     m_stateShare.draw(m_showStateShare);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -115,7 +115,8 @@ UserSettings g_userSettings = {
         .showPipelineCompilation {"backend.showPipelineCompilation", false},
         .wasPresetChosen {"backend.wasPresetChosen", false},
         .enableCrashReporting {"backend.enableCrashReporting", true},
-        .cardFileType {"backend.cardFileType", static_cast<int>(CARD_GCIFOLDER)}
+        .cardFileType {"backend.cardFileType", static_cast<int>(CARD_GCIFOLDER)},
+        .enableAdvancedSettings {"backend.enableAdvancedSettings", false},
     }
 };
 
@@ -214,6 +215,7 @@ void registerSettings() {
     Register(g_userSettings.backend.wasPresetChosen);
     Register(g_userSettings.backend.enableCrashReporting);
     Register(g_userSettings.backend.cardFileType);
+    Register(g_userSettings.backend.enableAdvancedSettings);
 }
 
 // Transient settings

--- a/src/dusk/ui/menu_bar.cpp
+++ b/src/dusk/ui/menu_bar.cpp
@@ -50,7 +50,11 @@ MenuBar::MenuBar() : Document(kDocumentSource), mRoot(mDocument->GetElementById(
     // mTabBar->add_tab("Warp", [] {
     //     // TODO
     // });
-    mTabBar->add_tab("Editor", [this] { push(std::make_unique<EditorWindow>()); });
+
+    if (getSettings().backend.enableAdvancedSettings) {
+        mTabBar->add_tab("Editor", [this] { push(std::make_unique<EditorWindow>()); });
+    }
+
     mTabBar->add_tab("Achievements", [this] { push(std::make_unique<AchievementsWindow>()); });
     mTabBar->add_tab("Reset", [this] {
         mTabBar->set_active_tab(-1);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -866,6 +866,12 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .key = "Show Pipeline Compilation",
                 .helpText = "Show an overlay when shaders are being compiled for your hardware.",
             });
+
+        config_bool_select(leftPane, rightPane, getSettings().backend.enableAdvancedSettings,
+            {
+                .key = "Enable Advanced Settings",
+                .helpText = "Show the advanced settings on the menu bar.<br/>Most users should have this disabled.",
+            });
     });
 }
 

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -14,6 +14,7 @@
 #include "pane.hpp"
 #include "prelaunch.hpp"
 #include "ui.hpp"
+#include "menu_bar.hpp"
 
 #include <algorithm>
 
@@ -871,6 +872,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             {
                 .key = "Enable Advanced Settings",
                 .helpText = "Show the advanced settings on the menu bar.<br/>Most users should have this disabled.",
+                .onChange = [](bool value) { get_document_stack()[0] = std::make_unique<MenuBar>(); },
             });
     });
 }

--- a/src/dusk/ui/ui.cpp
+++ b/src/dusk/ui/ui.cpp
@@ -363,6 +363,10 @@ void push_toast(Toast toast) noexcept {
     sToasts.push_back(std::move(toast));
 }
 
+std::vector<std::unique_ptr<Document> >& get_document_stack() noexcept {
+    return sDocumentStack;
+}
+
 std::deque<Toast>& get_toasts() noexcept {
     return sToasts;
 }

--- a/src/dusk/ui/ui.hpp
+++ b/src/dusk/ui/ui.hpp
@@ -82,6 +82,8 @@ Rml::Element* append(Rml::Element* parent, const Rml::String& tag) noexcept;
 NavCommand map_nav_event(const Rml::Event& event) noexcept;
 Insets safe_area_insets(Rml::Context* context) noexcept;
 
+std::vector<std::unique_ptr<Document> >& get_document_stack() noexcept;
+
 void push_toast(Toast toast) noexcept;
 std::deque<Toast>& get_toasts() noexcept;
 void show_menu_notification() noexcept;


### PR DESCRIPTION
Disabled by default. Closes #665

Disable Hotkeys (except for Ctrl+R, F11 and F1) and the "Editor" tab in the main bar if Advanced Settings is disabled.