### PR TITLE
Option to Invert First Person Aiming

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -144,6 +144,8 @@ struct UserSettings {
         ConfigVar<bool> freeCamera;
         ConfigVar<bool> invertCameraXAxis;
         ConfigVar<bool> invertCameraYAxis;
+        ConfigVar<bool> invertFirstPersonXAxis;
+        ConfigVar<bool> invertFirstPersonYAxis;
         ConfigVar<float> freeCameraSensitivity;
         ConfigVar<bool> debugFlyCam;
         ConfigVar<bool> debugFlyCamLockEvents;

--- a/src/d/actor/d_a_alink_link.inc
+++ b/src/d/actor/d_a_alink_link.inc
@@ -119,8 +119,8 @@ BOOL daAlink_c::setBodyAngleToCamera() {
                 var_f31 /= dComIfGp_getCameraZoomScale(field_0x317c);
             }
 
-            shape_angle.y = shape_angle.y + (var_f31 * cM_ssin(mStickAngle));
-            sp8 = mBodyAngle.x + (var_f31 * cM_scos(mStickAngle));
+            shape_angle.y = shape_angle.y + (var_f31 * cM_ssin(mStickAngle) IF_DUSK(* (dusk::getSettings().game.invertFirstPersonXAxis ? -1.0f : 1.0f)));
+            sp8 = mBodyAngle.x + (var_f31 * cM_scos(mStickAngle) IF_DUSK(* (dusk::getSettings().game.invertFirstPersonYAxis ? -1.0f : 1.0f)));
 
             if (checkNotItemSinkLimit() && sp8 > 0 && sp8 > mBodyAngle.x) {
                 sp8 = mBodyAngle.x;
@@ -144,8 +144,8 @@ BOOL daAlink_c::setBodyAngleToCamera() {
             f32 gy_pitch = 0.f;
             dusk::gyro::getAimDeltas(gy_yaw, gy_pitch);
 
-            shape_angle.y = shape_angle.y + cM_rad2s(gy_yaw * gyro_scale);
-            sp8 = sp8 + cM_rad2s(gy_pitch * gyro_scale);
+            shape_angle.y = shape_angle.y + cM_rad2s(gy_yaw * gyro_scale * (dusk::getSettings().game.invertFirstPersonXAxis ? -1.0f : 1.0f));
+            sp8 = sp8 + cM_rad2s(gy_pitch * gyro_scale * (dusk::getSettings().game.invertFirstPersonYAxis ? -1.0f : 1.0f));
 
             if (checkNotItemSinkLimit() && sp8 > 0 && sp8 > mBodyAngle.x) {
                 sp8 = mBodyAngle.x;

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -81,6 +81,8 @@ UserSettings g_userSettings = {
         .freeCamera {"game.freeCamera", false},
         .invertCameraXAxis {"game.invertCameraXAxis", false},
         .invertCameraYAxis {"game.invertCameraYAxis", false},
+        .invertFirstPersonXAxis {"game.invertFirstPersonXAxis", false},
+        .invertFirstPersonYAxis {"game.invertFirstPersonYAxis", false},
         .freeCameraSensitivity {"game.freeCameraSensitivity", 1.0f},
         .debugFlyCam {"game.debugFlyCam", false},
         .debugFlyCamLockEvents {"game.debugFlyCamLockEvents", true},
@@ -171,6 +173,8 @@ void registerSettings() {
     Register(g_userSettings.game.enableMirrorMode);
     Register(g_userSettings.game.invertCameraXAxis);
     Register(g_userSettings.game.invertCameraYAxis);
+    Register(g_userSettings.game.invertFirstPersonXAxis);
+    Register(g_userSettings.game.invertFirstPersonYAxis);
     Register(g_userSettings.game.freeCameraSensitivity);
     Register(g_userSettings.game.minimalHUD);
     Register(g_userSettings.game.pauseOnFocusLost);

--- a/src/dusk/ui/preset.cpp
+++ b/src/dusk/ui/preset.cpp
@@ -33,6 +33,7 @@ void applyPresetDusk() {
     s.game.fastTears.setValue(true);
     s.game.biggerWallets.setValue(true);
     s.game.invertCameraXAxis.setValue(true);
+    s.game.invertFirstPersonYAxis.setValue(true);
     s.game.no2ndFishForCat.setValue(true);
     s.game.enableAchievementToasts.setValue(true);
     s.game.enableControllerToasts.setValue(true);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -641,6 +641,10 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
         config_percent_select(leftPane, rightPane, getSettings().game.freeCameraSensitivity,
             "Free Camera Sensitivity", "Adjusts twin-stick camera sensitivity.", 50, 200, 5,
             [] { return !getSettings().game.freeCamera; });
+        addOption("Invert First Person X Axis", getSettings().game.invertFirstPersonXAxis,
+            "Invert horizontal movement while aiming with items or first person camera. Applies to both stick and gyro aiming.");
+        addOption("Invert First Person Y Axis", getSettings().game.invertFirstPersonYAxis,
+            "Invert vertical movement while aiming with items or first person camera. Applies to both stick and gyro aiming.");
 
         leftPane.add_section("Gyro");
         leftPane.register_control(


### PR DESCRIPTION
Would be helpful if some others could stress test this to make sure it behaves properly in all scenarios/control schemes.

Also included inverted Y aiming (so up on the stick aims up) in the Dusk preset since it's what TPHD (and WWHD/others) do, but if that's undesired I can remove it.