### PR TITLE
Fix: Compiling on GCC15

### DIFF
--- a/include/dusk/io.hpp
+++ b/include/dusk/io.hpp
@@ -2,14 +2,12 @@
 #define DUSK_IO_HPP
 
 #include <vector>
+#include <filesystem>
 
 // I can't believe it's 2026 and neither SDL (no error codes) nor
 // C++ (no error codes) have a file system API functional enough for me to use.
 // Here you go, this one's inspired by C#. I only wrote the functions I need.
 
-namespace std::filesystem {
-    class path;
-}
 
 namespace dusk::io {
 


### PR DESCRIPTION
This fixes being able to compile on GCC 15, currently exits with an ambiguity between std::filesystem::path and the path defined in `dusk/io.hpp`.

