### PR TITLE
Use safe string copies in d_save.cpp

### DIFF
--- a/src/d/d_save.cpp
+++ b/src/d/d_save.cpp
@@ -31,6 +31,9 @@
 #include "dusk/settings.h"
 #include <f_ap/f_ap_game.h>
 #include <dusk/autosave.h>
+
+#include "dusk/string.hpp"
+#define strcpy dusk::SafeStringCopy
 #endif
 
 static u8 dSv_item_rename(u8 i_itemNo) {

--- a/src/d/d_save.cpp
+++ b/src/d/d_save.cpp
@@ -30,7 +30,6 @@
 #if TARGET_PC
 #include "dusk/settings.h"
 #include <f_ap/f_ap_game.h>
-#include <dusk/autosave.h>
 
 #include "dusk/string.hpp"
 #define strcpy dusk::SafeStringCopy


### PR DESCRIPTION
Seeing sentry crashes here that I suspect involve buffer overflows here.