### PR TITLE
Clamp Eye LOD For Cutscene Midna

### DIFF
--- a/src/d/actor/d_a_midna.cpp
+++ b/src/d/actor/d_a_midna.cpp
@@ -419,9 +419,30 @@ int daMidna_c::createHeap() {
             return 0;
         }
 
+#if TARGET_PC
+        if (mpDemoFCTongueBmd != NULL) {
+            if(!daAlink_c::initDemoBck(&mpDemoFCTmpBck, "demo00_Midna_cut00_FC_tmp.bck")) {
+                return 0;
+            }
+
+            // Update Midna's eye maxLOD to prevent the eyes from disappearing
+            J3DTexture* tex = mpDemoFCTongueBmd->getModelData()->getTexture();
+            JUTNameTab* nametable = mpDemoFCTongueBmd->getModelData()->getTextureName();
+            if (tex != nullptr && nametable != nullptr) {
+                for (u16 i = 0; i < tex->getNum(); i++) {
+                    const char* tex_name = nametable->getName(i);
+                    if (tex_name != NULL && strcmp(tex_name, "midona_eyeball") == 0) {
+                        ResTIMG* timg = tex->getResTIMG(i);
+                        timg->maxLOD = 0;
+                    }
+                }
+            }
+        }
+#else
         if (mpDemoFCTongueBmd != NULL && !daAlink_c::initDemoBck(&mpDemoFCTmpBck, "demo00_Midna_cut00_FC_tmp.bck")) {
             return 0;
         }
+#endif
 
         modelData =
             (J3DModelData*)dComIfG_getObjectRes(dStage_roomControl_c::getDemoArcName(), "demo00_Midna_cut00_BD_tmp.bmd");
@@ -433,6 +454,21 @@ int daMidna_c::createHeap() {
 
             modelData->getMaterialNodePointer(2)->setMaterialAnm(mpEyeMatAnm[0]);
             modelData->getMaterialNodePointer(3)->setMaterialAnm(mpEyeMatAnm[1]);
+
+#if TARGET_PC
+            // Update Midna's eye maxLOD to prevent the eyes from disappearing
+            J3DTexture* tex = modelData->getTexture();
+            JUTNameTab* nametable = modelData->getTextureName();
+            if (tex != nullptr && nametable != nullptr) {
+                for (u16 i = 0; i < tex->getNum(); i++) {
+                    const char* tex_name = nametable->getName(i);
+                    if (tex_name != NULL && strcmp(tex_name, "midona_eyeball") == 0) {
+                        ResTIMG* timg = tex->getResTIMG(i);
+                        timg->maxLOD = 0;
+                    }
+                }
+            }
+#endif
         }
 
         if (!initDemoModel(&mpDemoBDMaskBmd, "demo00_Midna_cut00_BD_mask.bmd", 0)) {


### PR DESCRIPTION
Change for `demo00_Midna_cut00_BD_tmp` seems to be the important one for the Master Sword cutscene. I'm not sure where `demo00_Midna_cut00_FC_tongue` is visible (it didn't make a visible difference in the MS cutscene on its own), but it has the eye model/texture so I also limited that LOD to be safe.

Resolves #680 