### PR TITLE
Fix LJA achievement triggering from cutscene teleport

### DIFF
--- a/src/dusk/achievements.cpp
+++ b/src/dusk/achievements.cpp
@@ -692,6 +692,12 @@ std::vector<AchievementSystem::Entry> AchievementSystem::makeEntries() {
                     return;
                 }
 
+                // prevent stuff like https://github.com/TwilitRealm/dusklight/issues/949
+                if (link->getDemoMode() != 0) {
+                    inJump = false;
+                    return;
+                }
+
                 if (!inJump) {
                     if (link->mProcID == daAlink_c::PROC_CUT_JUMP) {
                         inJump = true;


### PR DESCRIPTION
Attempt to fix #949 by invalidating the achievement whenever a cutscene starts. A bit blunt, but a  LJA shouldn't generally overlap with one anyway ?