### PR TITLE
Refactor notification settings, allow disabling controller toasts

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -102,8 +102,8 @@ struct UserSettings {
         ConfigVar<bool> minimalHUD;
         ConfigVar<bool> pauseOnFocusLost;
         ConfigVar<bool> enableLinkDollRotation;
-        ConfigVar<bool> enableAchievementNotifications;
-
+        ConfigVar<bool> enableAchievementToasts;
+        ConfigVar<bool> enableControllerToasts;
 
         // Graphics
         ConfigVar<BloomMode> bloomMode;

--- a/src/dusk/achievements.cpp
+++ b/src/dusk/achievements.cpp
@@ -1113,7 +1113,7 @@ void AchievementSystem::processEntry(Entry& e) {
     if (nowUnlocked) {
         e.achievement.progress = e.achievement.isCounter ? e.achievement.goal : 1;
         e.achievement.unlocked = true;
-        if (getSettings().game.enableAchievementNotifications) {
+        if (getSettings().game.enableAchievementToasts) {
             ui::push_toast({
                 .type = "achievement",
                 .title = "Achievement Unlocked!",

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -50,7 +50,8 @@ UserSettings g_userSettings = {
         .minimalHUD {"game.minimalHUD", false},
         .pauseOnFocusLost {"game.pauseOnFocusLost", false},
         .enableLinkDollRotation {"game.enableLinkDollRotation", false},
-        .enableAchievementNotifications {"game.enableAchievementNotifications", true},
+        .enableAchievementToasts {"game.enableAchievementToasts", true},
+        .enableControllerToasts {"game.enableControllerToasts", true},
 
         // Graphics
         .bloomMode {"game.bloomMode", BloomMode::Dusk},
@@ -183,7 +184,8 @@ void registerSettings() {
     Register(g_userSettings.game.freeMagicArmor);
     Register(g_userSettings.game.restoreWiiGlitches);
     Register(g_userSettings.game.enableLinkDollRotation);
-    Register(g_userSettings.game.enableAchievementNotifications);
+    Register(g_userSettings.game.enableAchievementToasts);
+    Register(g_userSettings.game.enableControllerToasts);
     Register(g_userSettings.game.noMissClimbing);
     Register(g_userSettings.game.noLowHpSound);
     Register(g_userSettings.game.midnasLamentNonStop);

--- a/src/dusk/ui/preset.cpp
+++ b/src/dusk/ui/preset.cpp
@@ -14,7 +14,8 @@ void applyPresetClassic() {
     auto& s = getSettings();
     s.video.lockAspectRatio.setValue(true);
     s.game.bloomMode.setValue(BloomMode::Classic);
-    s.game.enableAchievementNotifications.setValue(false);
+    s.game.enableAchievementToasts.setValue(false);
+    s.game.enableControllerToasts.setValue(false);
     s.game.internalResolutionScale.setValue(1);
     s.game.shadowResolutionMultiplier.setValue(1);
     s.game.hideTvSettingsScreen.setValue(false);
@@ -33,7 +34,8 @@ void applyPresetDusk() {
     s.game.biggerWallets.setValue(true);
     s.game.invertCameraXAxis.setValue(true);
     s.game.no2ndFishForCat.setValue(true);
-    s.game.enableAchievementNotifications.setValue(true);
+    s.game.enableAchievementToasts.setValue(true);
+    s.game.enableControllerToasts.setValue(true);
     s.game.enableQuickTransform.setValue(true);
     s.game.instantSaves.setValue(true);
     s.game.midnasLamentNonStop.setValue(true);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -889,10 +889,69 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
         auto& rightPane = add_child<Pane>(content, Pane::Type::Uncontrolled);
 
         leftPane.add_section("Dusk");
-        config_bool_select(leftPane, rightPane, getSettings().game.enableAchievementNotifications,
-            {
-                .key = "Achievement Notifications",
-                .helpText = "Display a toast when an achievement is unlocked.",
+        leftPane.register_control(
+            leftPane.add_select_button({
+                .key = "Toasts",
+                .getValue = [] {
+                    const bool ach = getSettings().game.enableAchievementToasts.getValue();
+                    const bool ctl = getSettings().game.enableControllerToasts.getValue();
+                    if (!ach && !ctl) {
+                        return Rml::String{"Off"};
+                    }
+                    if (ach && ctl) {
+                        return Rml::String{"All"};
+                    }
+                    return Rml::String{"Some"};
+                },
+                .isModified = [] {
+                    const auto& ach = getSettings().game.enableAchievementToasts;
+                    const auto& ctl = getSettings().game.enableControllerToasts;
+                    return ach.getValue() != ach.getDefaultValue() || ctl.getValue() != ctl.getDefaultValue();
+                },
+            }),
+            rightPane, [](Pane& pane) {
+                pane.clear();
+                pane.add_button("Select All").on_pressed([] {
+                    mDoAud_seStartMenu(kSoundItemChange);
+                    getSettings().game.enableAchievementToasts.setValue(true);
+                    getSettings().game.enableControllerToasts.setValue(true);
+                    config::Save();
+                });
+                pane.add_button("Select None").on_pressed([] {
+                    mDoAud_seStartMenu(kSoundItemChange);
+                    getSettings().game.enableAchievementToasts.setValue(false);
+                    getSettings().game.enableControllerToasts.setValue(false);
+                    config::Save();
+                });
+
+                pane.add_section("Types");
+                pane.add_button(
+                    {
+                        .text = "Achievements",
+                        .isSelected =
+                        [] {
+                            return getSettings().game.enableAchievementToasts.getValue();
+                        },
+                    })
+                    .on_pressed([] {
+                        mDoAud_seStartMenu(kSoundItemChange);
+                        auto& v = getSettings().game.enableAchievementToasts;
+                        v.setValue(!v.getValue());
+                        config::Save();
+                    });
+                pane.add_button(
+                    {
+                        .text = "Controller",
+                        .isSelected =
+                            [] { return getSettings().game.enableControllerToasts.getValue(); },
+                    })
+                    .on_pressed([] {
+                        mDoAud_seStartMenu(kSoundItemChange);
+                        auto& v = getSettings().game.enableControllerToasts;
+                        v.setValue(!v.getValue());
+                        config::Save();
+                    });
+                pane.add_rml("<br/>Choose which in-game toasts can be displayed.");
             });
 #if DUSK_ENABLE_SENTRY_NATIVE
         config_bool_select(leftPane, rightPane, getSettings().backend.enableCrashReporting,

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -891,7 +891,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
         leftPane.add_section("Dusk");
         leftPane.register_control(
             leftPane.add_select_button({
-                .key = "Toasts",
+                .key = "Notifications",
                 .getValue = [] {
                     const bool ach = getSettings().game.enableAchievementToasts.getValue();
                     const bool ctl = getSettings().game.enableControllerToasts.getValue();
@@ -951,7 +951,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                         v.setValue(!v.getValue());
                         config::Save();
                     });
-                pane.add_rml("<br/>Choose which in-game toasts can be displayed.");
+                pane.add_rml("<br/>Choose which notifications can be displayed.");
             });
 #if DUSK_ENABLE_SENTRY_NATIVE
         config_bool_select(leftPane, rightPane, getSettings().backend.enableCrashReporting,

--- a/src/dusk/ui/ui.cpp
+++ b/src/dusk/ui/ui.cpp
@@ -125,43 +125,47 @@ void handle_event(const SDL_Event& event) noexcept {
     if (event.type == SDL_EVENT_GAMEPAD_ADDED) {
         auto* gamepad = SDL_GetGamepadFromID(event.gdevice.which);
         if (SDL_GamepadConnected(gamepad)) {
-            const char* name = SDL_GetGamepadName(gamepad);
-            Rml::String content = fmt::format("<span>{}</span>", name ? name : "[Unknown]");
-            Rml::String title = "Controller connected";
-            if (const char* icon = connection_state_icon(SDL_GetGamepadConnectionState(gamepad))) {
-                title = fmt::format(
-                    "<row><span>{}</span> <icon class=\"connection\">&#x{};</icon></row>", title,
-                    icon);
-            }
-            int batteryLevel = -1;
-            const auto powerState = SDL_GetGamepadPowerInfo(gamepad, &batteryLevel);
-            if (powerState != SDL_POWERSTATE_UNKNOWN) {
-                content = fmt::format(
-                    "<row>{}</row><row class=\"muted\"><icon class=\"battery\">&#x{};</icon>",
-                    content, battery_icon(powerState, batteryLevel));
-                if (batteryLevel > -1) {
-                    content = fmt::format("{}&nbsp;<span>{}%</span>", content, batteryLevel);
+            if (getSettings().game.enableControllerToasts) {
+                const char* name = SDL_GetGamepadName(gamepad);
+                Rml::String content = fmt::format("<span>{}</span>", name ? name : "[Unknown]");
+                Rml::String title = "Controller connected";
+                if (const char* icon = connection_state_icon(SDL_GetGamepadConnectionState(gamepad))) {
+                    title = fmt::format(
+                        "<row><span>{}</span> <icon class=\"connection\">&#x{};</icon></row>", title,
+                        icon);
                 }
-                content += "</row>";
+                int batteryLevel = -1;
+                const auto powerState = SDL_GetGamepadPowerInfo(gamepad, &batteryLevel);
+                if (powerState != SDL_POWERSTATE_UNKNOWN) {
+                    content = fmt::format(
+                        "<row>{}</row><row class=\"muted\"><icon class=\"battery\">&#x{};</icon>",
+                        content, battery_icon(powerState, batteryLevel));
+                    if (batteryLevel > -1) {
+                        content = fmt::format("{}&nbsp;<span>{}%</span>", content, batteryLevel);
+                    }
+                    content += "</row>";
+                }
+                push_toast({
+                    .type = "controller",
+                    .title = title,
+                    .content = content,
+                    .duration = std::chrono::seconds(4),
+                });
             }
-            push_toast({
-                .type = "controller",
-                .title = title,
-                .content = content,
-                .duration = std::chrono::seconds(4),
-            });
             sConnectedGamepads.insert(event.gdevice.which);
         }
     } else if (event.type == SDL_EVENT_GAMEPAD_REMOVED &&
                sConnectedGamepads.contains(event.gdevice.which))
     {
-        const char* name = SDL_GetGamepadNameForID(event.gdevice.which);
-        push_toast({
-            .type = "controller",
-            .title = "Controller disconnected",
-            .content = name ? name : "[Unknown]",
-            .duration = std::chrono::seconds(4),
-        });
+        if (getSettings().game.enableControllerToasts) {
+            const char* name = SDL_GetGamepadNameForID(event.gdevice.which);
+            push_toast({
+                .type = "controller",
+                .title = "Controller disconnected",
+                .content = name ? name : "[Unknown]",
+                .duration = std::chrono::seconds(4),
+            });
+        }
         sConnectedGamepads.erase(event.gdevice.which);
     }
     input::handle_event(event);


### PR DESCRIPTION
Replaces "Achievement Notifications" in the Interface tab with a multi-select "Toasts" option, allowing users to disable their choice of toast types.

<img width="1218" height="928" alt="image" src="https://github.com/user-attachments/assets/8dc3d6ff-3628-4da9-8650-62babc2afed6" />
