### PR TITLE
Crash Reporting Popup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,6 +444,12 @@ target_link_libraries(dusk PRIVATE aurora::main ${GAME_LIBS} ${JSYSTEM_LINK_LIBR
 target_precompile_headers(dusk PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/include/dusk_pch.hpp>")
 if (TARGET crashpad_handler)
     add_dependencies(dusk crashpad_handler)
+    add_custom_command(TARGET dusk POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE:crashpad_handler>"
+            "$<TARGET_FILE_DIR:dusk>"
+        COMMENT "Copying crashpad handler"
+    )
 endif ()
 
 if (ANDROID)

--- a/files.cmake
+++ b/files.cmake
@@ -1494,6 +1494,8 @@ set(DUSK_FILES
         src/dusk/ui/prelaunch.hpp
         src/dusk/ui/preset.cpp
         src/dusk/ui/preset.hpp
+        src/dusk/ui/reporting.cpp
+        src/dusk/ui/reporting.hpp
         src/dusk/ui/select_button.cpp
         src/dusk/ui/select_button.hpp
         src/dusk/ui/settings.cpp

--- a/include/dusk/crash_reporting.h
+++ b/include/dusk/crash_reporting.h
@@ -1,8 +1,17 @@
 #pragma once
 
-namespace dusk {
+namespace dusk::crash_reporting {
 
-void InitializeCrashReporting();
-void ShutdownCrashReporting();
+enum class Consent {
+    Unavailable,
+    Unknown,
+    Given,
+    Revoked,
+};
 
-}  // namespace dusk
+void initialize();
+void shutdown();
+Consent get_consent();
+void set_consent(bool enabled);
+
+}  // namespace dusk::crash_reporting

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -184,6 +184,7 @@ struct UserSettings {
         ConfigVar<bool> skipPreLaunchUI;
         ConfigVar<bool> showPipelineCompilation;
         ConfigVar<bool> wasPresetChosen;
+        ConfigVar<bool> wasCrashReportChosen;
         ConfigVar<bool> enableCrashReporting;
         ConfigVar<bool> checkForUpdates;
         ConfigVar<int> cardFileType;

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -184,8 +184,6 @@ struct UserSettings {
         ConfigVar<bool> skipPreLaunchUI;
         ConfigVar<bool> showPipelineCompilation;
         ConfigVar<bool> wasPresetChosen;
-        ConfigVar<bool> wasCrashReportChosen;
-        ConfigVar<bool> enableCrashReporting;
         ConfigVar<bool> checkForUpdates;
         ConfigVar<int> cardFileType;
         ConfigVar<bool> enableAdvancedSettings;

--- a/src/dusk/crash_reporting.cpp
+++ b/src/dusk/crash_reporting.cpp
@@ -4,7 +4,6 @@
 #include "dusk/dusk.h"
 #include "dusk/logging.h"
 #include "dusk/main.h"
-#include "dusk/settings.h"
 #include "version.h"
 
 #include <cstdlib>
@@ -13,114 +12,83 @@
 #include <string_view>
 #include <system_error>
 
-#include "SDL3/SDL_filesystem.h"
-
 #if DUSK_ENABLE_SENTRY_NATIVE
 #include <sentry.h>
 #endif
 
-namespace dusk {
+namespace dusk::crash_reporting {
 
 namespace {
 
 #if DUSK_ENABLE_SENTRY_NATIVE
 bool g_sentryInitialized = false;
 
-bool IsTruthy(std::string_view value) {
-    return value == "1" || value == "true" || value == "TRUE" || value == "yes"
-        || value == "YES" || value == "on" || value == "ON";
+bool truthy(std::string_view value) {
+    return value == "1" || value == "true" || value == "TRUE" || value == "yes" || value == "YES" ||
+           value == "on" || value == "ON";
 }
 
-std::string GetEnvOrEmpty(const char* name) {
+std::string env_or_empty(const char* name) {
     if (const char* value = std::getenv(name)) {
         return value;
     }
     return {};
 }
 
-bool GetEffectiveEnabled() {
-    const std::string env = GetEnvOrEmpty("DUSK_SENTRY_ENABLED");
-    if (!env.empty()) {
-        return IsTruthy(env);
-    }
-    return getSettings().backend.enableCrashReporting;
+bool disabled_by_env() {
+    const std::string env = env_or_empty("DUSK_SENTRY_ENABLED");
+    return !env.empty() && !truthy(env);
 }
 
-std::string GetEffectiveDsn() {
-    const std::string env = GetEnvOrEmpty("DUSK_SENTRY_DSN");
+std::string effective_dsn() {
+    const std::string env = env_or_empty("DUSK_SENTRY_DSN");
     if (!env.empty()) {
         return env;
     }
     return DUSK_SENTRY_DSN;
 }
 
-bool GetEffectiveDebug() {
-    const std::string env = GetEnvOrEmpty("DUSK_SENTRY_DEBUG");
+bool effective_debug() {
+    const std::string env = env_or_empty("DUSK_SENTRY_DEBUG");
     if (!env.empty()) {
-        return IsTruthy(env);
+        return truthy(env);
     }
     return false;
 }
 
-std::string GetReleaseName() {
+std::string release_name() {
     return std::string(AppName) + "@" DUSK_WC_DESCRIBE;
 }
 
-std::filesystem::path GetSentryDatabasePath() {
+std::filesystem::path sentry_database_path() {
     return dusk::ConfigPath / "sentry";
 }
 
-std::filesystem::path GetLogAttachmentPath() {
+std::filesystem::path log_attachment_path() {
     if (const char* logPath = GetLogFilePath()) {
         return logPath;
     }
     return {};
 }
 
-std::filesystem::path GetCrashpadHandlerPath() {
-    const char* basePath = SDL_GetBasePath();
-    if (!basePath) {
-        return {};
-    }
-
-    const std::filesystem::path handlerDir(basePath);
-#if _WIN32
-    return handlerDir / "crashpad_handler.exe";
-#else
-    return handlerDir / "crashpad_handler";
-#endif
-}
-
-void ConfigurePathOptions(sentry_options_t* options) {
-    const auto databasePath = GetSentryDatabasePath();
+void configure_path_options(sentry_options_t* options) {
+    const auto databasePath = sentry_database_path();
     std::error_code ec;
     std::filesystem::create_directories(databasePath, ec);
     if (ec) {
-        DuskLog.warn("Unable to create Sentry database path '{}': {}",
-                     databasePath.string(), ec.message());
+        DuskLog.warn(
+            "Unable to create Sentry database path '{}': {}", databasePath.string(), ec.message());
     }
 
 #if _WIN32
     const std::wstring databasePathWide = databasePath.wstring();
     sentry_options_set_database_pathw(options, databasePathWide.c_str());
-
-    const auto handlerPath = GetCrashpadHandlerPath();
-    if (!handlerPath.empty()) {
-        const std::wstring handlerPathWide = handlerPath.wstring();
-        sentry_options_set_handler_pathw(options, handlerPathWide.c_str());
-    }
 #else
     const std::string databasePathUtf8 = databasePath.string();
     sentry_options_set_database_path(options, databasePathUtf8.c_str());
-
-    const auto handlerPath = GetCrashpadHandlerPath();
-    if (!handlerPath.empty()) {
-        const std::string handlerPathUtf8 = handlerPath.string();
-        sentry_options_set_handler_path(options, handlerPathUtf8.c_str());
-    }
 #endif
 
-    const auto logPath = GetLogAttachmentPath();
+    const auto logPath = log_attachment_path();
     if (!logPath.empty()) {
 #if _WIN32
         sentry_options_add_attachmentw(options, logPath.wstring().c_str());
@@ -133,32 +101,29 @@ void ConfigurePathOptions(sentry_options_t* options) {
 
 }  // namespace
 
-void InitializeCrashReporting() {
+void initialize() {
 #if DUSK_ENABLE_SENTRY_NATIVE
-    if (g_sentryInitialized) {
+    if (g_sentryInitialized || disabled_by_env()) {
         return;
     }
 
-    if (!GetEffectiveEnabled()) {
-        return;
-    }
-
-    const std::string dsn = GetEffectiveDsn();
+    const std::string dsn = effective_dsn();
     if (dsn.empty()) {
         DuskLog.warn("Crash reporting is enabled but no Sentry DSN is configured");
         return;
     }
 
-    const std::string release = GetReleaseName();
+    const std::string release = release_name();
 
     sentry_options_t* options = sentry_options_new();
     sentry_options_set_dsn(options, dsn.c_str());
     sentry_options_set_release(options, release.c_str());
     sentry_options_set_environment(options, DUSK_SENTRY_ENVIRONMENT);
-    sentry_options_set_debug(options, GetEffectiveDebug() ? 1 : 0);
+    sentry_options_set_debug(options, effective_debug() ? 1 : 0);
+    sentry_options_set_require_user_consent(options, 1);
     sentry_options_set_cache_keep(options, 1);
     sentry_options_set_max_breadcrumbs(options, 100);
-    ConfigurePathOptions(options);
+    configure_path_options(options);
 
     if (sentry_init(options) != 0) {
         DuskLog.warn("Failed to initialize Sentry crash reporting");
@@ -173,7 +138,7 @@ void InitializeCrashReporting() {
 #endif
 }
 
-void ShutdownCrashReporting() {
+void shutdown() {
 #if DUSK_ENABLE_SENTRY_NATIVE
     if (!g_sentryInitialized) {
         return;
@@ -184,4 +149,40 @@ void ShutdownCrashReporting() {
 #endif
 }
 
-}  // namespace dusk
+Consent get_consent() {
+#if DUSK_ENABLE_SENTRY_NATIVE
+    if (!g_sentryInitialized) {
+        return Consent::Unavailable;
+    }
+
+    switch (sentry_user_consent_get()) {
+    case SENTRY_USER_CONSENT_GIVEN:
+        return Consent::Given;
+    case SENTRY_USER_CONSENT_REVOKED:
+        return Consent::Revoked;
+    case SENTRY_USER_CONSENT_UNKNOWN:
+    default:
+        return Consent::Unknown;
+    }
+#else
+    return Consent::Unavailable;
+#endif
+}
+
+void set_consent(bool enabled) {
+#if DUSK_ENABLE_SENTRY_NATIVE
+    if (!g_sentryInitialized) {
+        return;
+    }
+
+    if (enabled) {
+        sentry_user_consent_give();
+    } else {
+        sentry_user_consent_revoke();
+    }
+#else
+    (void)enabled;
+#endif
+}
+
+}  // namespace dusk::crash_reporting

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -121,6 +121,7 @@ UserSettings g_userSettings = {
         .skipPreLaunchUI {"backend.skipPreLaunchUI", false},
         .showPipelineCompilation {"backend.showPipelineCompilation", false},
         .wasPresetChosen {"backend.wasPresetChosen", false},
+        .wasCrashReportChosen {"backend.wasCrashReportChosen", false},
         .enableCrashReporting {"backend.enableCrashReporting", true},
         .checkForUpdates {"backend.checkForUpdates", true},
         .cardFileType {"backend.cardFileType", static_cast<int>(CARD_GCIFOLDER)},
@@ -228,6 +229,7 @@ void registerSettings() {
     Register(g_userSettings.backend.skipPreLaunchUI);
     Register(g_userSettings.backend.showPipelineCompilation);
     Register(g_userSettings.backend.wasPresetChosen);
+    Register(g_userSettings.backend.wasCrashReportChosen);
     Register(g_userSettings.backend.enableCrashReporting);
     Register(g_userSettings.backend.checkForUpdates);
     Register(g_userSettings.backend.cardFileType);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -121,8 +121,6 @@ UserSettings g_userSettings = {
         .skipPreLaunchUI {"backend.skipPreLaunchUI", false},
         .showPipelineCompilation {"backend.showPipelineCompilation", false},
         .wasPresetChosen {"backend.wasPresetChosen", false},
-        .wasCrashReportChosen {"backend.wasCrashReportChosen", false},
-        .enableCrashReporting {"backend.enableCrashReporting", true},
         .checkForUpdates {"backend.checkForUpdates", true},
         .cardFileType {"backend.cardFileType", static_cast<int>(CARD_GCIFOLDER)},
         .enableAdvancedSettings {"backend.enableAdvancedSettings", false},
@@ -229,8 +227,6 @@ void registerSettings() {
     Register(g_userSettings.backend.skipPreLaunchUI);
     Register(g_userSettings.backend.showPipelineCompilation);
     Register(g_userSettings.backend.wasPresetChosen);
-    Register(g_userSettings.backend.wasCrashReportChosen);
-    Register(g_userSettings.backend.enableCrashReporting);
     Register(g_userSettings.backend.checkForUpdates);
     Register(g_userSettings.backend.cardFileType);
     Register(g_userSettings.backend.enableAdvancedSettings);

--- a/src/dusk/ui/reporting.cpp
+++ b/src/dusk/ui/reporting.cpp
@@ -1,10 +1,11 @@
-#if DUSK_SENTRY_NATIVE
+#if DUSK_ENABLE_SENTRY_NATIVE
 
 #include "reporting.hpp"
 
 #include "button.hpp"
 #include "dusk/config.hpp"
 #include "dusk/settings.h"
+#include "dusk/crash_reporting.h"
 #include "ui.hpp"
 
 #include <dolphin/gx/GXAurora.h>
@@ -27,7 +28,10 @@ CrashReportWindow::CrashReportWindow() : WindowSmall("modal", "modal-dialog") {
     auto* intro = append(mDialog, "div");
     intro->SetClass("modal-body", true);
     intro->SetInnerRML(
-        "Dusk can autometically send crash reports to developers, which help tremendously when finding and fixing bugs. These reports may include some personal information. This can be changed in the settings menu at any time.");
+        "Dusk can autometically send crash reports to the developers. "
+        "Submissions may contain sensitive information. Refrain from enabling reporting if you do not agree "
+        "with the following inclusions:<br/>- Operating System<br/>- CPU Architecture<br/>- GPU Model & Driver Version<br/>"
+        "- Account Username<br/><br/>This can be changed in the Settings menu at any time.");
 
     auto* grid = append(mDialog, "div");
     grid->SetClass("preset-grid", true);
@@ -40,16 +44,15 @@ CrashReportWindow::CrashReportWindow() : WindowSmall("modal", "modal-dialog") {
 
     static constexpr OptionInfo kOptions[] = {
         {"Enabled",
-         "Send crash reports to Dusk developers. Reports will include your system username.",
+         "Send crash reports to Dusk developers. Reports will include the information described above.",
          []() {
             dusk::getSettings().backend.enableCrashReporting.setValue(true);
          }},
         {"Disabled",
-         "Do not send crash reports. "
-         "This may make it more difficult to resolve any bugs you encounter.",
+         "Do not send crash reports. This may make it more difficult to resolve bugs you encounter.",
          []() {
             dusk::getSettings().backend.enableCrashReporting.setValue(false);
-            //ShutdownCrashReporting();
+            dusk::ShutdownCrashReporting();
          }},
     };
 

--- a/src/dusk/ui/reporting.cpp
+++ b/src/dusk/ui/reporting.cpp
@@ -1,0 +1,116 @@
+#if DUSK_SENTRY_NATIVE
+
+#include "reporting.hpp"
+
+#include "button.hpp"
+#include "dusk/config.hpp"
+#include "dusk/settings.h"
+#include "ui.hpp"
+
+#include <dolphin/gx/GXAurora.h>
+
+namespace dusk::ui {
+
+CrashReportWindow::CrashReportWindow() : WindowSmall("modal", "modal-dialog") {
+    mDialog->SetClass("modal-dialog", true);
+
+    auto* header = append(mDialog, "div");
+    header->SetClass("modal-header", true);
+
+    auto* title = append(header, "div");
+    title->SetClass("modal-title", true);
+    title->SetInnerRML("Send Crash Reports");
+
+    auto* headIcon = append(header, "icon");
+    headIcon->SetClass("question-mark", true);
+
+    auto* intro = append(mDialog, "div");
+    intro->SetClass("modal-body", true);
+    intro->SetInnerRML(
+        "Dusk can autometically send crash reports to developers, which help tremendously when finding and fixing bugs. These reports may include some personal information. This can be changed in the settings menu at any time.");
+
+    auto* grid = append(mDialog, "div");
+    grid->SetClass("preset-grid", true);
+
+    struct OptionInfo {
+        const char* name;
+        const char* desc;
+        void (*apply)();
+    };
+
+    static constexpr OptionInfo kOptions[] = {
+        {"Enabled",
+         "Send crash reports to Dusk developers. Reports will include your system username.",
+         []() {
+            dusk::getSettings().backend.enableCrashReporting.setValue(true);
+         }},
+        {"Disabled",
+         "Do not send crash reports. "
+         "This may make it more difficult to resolve any bugs you encounter.",
+         []() {
+            dusk::getSettings().backend.enableCrashReporting.setValue(false);
+            //ShutdownCrashReporting();
+         }},
+    };
+
+    for (const auto& option : kOptions) {
+        auto* col = append(grid, "div");
+        col->SetClass("preset-col", true);
+
+        auto btn = std::make_unique<Button>(col, Rml::String(option.name));
+        btn->on_nav_command([this, apply = option.apply](Rml::Event&, NavCommand cmd) {
+            if (cmd == NavCommand::Confirm) {
+                apply();
+                getSettings().backend.wasCrashReportChosen.setValue(true);
+                config::Save();
+                hide(true);
+                return true;
+            }
+            return false;
+        });
+        mButtons.push_back(std::move(btn));
+
+        auto* desc = append(col, "div");
+        desc->SetClass("preset-desc", true);
+        desc->SetInnerRML(option.desc);
+    }
+}
+
+bool CrashReportWindow::focus() {
+    if (!mButtons.empty()) {
+        return mButtons.back()->focus();
+    }
+    return false;
+}
+
+bool CrashReportWindow::handle_nav_command(Rml::Event& event, NavCommand cmd) {
+    if (cmd == NavCommand::Cancel || cmd == NavCommand::Menu) {
+        return true;
+    }
+    int direction = 0;
+    if (cmd == NavCommand::Left) {
+        direction = -1;
+    } else if (cmd == NavCommand::Right) {
+        direction = 1;
+    } else {
+        return false;
+    }
+    auto* target = event.GetTargetElement();
+    for (int i = 0; i < static_cast<int>(mButtons.size()); ++i) {
+        if (mButtons[i]->contains(target)) {
+            const int next = i + direction;
+            if (next >= 0 && next < static_cast<int>(mButtons.size())) {
+                if (mButtons[next]->focus()) {
+                    mDoAud_seStartMenu(kSoundItemFocus);
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+    return false;
+}
+
+}  // namespace dusk::ui
+
+#endif

--- a/src/dusk/ui/reporting.cpp
+++ b/src/dusk/ui/reporting.cpp
@@ -3,8 +3,6 @@
 #include "reporting.hpp"
 
 #include "button.hpp"
-#include "dusk/config.hpp"
-#include "dusk/settings.h"
 #include "dusk/crash_reporting.h"
 #include "ui.hpp"
 
@@ -28,10 +26,11 @@ CrashReportWindow::CrashReportWindow() : WindowSmall("modal", "modal-dialog") {
     auto* intro = append(mDialog, "div");
     intro->SetClass("modal-body", true);
     intro->SetInnerRML(
-        "Dusk can autometically send crash reports to the developers. "
-        "Submissions may contain sensitive information. Refrain from enabling reporting if you do not agree "
-        "with the following inclusions:<br/>- Operating System<br/>- CPU Architecture<br/>- GPU Model & Driver Version<br/>"
-        "- Account Username<br/><br/>This can be changed in the Settings menu at any time.");
+        "Dusk can automatically send crash reports to the developers. Crash reports contain the "
+        "following:"
+        "<br/>• Operating system version<br/>• CPU architecture<br/>• GPU model & driver version"
+        "<br/>• File paths (may include account username)<br/>• Stack trace<br/><br/>"
+        "This can be changed in the Settings menu at any time.");
 
     auto* grid = append(mDialog, "div");
     grid->SetClass("preset-grid", true);
@@ -43,17 +42,14 @@ CrashReportWindow::CrashReportWindow() : WindowSmall("modal", "modal-dialog") {
     };
 
     static constexpr OptionInfo kOptions[] = {
-        {"Enabled",
-         "Send crash reports to Dusk developers. Reports will include the information described above.",
-         []() {
-            dusk::getSettings().backend.enableCrashReporting.setValue(true);
-         }},
-        {"Disabled",
-         "Do not send crash reports. This may make it more difficult to resolve bugs you encounter.",
-         []() {
-            dusk::getSettings().backend.enableCrashReporting.setValue(false);
-            dusk::ShutdownCrashReporting();
-         }},
+        {"Enable",
+            "Send crash reports to Dusk developers. Reports will include the information described "
+            "above.",
+            [] { crash_reporting::set_consent(true); }},
+        {"Disable",
+            "Do not send crash reports. This may make it more difficult to resolve issues you "
+            "encounter.",
+            [] { crash_reporting::set_consent(false); }},
     };
 
     for (const auto& option : kOptions) {
@@ -64,8 +60,6 @@ CrashReportWindow::CrashReportWindow() : WindowSmall("modal", "modal-dialog") {
         btn->on_nav_command([this, apply = option.apply](Rml::Event&, NavCommand cmd) {
             if (cmd == NavCommand::Confirm) {
                 apply();
-                getSettings().backend.wasCrashReportChosen.setValue(true);
-                config::Save();
                 hide(true);
                 return true;
             }

--- a/src/dusk/ui/reporting.hpp
+++ b/src/dusk/ui/reporting.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#if DUSK_ENABLE_SENTRY_NATIVE
+
+#include "component.hpp"
+#include "window.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace dusk::ui {
+
+class CrashReportWindow : public WindowSmall {
+public:
+    CrashReportWindow();
+
+    bool focus() override;
+
+protected:
+    bool handle_nav_command(Rml::Event& event, NavCommand cmd) override;
+
+private:
+    std::vector<std::unique_ptr<Component>> mButtons;
+};
+
+}  // namespace dusk::ui
+
+#endif

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -19,6 +19,10 @@
 #include "prelaunch.hpp"
 #include "ui.hpp"
 
+#if DUSK_ENABLE_SENTRY_NATIVE
+#include "dusk/crash_reporting.h"
+#endif
+
 #include <algorithm>
 
 namespace dusk::ui {
@@ -1033,7 +1037,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                             "inclusions:<br/><br/> "
                             "- Operating System<br/>- CPU Architecture<br/>- GPU Model & Driver "
                             "Version<br/>"
-                            "- Account Username"
+                            "- Account Username",
                 .onChange = [](bool enabled) {
                     if(enabled) {
                         dusk::InitializeCrashReporting();

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1033,7 +1033,16 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                             "inclusions:<br/><br/> "
                             "- Operating System<br/>- CPU Architecture<br/>- GPU Model & Driver "
                             "Version<br/>"
-                            "- Account Username"});
+                            "- Account Username"
+                .onChange = [](bool enabled) {
+                    if(enabled) {
+                        dusk::InitializeCrashReporting();
+                    }
+                    else {
+                        dusk::ShutdownCrashReporting();
+                    }
+                },
+            });
 #endif
         config_bool_select(leftPane, rightPane, getSettings().backend.skipPreLaunchUI,
             {

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1028,25 +1028,24 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 pane.add_rml("<br/>Choose which notifications can be displayed.");
             });
 #if DUSK_ENABLE_SENTRY_NATIVE
-        config_bool_select(leftPane, rightPane, getSettings().backend.enableCrashReporting,
-            {.key = "Crash Reporting",
-                .helpText = "Enable automatic reporting of crashes to the developers.<br/><br/>"
-                            "Submissions include logs which may contain sensitive information. "
-                            "Refrain from "
-                            "enabling reporting if you do not agree with the following "
-                            "inclusions:<br/><br/> "
-                            "- Operating System<br/>- CPU Architecture<br/>- GPU Model & Driver "
-                            "Version<br/>"
-                            "- Account Username",
-                .onChange = [](bool enabled) {
-                    if(enabled) {
-                        dusk::InitializeCrashReporting();
-                    }
-                    else {
-                        dusk::ShutdownCrashReporting();
-                    }
+        auto& crashReporting = leftPane.add_child<BoolButton>(BoolButton::Props{
+            .key = "Crash Reporting",
+            .getValue =
+                [] { return crash_reporting::get_consent() == crash_reporting::Consent::Given; },
+            .setValue = [](bool enabled) { crash_reporting::set_consent(enabled); },
+            .isDisabled =
+                [] {
+                    return crash_reporting::get_consent() == crash_reporting::Consent::Unavailable;
                 },
-            });
+            .isModified = [] { return false; },
+        });
+        leftPane.register_control(crashReporting, rightPane, [](Pane& pane) {
+            pane.clear();
+            pane.add_rml("Dusk can automatically send crash reports to the developers. Crash "
+                         "reports contain the following:<br/>• Operating system version<br/>• CPU "
+                         "architecture<br/>• GPU model & driver version<br/>• File paths (may "
+                         "include account username)<br/>• Stack trace");
+        });
 #endif
         config_bool_select(leftPane, rightPane, getSettings().backend.skipPreLaunchUI,
             {

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -90,6 +90,10 @@
 #include <TargetConditionals.h>
 #endif
 
+#if DUSK_ENABLE_SENTRY_NATIVE
+#include "dusk/ui/reporting.hpp"
+#endif
+
 // --- GLOBALS ---
 s8 mDoMain::developmentMode = -1;
 OSTime mDoMain::sPowerOnTime;
@@ -852,6 +856,12 @@ int game_main(int argc, char* argv[]) {
 
         dusk::IsGameLaunched = true;
     }
+
+#if DUSK_ENABLE_SENTRY_NATIVE
+    if (!dusk::getSettings().backend.wasCrashReportChosen) {
+        dusk::ui::push_document(std::make_unique<dusk::ui::CrashReportWindow>());
+    }
+#endif
 
     if (!dusk::getSettings().backend.wasPresetChosen) {
         dusk::ui::push_document(std::make_unique<dusk::ui::PresetWindow>());

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -697,7 +697,7 @@ int game_main(int argc, char* argv[]) {
 
     dusk::config::LoadFromUserPreferences();
     ApplyCVarOverrides(parsed_arg_options["cvar"]);
-    dusk::InitializeCrashReporting();
+    dusk::crash_reporting::initialize();
     EnsureInitialPipelineCache(dusk::ConfigPath);
     // TODO: How to handle this?
     //PADSetDefaultMapping(&defaultPadMapping, PAD_TYPE_STANDARD);
@@ -748,7 +748,7 @@ int game_main(int argc, char* argv[]) {
     // Run ImGui UI loop if Aurora couldn't initialize a backend
     if (auroraInfo.backend == BACKEND_NULL) {
         launchUILoop();
-        dusk::ShutdownCrashReporting();
+        dusk::crash_reporting::shutdown();
         dusk::ShutdownFileLogging();
         fflush(stdout);
         fflush(stderr);
@@ -826,7 +826,7 @@ int game_main(int argc, char* argv[]) {
 
             // pre game launch ui main loop
             if (!launchUILoop()) {
-                dusk::ShutdownCrashReporting();
+                dusk::crash_reporting::shutdown();
                 dusk::ShutdownFileLogging();
                 fflush(stdout);
                 fflush(stderr);
@@ -858,7 +858,7 @@ int game_main(int argc, char* argv[]) {
     }
 
 #if DUSK_ENABLE_SENTRY_NATIVE
-    if (!dusk::getSettings().backend.wasCrashReportChosen) {
+    if (dusk::crash_reporting::get_consent() == dusk::crash_reporting::Consent::Unknown) {
         dusk::ui::push_document(std::make_unique<dusk::ui::CrashReportWindow>());
     }
 #endif
@@ -894,7 +894,7 @@ int game_main(int argc, char* argv[]) {
 
     dusk::MoviePlayerShutdown();
 
-    dusk::ShutdownCrashReporting();
+    dusk::crash_reporting::shutdown();
     dusk::ShutdownFileLogging();
     fflush(stdout);
     fflush(stderr);


### PR DESCRIPTION
If the build has crash reporting, adds a menu on startup to explain what is included/give you the option to disable it. Does not handle reports before the UI is totally set up, those cases should be handled via the cvar command line option if someone is really concerned about it.