### PR TITLE
Invert Air/Swim Axes

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -150,6 +150,8 @@ struct UserSettings {
         ConfigVar<bool> invertCameraYAxis;
         ConfigVar<bool> invertFirstPersonXAxis;
         ConfigVar<bool> invertFirstPersonYAxis;
+        ConfigVar<bool> invertAirSwimX;
+        ConfigVar<bool> invertAirSwimY;
         ConfigVar<float> freeCameraSensitivity;
         ConfigVar<bool> debugFlyCam;
         ConfigVar<bool> debugFlyCamLockEvents;

--- a/src/d/actor/d_a_alink_swim.inc
+++ b/src/d/actor/d_a_alink_swim.inc
@@ -216,7 +216,7 @@ void daAlink_c::setSpeedAndAngleSwim() {
             if (checkEventRun()) {
                 var_r28 = mMoveAngle;
             } else {
-                var_r28 = shape_angle.y + (16384.0f * cM_ssin(mStickAngle));
+                var_r28 = shape_angle.y + (16384.0f * cM_ssin(mStickAngle) IF_DUSK(* (dusk::getSettings().game.invertAirSwimX ? -1.0f : 1.0f)));
             }
 
             cLib_addCalcAngleS(&shape_angle.y, var_r28, mpHIO->mSwim.m.mUnderwaterTurnRate, mpHIO->mSwim.m.mUnderwaterMaxTurn, mpHIO->mSwim.m.mUnderwaterMinTurn);
@@ -835,7 +835,7 @@ void daAlink_c::setSwimMoveAnime() {
         } else {
             s16 var_r24;
             if (checkInputOnR() && !checkEventRun()) {
-                var_r24 = 13653.0f * cM_scos(mStickAngle);
+                var_r24 = 13653.0f * cM_scos(mStickAngle) IF_DUSK(* (dusk::getSettings().game.invertAirSwimY ? -1.0f : 1.0f));
             } else {
                 var_r24 = 0;
             }

--- a/src/d/actor/d_a_kago.cpp
+++ b/src/d/actor/d_a_kago.cpp
@@ -3530,6 +3530,15 @@ void daKago_c::action() {
 #endif
     mStickY = mDoCPd_c::getStickY(PAD_1);
 
+#ifdef TARGET_PC
+    if(dusk::getSettings().game.invertAirSwimX) {
+        mStickX = -mStickX;
+    }
+    if(dusk::getSettings().game.invertAirSwimY) {
+        mStickY = -mStickY;
+    }
+#endif
+
     u8 prevIsWaterfall = mIsWaterfall;
     mIsWaterfall = FALSE;
     fpcM_Search(s_waterfall, this);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -85,6 +85,8 @@ UserSettings g_userSettings = {
         .invertCameraYAxis {"game.invertCameraYAxis", false},
         .invertFirstPersonXAxis {"game.invertFirstPersonXAxis", false},
         .invertFirstPersonYAxis {"game.invertFirstPersonYAxis", false},
+        .invertAirSwimX {"game.invertAirSwimX", false},
+        .invertAirSwimY {"game.invertAirSwimY", false},
         .freeCameraSensitivity {"game.freeCameraSensitivity", 1.0f},
         .debugFlyCam {"game.debugFlyCam", false},
         .debugFlyCamLockEvents {"game.debugFlyCamLockEvents", true},
@@ -209,6 +211,8 @@ void registerSettings() {
     Register(g_userSettings.game.invertCameraYAxis);
     Register(g_userSettings.game.invertFirstPersonXAxis);
     Register(g_userSettings.game.invertFirstPersonYAxis);
+    Register(g_userSettings.game.invertAirSwimX);
+    Register(g_userSettings.game.invertAirSwimY);
     Register(g_userSettings.game.freeCameraSensitivity);
     Register(g_userSettings.game.minimalHUD);
     Register(g_userSettings.game.pauseOnFocusLost);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -819,6 +819,10 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             "Invert horizontal movement while aiming with items or first person camera. Applies only to the control stick (the gyroscope can be inverted in Input settings).");
         addOption("Invert First Person Y Axis", getSettings().game.invertFirstPersonYAxis,
             "Invert vertical movement while aiming with items or first person camera. Applies only to the control stick (the gyroscope can be inverted in Input settings).");
+        addOption("Invert Air/Swim X Axis", getSettings().game.invertAirSwimX,
+            "Invert horizontal movement while flying or swimming.");
+        addOption("Invert Air/Swim Y Axis", getSettings().game.invertAirSwimY,
+            "Invert vertical movement while flying or swimming.");
 
         leftPane.add_section("Gyro");
         leftPane.register_control(


### PR DESCRIPTION
Apparently this is a setting HD has...

Currently only affects swimming, need to look for the flying code (will remain draft until then). Option name is based on HD but I'm open to changing it if we think another wording is more clear, also haven't seen like anyone ask for this so totally fine if it's closed to avoid menu clutter.