### PR TITLE
1.1.1 fixes

### DIFF
--- a/include/dusk/audio/DuskAudioSystem.h
+++ b/include/dusk/audio/DuskAudioSystem.h
@@ -1,8 +1,19 @@
 #pragma once
 
+#include <cmath>
 #include <dolphin/types.h>
 
 namespace dusk::audio {
+
+    // Converts a 0-1 volume to a linear amplitude multiplier.
+    // The curve is -4 dB per 10% step: 100% = 0 dB, 90% = -4 dB, ..., 0% = -inf dB
+    inline f32 MasterVolumeToLinear(f32 v) {
+        if (v <= 0.0f) {
+            return 0.0f;
+        }
+        return std::pow(10.0f, (v - 1.0f) * 2.0f);
+    }
+
     /**
      * Initialize the audio system and start playing audio.
      */

--- a/include/dusk/config_var.hpp
+++ b/include/dusk/config_var.hpp
@@ -175,6 +175,7 @@ class ConfigVar : public ConfigVarBase {
     T defaultValue;
     T value;
     T overrideValue;
+    ConfigVarLayer priorLayer = ConfigVarLayer::Default;
 
 public:
     /**
@@ -265,6 +266,7 @@ public:
     void setSpeedrunValue(T newValue) {
         checkRegistered();
         if (layer != ConfigVarLayer::Override) {
+            priorLayer = layer;
             overrideValue = std::move(newValue);
             layer = ConfigVarLayer::Speedrun;
         }
@@ -282,7 +284,7 @@ public:
         checkRegistered();
         if (layer == ConfigVarLayer::Speedrun) {
             overrideValue = {};
-            layer = ConfigVarLayer::Value;
+            layer = priorLayer;
         }
     }
 
@@ -293,7 +295,8 @@ public:
      */
     [[nodiscard]] constexpr const T& getValueForSave() const noexcept {
         checkRegistered();
-        return layer == ConfigVarLayer::Default ? defaultValue : value;
+        const ConfigVarLayer effectiveLayer = (layer == ConfigVarLayer::Speedrun) ? priorLayer : layer;
+        return effectiveLayer == ConfigVarLayer::Default ? defaultValue : value;
     }
 };
 

--- a/src/d/actor/d_a_alink_swindow.inc
+++ b/src/d/actor/d_a_alink_swindow.inc
@@ -77,7 +77,12 @@ int daAlink_c::loadModelDVD() {
             mpWlMidnaHairModel = NULL;
 
             if (!checkNoResetFlg2(FLG2_UNK_280000)) {
-                dComIfG_resDelete(&mPhaseReq, mArcName);
+                if (!dComIfG_resDelete(&mPhaseReq, mArcName)) {
+#if TARGET_PC
+                    // resDelete no-ops if load was in-progress; force-unregister before freeAll
+                    dComIfG_deleteObjectResMain(mArcName);
+#endif
+                }
                 cPhs_Reset(&mPhaseReq);
                 mpArcHeap->freeAll();
 

--- a/src/d/actor/d_a_alink_wolf.inc
+++ b/src/d/actor/d_a_alink_wolf.inc
@@ -8723,6 +8723,12 @@ int daAlink_c::procWolfCargoCarry() {
             return checkNextActionWolf(0);
         }
 
+#if TARGET_PC
+        if (field_0x280c.getActor() == NULL) {
+            return checkNextActionWolf(0);
+        }
+#endif
+
         mDoMtx_stack_c::copy(((e_yc_class*)field_0x280c.getActor())->getLegR3Mtx());
         mDoMtx_stack_c::transM(-9.0f, -7.0f, -30.0f);
         mDoMtx_stack_c::multVecZero(&current.pos);

--- a/src/d/d_ev_camera.cpp
+++ b/src/d/d_ev_camera.cpp
@@ -3882,7 +3882,11 @@ bool dCamera_c::hintTalkEvCamera() {
 
         cSAngle acStack_1fc(20.0f);
         for (i = 0; i < 2; i++) {
+#if AVOID_UB
+            for (j = 0; j < 10; j++) {
+#else
             for (j = 0; j < 12; j++) {
+#endif
                 cSAngle acStack_200(local_b0[j] * fVar22);
                 hintTalk->mDirection.U(acStack_1f8 + acStack_200);
                 hintTalk->mDirection.V(((hintTalk->field_0x28.V() * acStack_200.Cos()) * 0.2f) + acStack_1fc);

--- a/src/dusk/autosave.cpp
+++ b/src/dusk/autosave.cpp
@@ -26,8 +26,12 @@ void updateAutoSave() {
     (AutoSaveFuncsProc[mAutoSaveProc])();
 }
 
-void writeAutoSave() {
-    int stageNo = dStage_stagInfo_GetSaveTbl(dComIfGp_getStageStagInfo());
+bool writeAutoSave() {
+    stage_stag_info_class* stagInfo = dComIfGp_getStageStagInfo();
+    if (stagInfo == nullptr) {
+        return false;
+    }
+    int stageNo = dStage_stagInfo_GetSaveTbl(stagInfo);
 
     dComIfGs_putSave(stageNo);
     dComIfGs_setMemoryToCard(mSaveBuffer, dComIfGs_getDataNum());
@@ -40,6 +44,7 @@ void writeAutoSave() {
     }
 
     g_mDoMemCd_control.save(mSaveBuffer, sizeof(mSaveBuffer), 0);
+    return true;
 }
 
 void autoSaving() {
@@ -48,8 +53,9 @@ void autoSaving() {
         if (cardState == 2) {
             mAutoSaveProc = 1;
         } else if (cardState == 1) {
-            writeAutoSave();
-            mAutoSaveProc = 3;
+            if (writeAutoSave()) {
+                mAutoSaveProc = 3;
+            }
         }
     }
 }

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -13,7 +13,7 @@ UserSettings g_userSettings = {
     },
 
     .audio = {
-        .masterVolume {"audio.masterVolume", 80},
+        .masterVolume {"audio.masterVolume", 60},
         .mainMusicVolume {"audio.mainMusicVolume", 100},
         .subMusicVolume {"audio.subMusicVolume", 100},
         .soundEffectsVolume {"audio.soundEffectsVolume", 100},

--- a/src/dusk/ui/overlay.cpp
+++ b/src/dusk/ui/overlay.cpp
@@ -354,8 +354,9 @@ void Overlay::update() {
         }
     }
 
+    u32 count = 0;
     const bool showControllerWarning = PADGetIndexForPort(PAD_CHAN0) < 0 &&
-                                       PADGetKeyButtonBindings(PAD_CHAN0, nullptr) == nullptr &&
+                                       PADGetKeyButtonBindings(PAD_CHAN0, &count) == nullptr &&
                                        dynamic_cast<Window*>(top_document()) == nullptr &&
                                        dynamic_cast<WindowSmall*>(top_document()) == nullptr;
     if (showControllerWarning && mControllerWarning == nullptr) {

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -953,7 +953,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                     [](int value) {
                         getSettings().audio.masterVolume.setValue(value);
                         config::Save();
-                        audio::SetMasterVolume(value / 100.f);
+                        audio::SetMasterVolume(audio::MasterVolumeToLinear(value / 100.0f));
                     },
                 .isModified =
                     [] {

--- a/src/f_pc/f_pc_base.cpp
+++ b/src/f_pc/f_pc_base.cpp
@@ -136,8 +136,17 @@ base_process_class* fpcBs_Create(s16 i_profname, fpc_ProcID i_procID, void* i_ap
     u32 size;
 
     pprofile = (process_profile_definition*)fpcPf_Get(i_profname);
+    if (pprofile == NULL) {
+#if TARGET_PC
+        DuskLog.debug("fpcBs_Create: profile not found for profname={}", i_profname);
+#endif
+        return NULL;
+    }
+#if TARGET_PC
+    const char* procName = getProcName(i_profname);
     DuskLog.debug("fpcBs_Create: pid={} profname={} ({}) profile={} procSize={} unkSize={}",
-           i_procID, getProcName(i_profname), i_profname, (void*)pprofile, pprofile->process_size, pprofile->unk_size);
+           i_procID, procName ? procName : "(unknown)", i_profname, (void*)pprofile, pprofile->process_size, pprofile->unk_size);
+#endif
     size = pprofile->process_size + pprofile->unk_size;
 
     pprocess = (base_process_class*)cMl::memalignB(-4, size);

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -585,7 +585,7 @@ int game_main(int argc, char* argv[]) {
     }
     VISetFrameBufferScale(dusk::getSettings().game.internalResolutionScale.getValue());
 
-    dusk::audio::SetMasterVolume(dusk::getSettings().audio.masterVolume / 100.0f);
+    dusk::audio::SetMasterVolume(dusk::audio::MasterVolumeToLinear(dusk::getSettings().audio.masterVolume / 100.0f));
     dusk::audio::SetEnableReverb(dusk::getSettings().audio.enableReverb);
     dusk::audio::EnableHrtf = dusk::getSettings().audio.enableHrtf;
 


### PR DESCRIPTION
- Fix keyboard NPE
- Fix autosave NPE
- Fix hintTalkEvCamera buffer overrun UB
- Fix log UB when logging nullptr proc name 
- Fix NPE in kargorok wolf carry code
- Fix link dangling pointers
- Exponential master audio slider 
- Fix speedrun mode default layer restore issue (issue with damage multiplier restoring to 0 when unset instead of 1) 

Fixes #1167
Fixes #1171
Fixes #1173
Fixes #1174
Fixes #1176
Fixes #1178
Closes #688
