### PR TITLE
Fix Prelaunch Break-out

### DIFF
--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -193,9 +193,10 @@ Rml::String format_graphics_setting_value(GraphicsOption option, int value) {
     return "";
 }
 
-GraphicsTuner::GraphicsTuner(GraphicsTunerProps props)
+GraphicsTuner::GraphicsTuner(GraphicsTunerProps props, bool prelaunch)
     : Document(kDocumentSource), mOption(props.option), mValueMin(props.valueMin),
-      mValueMax(props.valueMax), mDefaultValue(props.defaultValue) {
+      mValueMax(props.valueMax), mDefaultValue(props.defaultValue), mPrelaunch(prelaunch)
+{
     if (mDocument == nullptr) {
         return;
     }
@@ -281,7 +282,8 @@ bool GraphicsTuner::handle_nav_command(Rml::Event& event, NavCommand cmd) {
         pop();
         return true;
     }
-    return Document::handle_nav_command(event, cmd);
+
+    return mPrelaunch ? false : Document::handle_nav_command(event, cmd);
 }
 
 void GraphicsTuner::reset_default() {

--- a/src/dusk/ui/graphics_tuner.hpp
+++ b/src/dusk/ui/graphics_tuner.hpp
@@ -59,7 +59,7 @@ struct GraphicsTunerProps {
 
 class GraphicsTuner : public Document {
 public:
-    explicit GraphicsTuner(GraphicsTunerProps props);
+    explicit GraphicsTuner(GraphicsTunerProps props, bool prelaunch);
 
     void show() override;
     void hide(bool close) override;
@@ -87,6 +87,7 @@ private:
     int mDefaultValue = 0;
     std::vector<std::unique_ptr<Component> > mComponents;
     Rml::Element* mRoot;
+    bool mPrelaunch;
 };
 
 }  // namespace dusk::ui

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -274,7 +274,7 @@ SelectButton& config_percent_select(Pane& leftPane, Pane& rightPane, ConfigVar<f
 
 template <typename T>
 void graphics_tuner_control(Window& window, Pane& leftPane, Pane& rightPane, ConfigVar<T>& var,
-    const GraphicsTunerProps& props) {
+    const GraphicsTunerProps& props, bool prelaunch) {
     leftPane.register_control(
         leftPane
             .add_select_button({
@@ -292,10 +292,10 @@ void graphics_tuner_control(Window& window, Pane& leftPane, Pane& rightPane, Con
                 .isModified = [&var] { return var.getValue() != var.getDefaultValue(); },
                 .submit = false,
             })
-            .on_nav_command([&window, props](Rml::Event&, NavCommand cmd) {
+            .on_nav_command([&window, props, prelaunch](Rml::Event&, NavCommand cmd) {
                 if (cmd == NavCommand::Confirm || cmd == NavCommand::Left ||
                     cmd == NavCommand::Right) {
-                    window.push(std::make_unique<GraphicsTuner>(props));
+                    window.push(std::make_unique<GraphicsTuner>(props, prelaunch));
                     return true;
                 }
                 return false;
@@ -551,7 +551,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .valueMin = 0,
                 .valueMax = 12,
                 .defaultValue = 0,
-            });
+            }, mPrelaunch);
         graphics_tuner_control(*this, leftPane, rightPane,
             getSettings().game.shadowResolutionMultiplier,
             GraphicsTunerProps{
@@ -561,7 +561,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .valueMin = 1,
                 .valueMax = 8,
                 .defaultValue = 1,
-            });
+            }, mPrelaunch);
 
         leftPane.add_section("Post-Processing");
         graphics_tuner_control(*this, leftPane, rightPane, getSettings().game.bloomMode,
@@ -572,7 +572,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .valueMin = static_cast<int>(BloomMode::Off),
                 .valueMax = static_cast<int>(BloomMode::Dusk),
                 .defaultValue = static_cast<int>(BloomMode::Classic),
-            });
+            }, mPrelaunch);
         graphics_tuner_control(*this, leftPane, rightPane, getSettings().game.bloomMultiplier,
             GraphicsTunerProps{
                 .option = GraphicsOption::BloomMultiplier,
@@ -581,7 +581,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .valueMin = 0,
                 .valueMax = 100,
                 .defaultValue = 100,
-            });
+            }, mPrelaunch);
 
         leftPane.add_section("Rendering");
         config_bool_select(leftPane, rightPane, getSettings().game.enableFrameInterpolation,


### PR DESCRIPTION
Prevents users from breaking out of the prelaunch menu through the `GraphicsTuner` pages. Basically copied over what `Window` does (since GraphicsTuner doesn't inherit from that/can't use it directly), not sure if there's a cleaner way to pass `mPrelaunch` down from `SettingsWindow` -> `GraphicsTuner`.

Fixes #737