### PR TITLE
Fix Overflow/Off-by-one. Fixes #1036 and #1012

### DIFF
--- a/include/d/d_event.h
+++ b/include/d/d_event.h
@@ -196,7 +196,7 @@ public:
     /* 0x108 */ int mSkipTimer;
     /* 0x10C */ int mSkipParameter;
     /* 0x110 */ BOOL mIsSkipFade;
-    /* 0x114 */ char mSkipEventName[20];
+    /* 0x114 */ char mSkipEventName[21];
     /* 0x128 */ u8 mCompulsory;
     /* 0x129 */ bool mRoomInfoSet;
     /* 0x12C */ int mRoomNo;

--- a/include/d/d_event.h
+++ b/include/d/d_event.h
@@ -196,7 +196,11 @@ public:
     /* 0x108 */ int mSkipTimer;
     /* 0x10C */ int mSkipParameter;
     /* 0x110 */ BOOL mIsSkipFade;
+#if TARGET_PC
     /* 0x114 */ char mSkipEventName[21];
+#else
+    /* 0x114 */ char mSkipEventName[20];
+#endif
     /* 0x128 */ u8 mCompulsory;
     /* 0x129 */ bool mRoomInfoSet;
     /* 0x12C */ int mRoomNo;


### PR DESCRIPTION
As seen in #1036 and #1012 20 is simply not enough space for some event names. Unsure if there's yet longer ones, but the length of the event names is 20 + Terminator, or 21.

