### PR TITLE
ci: publish release assets for tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,3 +272,39 @@ jobs:
             build/install/*.dll
             build/install/res/
             build/install/debug.7z
+
+  release:
+    name: Publish release assets
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build-linux
+      - build-apple
+      - build-android
+      - build-windows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts
+
+      - name: Package release assets
+        run: |
+          mkdir release-assets
+          for artifact_dir in artifacts/*; do
+            artifact_name="$(basename "$artifact_dir")"
+            (cd "$artifact_dir" && zip -r "../../release-assets/${artifact_name}.zip" .)
+          done
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release view "$GITHUB_REF_NAME" || gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$GITHUB_REF_NAME" release-assets/* --clobber


### PR DESCRIPTION
## Summary
- add a tag-only release job after all platform builds finish
- download workflow artifacts, zip each artifact bundle, and upload them to the matching GitHub Release
- create the release first when the tag exists but no release has been published yet

## Validation
- ruby YAML parse for .github/workflows/build.yml
- git diff --check

Note: this fixes future tag releases. Existing tag v1.1.0 was built successfully, but its workflow came from the old tag commit, so its artifacts still need to be uploaded manually or by retagging/rerunning with this workflow.