### PR TITLE
Fix OSReport strings corruption with non-trivial format

### DIFF
--- a/src/dusk/OSReport.cpp
+++ b/src/dusk/OSReport.cpp
@@ -25,10 +25,11 @@ static bool checkEnabled() {
 #define va_copy(d, s) ((d) = (s))
 #endif
 
-static std::string FormatToString(const char* msg, va_list list) {    
+static std::string FormatToString(const char* msg, va_list list) {
     size_t size = (strlen(msg) * 2) + 50;
     std::string str;
     va_list ap;
+    int attempts = 0;
     while (true) {
         str.resize(size);
         va_copy(ap, list);
@@ -36,7 +37,15 @@ static std::string FormatToString(const char* msg, va_list list) {
         va_end(ap);
         if (n > -1 && n < size) { 
             str.resize(n);
-            return str;
+            break;
+        }
+        
+        ++attempts;
+        if (attempts >= 3) {
+            if (n == -1) {
+                str.clear();
+            }
+            break;
         }
         if (n > -1) {
             size = n + 1;

--- a/src/dusk/OSReport.cpp
+++ b/src/dusk/OSReport.cpp
@@ -21,16 +21,30 @@ static bool checkEnabled() {
     return !__OSReport_disable || dusk::OSReportReallyForceEnable;
 }
 
-static std::string FormatToString(const char* msg, va_list list) {
-    int ret = vsnprintf(nullptr, 0, msg, list);
-    if (ret <= 0) {
-        return {};
+#ifndef va_copy
+#define va_copy(d, s) ((d) = (s))
+#endif
+
+static std::string FormatToString(const char* msg, va_list list) {    
+    size_t size = (strlen(msg) * 2) + 50;
+    std::string str;
+    va_list ap;
+    while (true) {
+        str.resize(size);
+        va_copy(ap, list);
+        int n = vsnprintf(str.data(), size, msg, ap);
+        va_end(ap);
+        if (n > -1 && n < size) { 
+            str.resize(n);
+            return str;
+        }
+        if (n > -1) {
+            size = n + 1;
+        } else {
+            size *= 2;
+        }
     }
-    ++ret;
-    std::unique_ptr<char[]> buf(new char[ret]);
-    vsnprintf(buf.get(), ret, msg, list);
-    buf[ret - 1] = '\0';
-    return {buf.get()};
+    return str;
 }
 
 void OSReport(const char* fmt, ...) {


### PR DESCRIPTION
Use a different method to format the string, this works more reliably and allows OSReport calls to be forwarded to the log.