### PR TITLE
Deselect Sub-Menu On Focus Change

### DIFF
--- a/src/dusk/ui/pane.cpp
+++ b/src/dusk/ui/pane.cpp
@@ -136,6 +136,7 @@ Component& Pane::register_control(
             for (const auto& child : mChildren) {
                 if (child->selected()) {
                     set_selected_item(-1);
+                    break;
                 }
             }
 

--- a/src/dusk/ui/pane.cpp
+++ b/src/dusk/ui/pane.cpp
@@ -126,11 +126,19 @@ Component& Pane::register_control(
             }
         });
     component.listen(component.root(), Rml::EventId::Focus,
-        [&component, &nextPane, callback = std::move(callback)](Rml::Event&) {
+        [this, &component, &nextPane, callback = std::move(callback)](Rml::Event&) {
             if (component.disabled()) {
                 return;
             }
             nextPane.clear();
+
+            // If an item is already selected, deselect
+            for (const auto& child : mChildren) {
+                if (child->selected()) {
+                    set_selected_item(-1);
+                }
+            }
+
             if (callback) {
                 callback(nextPane);
             }


### PR DESCRIPTION
- Unselect any previous items when focusing a new one

Wasn't sure where the best spot was to put this, was the first place I found that could reliably fix the issue. Might be over-inclusive/have the potential for unintended side effects so it deserves extra skepticism.