### PR TITLE
Don't slow down underwater rolling if the fastIronBoots cheat is on.

### DIFF
--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -16146,7 +16146,6 @@ int daAlink_c::procFrontRollInit() {
 
     if (checkNoResetFlg0(FLG0_WATER_IN_MOVE)) {
 #if TARGET_PC
-        // Encasing the following statemet in a new block because I've seen precedence for it in the source.
         if (!(dusk::getSettings().game.enableFastIronBoots))
 #endif
         {

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -16145,7 +16145,13 @@ int daAlink_c::procFrontRollInit() {
     }
 
     if (checkNoResetFlg0(FLG0_WATER_IN_MOVE)) {
-        mNormalSpeed *= mpHIO->mItem.mIronBoots.m.mWaterVelocityX;
+#if TARGET_PC
+        // Encasing the following statemet in a new block because I've seen precedence for it in the source.
+        if (!(dusk::getSettings().game.enableFastIronBoots))
+#endif
+        {
+            mNormalSpeed *= mpHIO->mItem.mIronBoots.m.mWaterVelocityX;
+        }
     } else if (checkHeavyStateOn(TRUE, TRUE)) {
         mNormalSpeed *= mHeavySpeedMultiplier;
     }
@@ -16280,8 +16286,13 @@ int daAlink_c::procFrontRollCrashInit() {
     speed.y = mpHIO->mFrontRoll.m.mCrashSpeedV;
 
     if (checkNoResetFlg0(FLG0_WATER_IN_MOVE)) {
-        mNormalSpeed *= mpHIO->mItem.mIronBoots.m.mWaterVelocityX;
-        speed.y *= mpHIO->mItem.mIronBoots.m.mWaterVelocityY;
+#if TARGET_PC
+        if (!(dusk::getSettings().game.enableFastIronBoots))
+#endif
+        {
+            mNormalSpeed *= mpHIO->mItem.mIronBoots.m.mWaterVelocityX;
+            speed.y *= mpHIO->mItem.mIronBoots.m.mWaterVelocityY;
+        }
     }
 
     ANGLE_ADD_2(current.angle.y, 0x8000);
@@ -16398,7 +16409,12 @@ int daAlink_c::procSideRollInit(int param_0) {
     mNormalSpeed = mpHIO->mGuard.mTurnMove.m.mSideRollSpeed;
 
     if (checkNoResetFlg0(FLG0_WATER_IN_MOVE)) {
-        mNormalSpeed *= mpHIO->mItem.mIronBoots.m.mWaterVelocityX;
+#if TARGET_PC
+        if (!(dusk::getSettings().game.enableFastIronBoots))
+#endif
+        {
+            mNormalSpeed *= mpHIO->mItem.mIronBoots.m.mWaterVelocityX;
+        }
     } else if (checkHeavyStateOn(TRUE, TRUE)) {
         mNormalSpeed *= mHeavySpeedMultiplier;
     }


### PR DESCRIPTION
Familiarizing myself with the code base to hopefully help out later, but adding this now because it annoyed me a little when I was playing around with cheats.

I'm not sure if adding a new block outside of the `#if TARGET_PC` sections is a good idea, especially if the sections outside dusk only macros are meant to be 1-to-1 with the upstream decomp project, which I imagine would put more emphasis on source binary reproducibility and this is one of those things that a compiler may naively change things around for, although I doubt it will, but I saw some precedents in the source with this, so I'm assuming it's alright.

**Not** a tested commit.