### PR TITLE
Fix Letter Menu Page Numbers

### DIFF
--- a/src/d/d_menu_letter.cpp
+++ b/src/d/d_menu_letter.cpp
@@ -965,7 +965,8 @@ void dMenu_Letter_c::screenSetBase() {
     }
     if (field_0x374 > 1) {
         J2DPane* pJVar6 = mpBaseScreen->search('pi_n');
-        f32 dVar18 = field_0x1f0[1]->getBounds().i.x - field_0x1f0[0]->getBounds().i.x;
+        f32 x1 = field_0x1f0[1]->getBounds().i.x;
+        f32 dVar18 = x1 - field_0x1f0[0]->getBounds().i.x;
         f32 dVar17 = dVar18 * (field_0x374 - 1);
         f32 dVar16 = (pJVar6->getWidth() / 2) - (dVar17 / 2);
         for (int i = 0; i < 9; i++) {


### PR DESCRIPTION
See commit message for explanation of the bug. It fixes the issue on my machine, though I'm not sure if this technically forces things to the right order per the standard? Or if a sufficiently aggressive attempt to optimize things might still make it break

This does not appear to affect any other uses of `getBounds`. If possible it would be good to upstream the change to decomp, but I don't have it set up so I can't check if this still matches.