### PR TITLE
Add TARGET_PC accessor daE_OC_c::getSphsAt() for mod use

### DIFF
--- a/include/d/actor/d_a_e_oc.h
+++ b/include/d/actor/d_a_e_oc.h
@@ -87,6 +87,15 @@ public:
     daE_OC_c* getTalkOc() { return mpTalk; }
     J3DModel* getOcModel() { return mpMorf->getModel(); }
 
+#if TARGET_PC
+    // Accessor for the attack-collision spheres so mods can adjust the
+    // attack-power (Atp) without depending on layout offsets — the original
+    // PowerPC offsets don't survive x64 ABI changes through the multiple-
+    // inheritance chain of dCcD_Sph, and decomp's STATIC_ASSERT is a no-op
+    // on non-MWERKS builds so the mismatch isn't caught at compile time.
+    dCcD_Sph* getSphsAt() { return mSphs_at; }
+#endif
+
 private:
     /* 0x5a0 */ request_of_phase_process_class mPhaseReqs[2];
     /* 0x5bc */ mDoExt_McaMorfSO* mpMorf;


### PR DESCRIPTION
Mods that adjust a Bokoblin's attack-collision spheres (e.g. to scale attack-power Atp at spawn) need access to mSphs_at, which is private. Reaching it via the documented PowerPC layout offset does not work on x64: dCcD_Sph's multiple-inheritance chain with 8-byte vtable pointers changes its size (~440 bytes on MSVC vs 312 on PowerPC), shifting mSphs_at's offset within daE_OC_c. Decomp's STATIC_ASSERT(sizeof(...) == 0xN) is a no-op outside MWERKS, so the mismatch is not caught at compile time and the mod silently writes to unrelated memory.

This adds a one-line public accessor returning the existing array, gated #if TARGET_PC so decomp-matching PowerPC builds are untouched.