### PR TITLE
set sdl app metadata when initializing audio

### DIFF
--- a/src/dusk/audio/DuskAudioSystem.cpp
+++ b/src/dusk/audio/DuskAudioSystem.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cassert>
 #include <span>
+#include <version.h>
 
 #include "JSystem/JAudio2/JASAiCtrl.h"
 #include "JSystem/JAudio2/JASChannel.h"
@@ -45,6 +46,7 @@ static int RenderNewAudioFrame();
 static void RenderAudioSubframe();
 
 static void InitSDL3Output() {
+    SDL_SetAppMetadata("Dusklight", DUSK_VERSION_STRING, "dev.twilitrealm.dusklight");
     SDL_Init(SDL_INIT_AUDIO);
 
     constexpr SDL_AudioSpec spec = {

--- a/src/dusk/audio/DuskAudioSystem.cpp
+++ b/src/dusk/audio/DuskAudioSystem.cpp
@@ -4,7 +4,6 @@
 #include <array>
 #include <cassert>
 #include <span>
-#include <version.h>
 
 #include "JSystem/JAudio2/JASAiCtrl.h"
 #include "JSystem/JAudio2/JASChannel.h"
@@ -46,7 +45,6 @@ static int RenderNewAudioFrame();
 static void RenderAudioSubframe();
 
 static void InitSDL3Output() {
-    SDL_SetAppMetadata("Dusklight", DUSK_VERSION_STRING, "dev.twilitrealm.dusklight");
     SDL_Init(SDL_INIT_AUDIO);
 
     constexpr SDL_AudioSpec spec = {

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -71,6 +71,7 @@
 #include <aurora/dvd.h>
 #include <dolphin/dvd.h>
 
+#include "SDL3/SDL_init.h"
 #include "SDL3/SDL_filesystem.h"
 #include "SDL3/SDL_iostream.h"
 #include "SDL3/SDL_misc.h"
@@ -523,6 +524,9 @@ int game_main(int argc, char* argv[]) {
             DuskLog.warn("Failed to load gamecontrollerdb.txt: {}", SDL_GetError());
         }
     }
+
+    // Set SDL metadata for audio mixers and macOS "About" menu
+    SDL_SetAppMetadata("Dusklight", DUSK_VERSION_STRING, "dev.twilitrealm.dusk");
 
     {
         const auto configPathString = dusk::ConfigPath.u8string();


### PR DESCRIPTION
The Dusklight SDL audio source appears as "SDL Application" in Pipewire audio mixers.
<img width="273" height="100" alt="05-12-26 06 20 22 PM" src="https://github.com/user-attachments/assets/9d87f9de-90a2-4b1d-bbcf-8e8d11a9b43d" />
This PR calls SDL_SetAppMetadata() before initializing the SDL audio source in order to give the audio source a proper name.
<img width="256" height="117" alt="image" src="https://github.com/user-attachments/assets/fa536195-e0f9-465d-9ebe-d89593756b58" />
