### PR TITLE
Prevent zipping of appimage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
           path: |
             build/install/Dusk-*.AppImage
             build/install/debug.tar.*
+          archive: false
 
   build-apple:
     name: Build Apple (${{matrix.name}})


### PR DESCRIPTION
Changing the workflow so the appimage is not zipped as [that is explicitly mentioned in the docs.](https://docs.appimage.org/packaging-guide/distribution.html#do-not-put-appimages-into-other-archives)

It would also allow users to get auto updates using [Gearlever](https://github.com/mijorus/gearlever/issues/446)