### PR TITLE
Navigate Carousel Without Focus

### DIFF
--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -208,7 +208,7 @@ GraphicsTuner::GraphicsTuner(GraphicsTunerProps props, bool prelaunch)
         description->SetInnerRML(escape(props.helpText));
     }
     if (auto* carouselParent = mDocument->GetElementById("carousel-container")) {
-        add_component<SteppedCarousel>(carouselParent,
+        mCarousel = &add_component<SteppedCarousel>(carouselParent,
             SteppedCarousel::Props{
                 .min = mValueMin,
                 .max = mValueMax,
@@ -280,6 +280,10 @@ bool GraphicsTuner::visible() const {
 bool GraphicsTuner::handle_nav_command(Rml::Event& event, NavCommand cmd) {
     if (cmd == NavCommand::Cancel) {
         pop();
+        return true;
+    }
+
+    if(mCarousel && mCarousel->handle_nav_command(cmd)) {
         return true;
     }
 

--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -195,8 +195,7 @@ Rml::String format_graphics_setting_value(GraphicsOption option, int value) {
 
 GraphicsTuner::GraphicsTuner(GraphicsTunerProps props, bool prelaunch)
     : Document(kDocumentSource), mOption(props.option), mValueMin(props.valueMin),
-      mValueMax(props.valueMax), mDefaultValue(props.defaultValue), mPrelaunch(prelaunch)
-{
+      mValueMax(props.valueMax), mDefaultValue(props.defaultValue), mPrelaunch(prelaunch) {
     if (mDocument == nullptr) {
         return;
     }
@@ -283,7 +282,7 @@ bool GraphicsTuner::handle_nav_command(Rml::Event& event, NavCommand cmd) {
         return true;
     }
 
-    if(mCarousel && mCarousel->handle_nav_command(cmd)) {
+    if (mCarousel && mCarousel->handle_nav_command(cmd)) {
         return true;
     }
 

--- a/src/dusk/ui/graphics_tuner.hpp
+++ b/src/dusk/ui/graphics_tuner.hpp
@@ -28,9 +28,9 @@ public:
 
     bool focus() override;
     void update() override;
+    bool handle_nav_command(NavCommand cmd);
 
 private:
-    bool handle_nav_command(NavCommand cmd);
     void apply(int value);
 
     Props mProps;
@@ -86,6 +86,7 @@ private:
     int mValueMax = 0;
     int mDefaultValue = 0;
     std::vector<std::unique_ptr<Component> > mComponents;
+    SteppedCarousel* mCarousel;
     Rml::Element* mRoot;
     bool mPrelaunch;
 };


### PR DESCRIPTION
Allow left/right inputs to change the setting value without having the arrow explicitly clicked. Fixes #707