### PR TITLE
feat(ui): add user-configurable ui scale + fix fps overlay overlap

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -70,6 +70,7 @@ struct UserSettings {
         ConfigVar<bool> lockAspectRatio;
         ConfigVar<bool> enableFpsOverlay;
         ConfigVar<int> fpsOverlayCorner;
+        ConfigVar<float> uiScale;
     } video;
 
     struct {

--- a/res/rml/overlay.rcss
+++ b/res/rml/overlay.rcss
@@ -225,6 +225,12 @@ fps[corner=br] {
     right: 12dp;
 }
 
+/* Avoid colliding with the Start/R menu bar (64dp tall) when it is open */
+fps[menu-open][corner=tl],
+fps[menu-open][corner=tr] {
+    top: 76dp;
+}
+
 logo {
     position: absolute;
     width: 100dp;

--- a/res/rml/tuner.rcss
+++ b/res/rml/tuner.rcss
@@ -145,3 +145,72 @@ footer-button.reset {
     font-family: "Material Symbols Rounded";
     font-weight: normal;
 }
+
+.tuner-preview {
+    display: none;
+}
+
+.tuner-preview.active {
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    padding: 0 64dp;
+}
+
+.preview-card {
+    width: 100%;
+    max-width: 560dp;
+    display: flex;
+    flex-direction: column;
+    gap: 12dp;
+    padding: 18dp 24dp;
+    background-color: rgba(21, 22, 16, 80%);
+    border: 1dp #92875B;
+    border-radius: 10dp;
+    backdrop-filter: blur(5dp);
+    color: #E0DBC8;
+    font-family: "Fira Sans";
+}
+
+.preview-heading {
+    font-family: "Fira Sans Condensed";
+    font-weight: bold;
+    font-size: 18dp;
+    text-transform: uppercase;
+    color: #92875B;
+}
+
+.preview-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16dp;
+    font-size: 20dp;
+}
+
+.preview-row .preview-key {
+    color: #E0DBC8;
+}
+
+.preview-row .preview-value {
+    font-weight: bold;
+    color: #C2A42D;
+}
+
+.preview-body {
+    font-size: 15dp;
+    line-height: 20dp;
+    color: rgba(224, 219, 200, 70%);
+}
+
+@media (max-height: 800dp) {
+    .tuner-preview.active {
+        padding: 0 48dp;
+    }
+
+    .preview-card {
+        max-width: 480dp;
+        padding: 14dp 20dp;
+        gap: 10dp;
+    }
+}

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -10,6 +10,7 @@ UserSettings g_userSettings = {
         .lockAspectRatio {"video.lockAspectRatio", false},
         .enableFpsOverlay {"game.enableFpsOverlay", false},
         .fpsOverlayCorner {"game.fpsOverlayCorner", 0},
+        .uiScale {"video.uiScale", 1.0f},
     },
 
     .audio = {
@@ -139,6 +140,7 @@ void registerSettings() {
     Register(g_userSettings.video.lockAspectRatio);
     Register(g_userSettings.video.enableFpsOverlay);
     Register(g_userSettings.video.fpsOverlayCorner);
+    Register(g_userSettings.video.uiScale);
 
     // Audio
     Register(g_userSettings.audio.masterVolume);

--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -11,10 +11,37 @@
 #include "dusk/settings.h"
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <string>
 
 namespace dusk::ui {
 namespace {
+
+constexpr std::array<float, 8> kUiScalePresets = {
+    0.80f,
+    0.90f,
+    1.00f,
+    1.10f,
+    1.25f,
+    1.50f,
+    1.75f,
+    2.00f,
+};
+constexpr int kUiScaleDefaultIndex = 2;
+
+int find_ui_scale_index(float value) {
+    int best = kUiScaleDefaultIndex;
+    float bestDiff = std::abs(kUiScalePresets[kUiScaleDefaultIndex] - value);
+    for (int i = 0; i < static_cast<int>(kUiScalePresets.size()); ++i) {
+        const float diff = std::abs(kUiScalePresets[i] - value);
+        if (diff < bestDiff) {
+            bestDiff = diff;
+            best = i;
+        }
+    }
+    return best;
+}
 
 const Rml::String kDocumentSource = R"RML(
 <rml>
@@ -23,6 +50,7 @@ const Rml::String kDocumentSource = R"RML(
 </head>
 <body>
     <div id="root" class="tuner-root">
+        <div id="preview" class="tuner-preview"></div>
         <div class="tuner">
             <div class="header">
                 <div id="title"></div>
@@ -37,6 +65,21 @@ const Rml::String kDocumentSource = R"RML(
 </rml>
 )RML";
 
+const Rml::String kUiScalePreviewSource = R"RML(
+<div class="preview-card">
+    <div class="preview-heading">Sample Menu</div>
+    <div class="preview-row">
+        <div class="preview-key">Enable VSync</div>
+        <div class="preview-value">On</div>
+    </div>
+    <div class="preview-row">
+        <div class="preview-key">Show FPS Counter</div>
+        <div class="preview-value">Top-Right</div>
+    </div>
+    <div class="preview-body">Menu text and controls scale together with this setting.</div>
+</div>
+)RML";
+
 int get_value(GraphicsOption option) {
     switch (option) {
     case GraphicsOption::InternalResolution:
@@ -49,6 +92,8 @@ int get_value(GraphicsOption option) {
         return std::clamp(
             static_cast<int>(getSettings().game.bloomMultiplier.getValue() * 100.0f + 0.5f), 0,
             100);
+    case GraphicsOption::UiScale:
+        return find_ui_scale_index(getSettings().video.uiScale.getValue());
     }
     return 0;
 }
@@ -69,6 +114,11 @@ void set_value(GraphicsOption option, int value) {
     case GraphicsOption::BloomMultiplier:
         getSettings().game.bloomMultiplier.setValue(std::clamp(value, 0, 100) / 100.0f);
         break;
+    case GraphicsOption::UiScale: {
+        const int idx = std::clamp(value, 0, static_cast<int>(kUiScalePresets.size()) - 1);
+        getSettings().video.uiScale.setValue(kUiScalePresets[idx]);
+        break;
+    }
     }
     config::Save();
 }
@@ -189,6 +239,10 @@ Rml::String format_graphics_setting_value(GraphicsOption option, int value) {
         break;
     case GraphicsOption::BloomMultiplier:
         return fmt::format("{}%", value);
+    case GraphicsOption::UiScale: {
+        const int idx = std::clamp(value, 0, static_cast<int>(kUiScalePresets.size()) - 1);
+        return fmt::format("{}%", static_cast<int>(kUiScalePresets[idx] * 100.0f + 0.5f));
+    }
     }
     return "";
 }
@@ -205,6 +259,12 @@ GraphicsTuner::GraphicsTuner(GraphicsTunerProps props, bool prelaunch)
     }
     if (auto* description = mDocument->GetElementById("description")) {
         description->SetInnerRML(escape(props.helpText));
+    }
+    if (auto* preview = mDocument->GetElementById("preview")) {
+        if (props.option == GraphicsOption::UiScale) {
+            preview->SetInnerRML(kUiScalePreviewSource);
+            preview->SetClass("active", true);
+        }
     }
     if (auto* carouselParent = mDocument->GetElementById("carousel-container")) {
         mCarousel = &add_component<SteppedCarousel>(carouselParent,

--- a/src/dusk/ui/graphics_tuner.hpp
+++ b/src/dusk/ui/graphics_tuner.hpp
@@ -44,6 +44,7 @@ enum class GraphicsOption {
     ShadowResolution,
     BloomMode,
     BloomMultiplier,
+    UiScale,
 };
 
 Rml::String format_graphics_setting_value(GraphicsOption option, int value);

--- a/src/dusk/ui/overlay.cpp
+++ b/src/dusk/ui/overlay.cpp
@@ -3,6 +3,8 @@
 #include "aurora/lib/logging.hpp"
 #include "dusk/achievements.h"
 #include "magic_enum.hpp"
+#include "menu_bar.hpp"
+#include "ui.hpp"
 #include "window.hpp"
 
 #include <SDL3/SDL_gamepad.h>
@@ -241,6 +243,16 @@ void Overlay::update() {
     }
 
     if (mFpsCounter != nullptr) {
+        const auto& docStack = get_document_stack();
+        const bool menuBarOpen = std::any_of(docStack.begin(), docStack.end(), [](const auto& doc) {
+            return dynamic_cast<const MenuBar*>(doc.get()) != nullptr && doc->visible() &&
+                   !doc->pending_close();
+        });
+        if (menuBarOpen) {
+            mFpsCounter->SetAttribute("menu-open", "");
+        } else {
+            mFpsCounter->RemoveAttribute("menu-open");
+        }
         if (getSettings().video.enableFpsOverlay.getValue()) {
             const int idx = getSettings().video.fpsOverlayCorner.getValue();
             mFpsCounter->SetAttribute("open", "");

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -19,7 +19,10 @@
 #include "prelaunch.hpp"
 #include "ui.hpp"
 
+#include <fmt/format.h>
+
 #include <algorithm>
+#include <cmath>
 
 namespace dusk::ui {
 namespace {
@@ -490,6 +493,50 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .key = "Pause on Focus Lost",
                 .isDisabled = [] { return IsMobile; },
             });
+        {
+            static const Rml::String kUiScaleHelpText =
+                "Scale all menus, the HUD overlay, and the pause menu. Useful when "
+                "playing on a TV from a distance.";
+            leftPane.register_control(
+                leftPane
+                    .add_select_button({
+                        .key = "UI Scale",
+                        .getValue =
+                            [] {
+                                const float v = getSettings().video.uiScale.getValue();
+                                return Rml::String{fmt::format(
+                                    "{}%", static_cast<int>(v * 100.0f + 0.5f))};
+                            },
+                        .isModified =
+                            [] {
+                                const auto& var = getSettings().video.uiScale;
+                                return std::abs(var.getValue() - var.getDefaultValue()) >
+                                       1e-4f;
+                            },
+                        .submit = false,
+                    })
+                    .on_nav_command([this](Rml::Event&, NavCommand cmd) {
+                        if (cmd == NavCommand::Confirm || cmd == NavCommand::Left ||
+                            cmd == NavCommand::Right) {
+                            push(std::make_unique<GraphicsTuner>(
+                                GraphicsTunerProps{
+                                    .option = GraphicsOption::UiScale,
+                                    .title = "UI Scale",
+                                    .helpText = kUiScaleHelpText,
+                                    .valueMin = 0,
+                                    .valueMax = 7,
+                                    .defaultValue = 2,
+                                },
+                                mPrelaunch));
+                            return true;
+                        }
+                        return false;
+                    }),
+                rightPane, [](Pane& pane) {
+                    pane.clear();
+                    pane.add_text(kUiScaleHelpText);
+                });
+        }
         leftPane.register_control(
             leftPane.add_select_button({
                 .key = "Show FPS Counter",

--- a/src/dusk/ui/ui.cpp
+++ b/src/dusk/ui/ui.cpp
@@ -7,11 +7,13 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cmath>
 #include <filesystem>
 #include <ranges>
 
 #include "aurora/lib/window.hpp"
 #include "dusk/io.hpp"
+#include "dusk/settings.h"
 #include "input.hpp"
 #include "prelaunch.hpp"
 #include "window.hpp"
@@ -217,6 +219,13 @@ Document* top_document() noexcept {
 void update() noexcept {
     if (!aurora::rmlui::is_initialized()) {
         return;
+    }
+
+    {
+        const float userScale = std::clamp(getSettings().video.uiScale.getValue(), 0.5f, 2.5f);
+        if (std::abs(aurora::rmlui::get_ui_scale() - userScale) > 1e-4f) {
+            aurora::rmlui::set_ui_scale(userScale);
+        }
     }
 
     input::update_input();


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft pending [encounter/aurora#169](https://github.com/encounter/aurora/pull/169).**
> The submodule pointer in this PR currently references a commit on a personal aurora fork that contains the `aurora::rmlui::set_ui_scale` API. Once the aurora PR merges, I'll re-point the submodule at upstream `encounter/aurora` and mark this ready for review.

## Summary
- Adds a new **UI Scale** option under Settings → Video with stepped presets (80% / 90% / 100% / 110% / 125% / 150% / 175% / 200%, default 100%). Persists via the existing `ConfigVar`/config system.
- Scales all RmlUi-driven surfaces (HUD overlay, popup menu bar, settings/modal windows, toasts, prelaunch UI) uniformly by multiplying the context's density-independent pixel ratio through Aurora's new `set_ui_scale` hook. No per-element changes; every `dp` length scales for free.
- Fixes the FPS overlay colliding with the Start/R popup menu bar when corner is top-left / top-right: the counter slides to `top: 76dp` while the menu bar is open, snaps back when it closes. Bottom corners untouched.
- Adds a sample-menu card preview to the UI Scale tuner page so the effect is visible while stepping through the carousel.
- ImGui debug overlays are intentionally **out of scope** (their font atlases are baked at startup; rebuilding would be a larger change). Only RmlUi scales.

## Motivation
On a 4K 55" TV viewed from sofa distance, Dusk's UI is uncomfortably small. The OS display scale is correct for desktop use but doesn't account for viewing distance, and there was no user-facing way to enlarge menus. Additionally the FPS overlay sits on top of the Start menu bar's title row when both are visible.

## Test plan
- [x] Build & run on macOS (Metal backend)
- [x] Settings → Video → UI Scale: stepping through every preset visibly grows / shrinks HUD, menus, toasts, modals, prelaunch UI; value persists across restarts
- [x] At 80% no layout breakage; at 200% no clipping in settings window
- [x] Tuner preview card grows / shrinks live with the carousel
- [x] FPS overlay (TL / TR) clears the menu bar when Start is held; snaps back when closed
- [x] FPS overlay (BL / BR) unaffected
- [x] Test on Windows / Linux backends
- [x] Verify on a real 4K display at couch distance (the original motivating use case)

## Notes
- Once aurora#169 lands, I'll bump the submodule pointer to upstream and remove the draft status.