### PR TITLE
Speedrun mode hotfixes

### DIFF
--- a/include/dusk/config_var.hpp
+++ b/include/dusk/config_var.hpp
@@ -285,6 +285,16 @@ public:
             layer = ConfigVarLayer::Value;
         }
     }
+
+    /**
+     * \brief Get the user-persisted value, ignoring any temporary overrides.
+     *
+     * Used by Save() to write the correct value even when a speedrun override is active.
+     */
+    [[nodiscard]] constexpr const T& getValueForSave() const noexcept {
+        checkRegistered();
+        return layer == ConfigVarLayer::Default ? defaultValue : value;
+    }
 };
 
 using ActionBindConfigVar = ConfigVar<int>;

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -61,7 +61,7 @@ void ConfigImpl<T>::loadFromJson(ConfigVar<T>& cVar, const json& jsonValue) {
 
 template<ConfigValue T>
 nlohmann::json ConfigImpl<T>::dumpToJson(const ConfigVar<T>& cVar) {
-    return cVar.getValue();
+    return cVar.getValueForSave();
 }
 
 template<ConfigValue T> requires std::is_integral_v<T> && std::is_signed_v<T>
@@ -249,7 +249,8 @@ void dusk::config::Save() {
     json j;
 
     for (const auto& pair : RegisteredConfigVars) {
-        if (pair.second->getLayer() == ConfigVarLayer::Value) {
+        const auto layer = pair.second->getLayer();
+        if (layer == ConfigVarLayer::Value || layer == ConfigVarLayer::Speedrun) {
             j[pair.first] = pair.second->getImpl()->dumpToJson(*pair.second);
         }
     }

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -80,6 +80,7 @@
 #include "dusk/audio/DuskAudioSystem.h"
 #include "dusk/audio/DuskDsp.hpp"
 #include "dusk/config.hpp"
+#include "dusk/speedrun.h"
 #include "dusk/settings.h"
 #include "dusk/io.hpp"
 #include "dusk/version.hpp"
@@ -519,6 +520,9 @@ int game_main(int argc, char* argv[]) {
     log_build_info();
 
     dusk::config::LoadFromUserPreferences();
+    if (dusk::getSettings().game.speedrunMode) {
+        dusk::resetForSpeedrunMode();
+    }
     ApplyCVarOverrides(parsed_arg_options["cvar"]);
     dusk::crash_reporting::initialize();
     // TODO: How to handle this?


### PR DESCRIPTION
- Speedrun overrides would save to disk when toggling on and off speedrun mode
- Speedrun overrides wouldn't properly set on start when starting in speedrun mode