### PR TITLE
Slingshot Cheat Speedrun Mode FIx

### DIFF
--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -184,6 +184,7 @@ void reset_for_speedrun_mode() {
 
     getSettings().game.infiniteHearts.setSpeedrunValue(false);
     getSettings().game.infiniteArrows.setSpeedrunValue(false);
+    getSettings().game.infiniteSeeds.setSpeedrunValue(false);
     getSettings().game.infiniteBombs.setSpeedrunValue(false);
     getSettings().game.infiniteOil.setSpeedrunValue(false);
     getSettings().game.infiniteOxygen.setSpeedrunValue(false);


### PR DESCRIPTION
Forgot to set it in one of the speedrun mode functions (having two makes this really easy to miss, might be worth trying to consolidate these?)