### PR TITLE
Recording Mode - Mute streams & Fix 1 note playing

### DIFF
--- a/src/f_ap/f_ap_game.cpp
+++ b/src/f_ap/f_ap_game.cpp
@@ -745,7 +745,8 @@ static void duskExecute() {
     updateAutoSave();
 
     if (dusk::getSettings().game.recordingMode) {
-        Z2GetSeqMgr()->bgmAllMute(0, 0);
+        Z2GetSoundMgr()->getSeqMgr()->getParams()->moveVolume(0.0f, 0);
+        Z2GetSoundMgr()->getStreamMgr()->getParams()->moveVolume(0.0f, 0);
     }
 
     if (mDoCPd_c::getHoldR(PAD_1) && mDoCPd_c::getTrigX(PAD_1)) {


### PR DESCRIPTION
There was a bug before where some songs would play their first note with recording mode and then mute themselves.
This PR fixes that and also mutes streamed music.