### PR TITLE
Always disable cursor if Gyro is set to Mouse mode and the menu is not open

### DIFF
--- a/src/dusk/imgui/ImGuiConsole.cpp
+++ b/src/dusk/imgui/ImGuiConsole.cpp
@@ -376,18 +376,18 @@ namespace dusk {
         }
 
         // Hide mouse cursor if the F1 menu is not open and the cursor is idle for 3 seconds.
-        ImGuiIO& io = ImGui::GetIO();
-        if (showMenu) {
-            mouseHideTimer = 0.0f;
-            ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange; // Imgui will re-show cursor.
-        } else if (io.MouseDelta.x != 0.0f || io.MouseDelta.y != 0.0f) {
-            mouseHideTimer = 0.0f;
-            ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange; // Imgui will re-show cursor.
-        } else if (mouseHideTimer <= 3.0f) {
-            mouseHideTimer += ImGui::GetIO().DeltaTime;
-        } else {
-            ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
-            SDL_HideCursor();
+        if (dusk::getSettings().game.gyroMode.getValue() != GyroMode::Mouse)
+        {
+            ImGuiIO& io = ImGui::GetIO();
+            if (io.MouseDelta.x != 0.0f || io.MouseDelta.y != 0.0f) {
+                mouseHideTimer = 0.0f;
+                ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange;  // Imgui will re-show cursor.
+            } else if (mouseHideTimer <= 3.0f) {
+                mouseHideTimer += ImGui::GetIO().DeltaTime;
+            } else {
+                ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
+                SDL_HideCursor();
+            }
         }
 
         ShowToasts();

--- a/src/dusk/ui/document.cpp
+++ b/src/dusk/ui/document.cpp
@@ -5,6 +5,7 @@
 
 #include "Z2AudioLib/Z2SeMgr.h"
 #include "m_Do/m_Do_audio.h"
+#include <imgui.h>
 
 namespace dusk::ui {
 namespace {
@@ -106,11 +107,25 @@ bool Document::visible() const {
 
 bool Document::handle_nav_command(Rml::Event& event, NavCommand cmd) {
     if (cmd == NavCommand::Menu) {
+        toggle_cursor_if_gyro(!visible());
         mDoAud_seStartMenu(visible() ? kSoundMenuClose : kSoundMenuOpen);
         toggle();
         return true;
     }
     return false;
+}
+
+void Document::toggle_cursor_if_gyro(bool cursor_enabled) {
+    if (dusk::getSettings().game.gyroMode.getValue() == GyroMode::Mouse)
+    {
+        if (cursor_enabled) {
+            ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange;
+            SDL_ShowCursor();
+        } else {
+            ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
+            SDL_HideCursor();
+        }
+    }
 }
 
 }  // namespace dusk::ui

--- a/src/dusk/ui/document.hpp
+++ b/src/dusk/ui/document.hpp
@@ -43,6 +43,8 @@ public:
     bool pending_close() const { return mPendingClose; }
     bool closed() const { return mClosed; }
 
+    void toggle_cursor_if_gyro(bool);
+
 protected:
     virtual bool handle_nav_command(Rml::Event& event, NavCommand cmd);
 

--- a/src/dusk/ui/menu_bar.cpp
+++ b/src/dusk/ui/menu_bar.cpp
@@ -42,6 +42,7 @@ MenuBar::MenuBar() : Document(kDocumentSource), mRoot(mDocument->GetElementById(
     mTabBar = std::make_unique<TabBar>(mRoot, TabBar::Props{
                                                   .onClose =
                                                       [this] {
+                                                          toggle_cursor_if_gyro(false);
                                                           mDoAud_seStartMenu(kSoundMenuClose);
                                                           hide(false);
                                                       },
@@ -203,6 +204,7 @@ bool MenuBar::handle_nav_command(Rml::Event& event, NavCommand cmd) {
         return true;
     }
     if (cmd == NavCommand::Cancel && visible()) {
+        toggle_cursor_if_gyro(false);
         mDoAud_seStartMenu(kSoundMenuClose);
         hide(false);
         return true;

--- a/src/dusk/ui/prelaunch.cpp
+++ b/src/dusk/ui/prelaunch.cpp
@@ -687,6 +687,8 @@ Prelaunch::Prelaunch() : Document(kDocumentSource), mRoot(mDocument->GetElementB
                 return;
             }
 
+            toggle_cursor_if_gyro(false);
+
             mDoAud_seStartMenu(kSoundPlay);
             show_menu_notification();
 


### PR DESCRIPTION
Needs to be tested on Steam Deck first!