### PR TITLE
Add support for portable mode in Dusk

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -93,6 +93,18 @@ Alternate presets available:
 #### Running
 Pass the disc image as a positional argument. Supported formats: ISO (GCM), RVZ, WIA, WBFS, CISO, GCZ
 ```sh
-build/{preset}/dusklight/path/to/game.rvz
+build/{preset}/dusklight /path/to/game.rvz
 ```
 If no path is specified, Dusklight defaults to `game.iso` in the current working directory.
+
+
+#### Portable
+To keep settings, saves, logs, and cache next to the executable, launch with `--portable`.
+Portable mode uses a sibling `data` folder.
+
+```sh
+build/{preset}/dusklight --portable /path/to/game.rvz
+```
+
+You can also create a `portable.txt` file next to the executable to enable portable mode
+automatically.

--- a/src/dusk/data.cpp
+++ b/src/dusk/data.cpp
@@ -29,6 +29,7 @@ aurora::Module Log{"dusk::data"};
 constexpr auto kLocationDescriptorName = "data_location.json";
 constexpr auto kPipelineCacheName = "pipeline_cache.db";
 constexpr auto kInitialPipelineCacheName = "initial_pipeline_cache.db";
+constexpr auto kPortableMarkerName = "portable.txt";
 
 enum class LocationMode {
     Default,
@@ -121,6 +122,16 @@ std::filesystem::path default_data_path(const std::filesystem::path& prefPath) {
 
 std::filesystem::path portable_data_path() {
     return base_path_relative("data");
+}
+
+bool portable_marker_exists() {
+#if defined(__ANDROID__) || (defined(TARGET_OS_IOS) && TARGET_OS_IOS) ||                           \
+    (defined(TARGET_OS_TV) && TARGET_OS_TV)
+    return false;
+#else
+    std::error_code ec;
+    return std::filesystem::is_regular_file(base_path_relative(kPortableMarkerName), ec);
+#endif
 }
 
 std::vector<std::filesystem::path> descriptor_paths(const std::filesystem::path& prefPath) {
@@ -949,7 +960,16 @@ bool is_data_path_restart_pending() {
     return normalized_path(ConfigPath) != normalized_path(configured_data_path());
 }
 
-std::filesystem::path initialize_data() {
+std::filesystem::path initialize_data(bool portableMode) {
+    if (portableMode || portable_marker_exists()) {
+        const auto dataPath = portable_data_path();
+        sActiveDescriptorPath.reset();
+        sConfiguredDataPath = dataPath;
+        ensure_data_directory(dataPath);
+        ensure_initial_pipeline_cache(dataPath);
+        return dataPath;
+    }
+
     const auto prefPath = get_pref_path();
     const auto descriptor = read_location_descriptor(prefPath);
     if (descriptor) {

--- a/src/dusk/data.hpp
+++ b/src/dusk/data.hpp
@@ -22,7 +22,7 @@
 
 namespace dusk::data {
 
-std::filesystem::path initialize_data();
+std::filesystem::path initialize_data(bool portableMode = false);
 std::filesystem::path configured_data_path();
 bool open_data_path();
 bool set_custom_data_path(const char* path);

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -490,6 +490,7 @@ int game_main(int argc, char* argv[]) {
             ("l,log-level", "Log level from " + std::to_string(AuroraLogLevel::LOG_DEBUG) + " to " + std::to_string(AuroraLogLevel::LOG_FATAL), cxxopts::value<uint8_t>()->default_value("0"))
             ("h,help", "Print usage")
             ("console", "Show the Windows console window for logs", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
+            ("portable", "Store settings, saves, logs, and cache in a data folder next to the executable", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
             ("dvd", "Path to DVD image file", cxxopts::value<std::string>())
             ("backend", "Graphics API backend to use (auto, d3d12, metal, vulkan, null)", cxxopts::value<std::string>())
             ("cvar", "Override configuration variables without modifying config", cxxopts::value<std::vector<std::string>>());
@@ -513,7 +514,7 @@ int game_main(int argc, char* argv[]) {
 
     const auto startupLogLevel =
         static_cast<AuroraLogLevel>(parsed_arg_options["log-level"].as<uint8_t>());
-    dusk::ConfigPath = dusk::data::initialize_data();
+    dusk::ConfigPath = dusk::data::initialize_data(parsed_arg_options["portable"].as<bool>());
     dusk::InitializeFileLogging(dusk::ConfigPath, startupLogLevel);
 
     log_build_info();


### PR DESCRIPTION
## Title

Add portable data folder startup support

## Summary

Adds startup-level portable mode support so Dusklight can keep user data next to the executable.

- Add a `--portable` command-line option.
- Add `portable.txt` marker support next to the executable.
- Use a sibling `data` folder for settings, saves, logs, and cache in portable mode.
- Avoid touching the platform preference path when portable mode is selected at startup.
- Document portable usage in `docs/building.md`.

## Notes

This is separate from the existing Data Folder / Portable Mode setting UI. The startup flag and marker file are intended for packaged portable builds or users who want portable behavior before preferences are loaded.

This implementation is partially inspired by Dolphin Emulator's portable mode behavior.


## Testing

- Ran `git diff --check`.
- Checked for conflict markers.
