### PR TITLE
Apply rebrand to bloom setting value name

### DIFF
--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -184,7 +184,7 @@ Rml::String format_graphics_setting_value(GraphicsOption option, int value) {
         case BloomMode::Classic:
             return "Classic";
         case BloomMode::Dusk:
-            return "Dusk";
+            return "Dusklight";
         }
         break;
     case GraphicsOption::BloomMultiplier:


### PR DESCRIPTION
The display name for BloomSetting::Dusk was unchanged in the rebranding
process, and still shows up as "Dusk" in the settings menu. Rename it to
"Dusklight" to bring it in line with the rebrand.