### PR TITLE
feat: auto-activate portable mode when 'portable/' folder exists next to executable

### DIFF
--- a/src/dusk/data.cpp
+++ b/src/dusk/data.cpp
@@ -124,14 +124,6 @@ std::filesystem::path base_path_relative(const std::filesystem::path& path) {
     return std::filesystem::path{basePath} / path;
 }
 
-std::filesystem::path host_path_relative(const std::filesystem::path& path) {
-    const auto dir = host_dir();
-    if (dir.empty()) {
-        return {};
-    }
-    return dir / path;
-}
-
 std::filesystem::path default_data_path(const std::filesystem::path& prefPath) {
 #ifdef __APPLE__
 #if TARGET_OS_IOS && !TARGET_OS_TV
@@ -910,6 +902,14 @@ void ensure_initial_pipeline_cache(const std::filesystem::path& configDir) {
 }
 
 }  // namespace
+
+std::filesystem::path host_path_relative(const std::filesystem::path& path) {
+    const auto dir = host_dir();
+    if (dir.empty()) {
+        return {};
+    }
+    return dir / path;
+}
 
 bool open_data_path() {
 #if DUSK_CAN_OPEN_DATA_FOLDER

--- a/src/dusk/data.cpp
+++ b/src/dusk/data.cpp
@@ -120,7 +120,17 @@ std::filesystem::path default_data_path(const std::filesystem::path& prefPath) {
 }
 
 std::filesystem::path portable_data_path() {
-    return base_path_relative("data");
+    return base_path_relative("portable");
+}
+
+// Returns the portable path if a 'portable' folder exists next to the executable, otherwise empty.
+std::filesystem::path auto_detect_portable_path() {
+    const auto path = portable_data_path();
+    if (path.empty()) {
+        return {};
+    }
+    std::error_code ec;
+    return std::filesystem::is_directory(path, ec) ? path : std::filesystem::path{};
 }
 
 std::vector<std::filesystem::path> descriptor_paths(const std::filesystem::path& prefPath) {
@@ -931,6 +941,11 @@ std::filesystem::path configured_data_path() {
         return *sConfiguredDataPath;
     }
 
+    if (const auto portablePath = auto_detect_portable_path(); !portablePath.empty()) {
+        sConfiguredDataPath = portablePath;
+        return *sConfiguredDataPath;
+    }
+
     const auto prefPath = get_pref_path();
     const auto descriptor = read_location_descriptor(prefPath);
     if (descriptor) {
@@ -950,6 +965,14 @@ bool is_data_path_restart_pending() {
 }
 
 std::filesystem::path initialize_data() {
+    if (const auto portablePath = auto_detect_portable_path(); !portablePath.empty()) {
+        sActiveDescriptorPath.reset();
+        sConfiguredDataPath = portablePath;
+        ensure_data_directory(portablePath);
+        ensure_initial_pipeline_cache(portablePath);
+        return portablePath;
+    }
+
     const auto prefPath = get_pref_path();
     const auto descriptor = read_location_descriptor(prefPath);
     if (descriptor) {

--- a/src/dusk/data.cpp
+++ b/src/dusk/data.cpp
@@ -96,12 +96,40 @@ std::filesystem::path get_pref_path() {
     return result;
 }
 
+// Returns the directory that contains the running executable or AppImage file.
+// For AppImages, SDL_GetBasePath() points into the temporary mount, not the real location.
+// The APPIMAGE env var holds the actual .AppImage path, so we use its parent instead.
+static std::filesystem::path host_dir() {
+    if (const char* appimage = std::getenv("APPIMAGE");
+        appimage != nullptr && appimage[0] != '\0')
+    {
+        std::error_code ec;
+        auto dir = std::filesystem::path(appimage).parent_path();
+        if (std::filesystem::is_directory(dir, ec)) {
+            return dir;
+        }
+    }
+    const auto* basePath = SDL_GetBasePath();
+    if (!basePath) {
+        return {};
+    }
+    return std::filesystem::path{basePath};
+}
+
 std::filesystem::path base_path_relative(const std::filesystem::path& path) {
     const auto* basePath = SDL_GetBasePath();
     if (!basePath) {
         return path;
     }
     return std::filesystem::path{basePath} / path;
+}
+
+std::filesystem::path host_path_relative(const std::filesystem::path& path) {
+    const auto dir = host_dir();
+    if (dir.empty()) {
+        return {};
+    }
+    return dir / path;
 }
 
 std::filesystem::path default_data_path(const std::filesystem::path& prefPath) {
@@ -123,9 +151,9 @@ std::filesystem::path portable_data_path() {
     return base_path_relative("portable");
 }
 
-// Returns the portable path if a 'portable' folder exists next to the executable, otherwise empty.
+// Returns the portable path if a 'portable' folder exists next to the executable/AppImage, otherwise empty.
 std::filesystem::path auto_detect_portable_path() {
-    const auto path = portable_data_path();
+    const auto path = host_path_relative("portable");
     if (path.empty()) {
         return {};
     }

--- a/src/dusk/data.hpp
+++ b/src/dusk/data.hpp
@@ -22,6 +22,7 @@
 
 namespace dusk::data {
 
+std::filesystem::path host_path_relative(const std::filesystem::path& path);
 std::filesystem::path initialize_data();
 std::filesystem::path configured_data_path();
 bool open_data_path();

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -42,6 +42,8 @@
 #include "SSystem/SComponent/c_counter.h"
 #include <cstring>
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <system_error>
 #include <thread>
@@ -607,6 +609,45 @@ int game_main(int argc, char* argv[]) {
         } else {
             DuskLog.warn("DVD image from command line failed validation: {}, opening prelaunch UI", dvd_path);
             forcePreLaunchUI = true;
+        }
+    }
+
+    // Auto-detect a disc image next to the AppImage/executable when none was specified.
+    if (!dvd_opened && !parsed_arg_options.count("dvd")) {
+        static constexpr std::string_view kDiscExtensions[] = {
+            ".rvz", ".iso", ".gcm", ".wia", ".ciso", ".gcz", ".wbfs",
+        };
+        const auto hostDir = dusk::data::host_path_relative(".");
+        if (!hostDir.empty()) {
+            std::error_code ec;
+            for (const auto& entry : std::filesystem::directory_iterator(hostDir, ec)) {
+                if (!entry.is_regular_file(ec)) {
+                    continue;
+                }
+                const auto ext = entry.path().extension().string();
+                const bool isDisc = std::any_of(std::begin(kDiscExtensions), std::end(kDiscExtensions),
+                    [&ext](std::string_view e) {
+                        return std::equal(ext.begin(), ext.end(), e.begin(), e.end(),
+                            [](char a, char b) { return std::tolower(a) == b; });
+                    });
+                if (!isDisc) {
+                    continue;
+                }
+                const auto candidate = dusk::io::fs_path_to_string(entry.path());
+                if (dusk::iso::inspect(candidate.c_str(), discInfo) == dusk::iso::ValidationError::Success) {
+                    DuskLog.info("Auto-detected disc image: {}", candidate);
+                    dvd_path = candidate;
+                    dvd_opened = aurora_dvd_open(dvd_path.c_str());
+                    if (dvd_opened) {
+                        dusk::getSettings().backend.isoPath.setValue(dvd_path);
+                        dusk::getSettings().backend.isoVerification.setValue(
+                            dusk::DiscVerificationState::Unknown);
+                        dusk::config::Save();
+                        dusk::IsGameLaunched = true;
+                    }
+                    break;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `host_dir()`: resolves the directory containing the AppImage file via the \`\$APPIMAGE\` env var (falls back to \`SDL_GetBasePath()\` for native executables — \`SDL_GetBasePath\` points to the temporary mount point inside an AppImage, not the actual file location)
- Adds public `host_path_relative()` in \`data.hpp\`
- Auto-portable detection in \`initialize_data()\` and \`configured_data_path()\` now uses \`host_path_relative\` so the \`portable/\` folder is resolved relative to the AppImage file on disk
- Auto-scans the host directory for disc images (\`.rvz\`/\`.iso\`/\`.gcm\`/\`.wia\`/\`.ciso\`/\`.gcz\`/\`.wbfs\`) at startup when no \`--dvd\` argument is provided; opens the first valid one found

## Behaviour

Place a \`portable/\` folder next to the AppImage → all data is stored there automatically.  
Place the disc image next to the AppImage → it is opened automatically without a file picker.

Both features require no flags, no config, no marker files.

## Motivation

AppImage + portable folder + disc image in the same directory: one folder to copy, everything works out of the box. Consistent with how projects like Eden handle portability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)