### PR TITLE
Autosplit feature

### DIFF
--- a/files.cmake
+++ b/files.cmake
@@ -1463,6 +1463,8 @@ set(DUSK_FILES
         src/dusk/imgui/ImGuiStateShare.cpp
         src/dusk/ui/achievements.cpp
         src/dusk/ui/achievements.hpp
+        src/dusk/ui/autosplits.cpp
+        src/dusk/ui/autosplits.hpp
         src/dusk/ui/bool_button.cpp
         src/dusk/ui/bool_button.hpp
         src/dusk/ui/button.cpp
@@ -1513,6 +1515,7 @@ set(DUSK_FILES
         src/dusk/ui/window.cpp
         src/dusk/ui/window.hpp
         src/dusk/achievements.cpp
+        src/dusk/autosplit.cpp
         src/dusk/iso_validate.cpp
         src/dusk/livesplit.cpp
         src/dusk/offset_ptr.cpp

--- a/include/dusk/autosplit.h
+++ b/include/dusk/autosplit.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace dusk::autosplit {
+
+struct SplitEvent {
+    const char* id;
+    const char* displayName;
+    std::function<bool()> check;
+};
+
+struct MappedSplit {
+    std::string name;
+    std::string eventId;
+};
+
+enum class ImportResult {
+    Success,
+    FileNotFound,
+    ReadError,
+    NoSegments,
+};
+
+class Manager {
+public:
+    static Manager& get();
+
+    void tick();
+    void onSpeedrunStart();
+    void onSpeedrunReset();
+
+    const std::vector<SplitEvent>& catalog() const noexcept { return mCatalog; }
+    const std::vector<MappedSplit>& splits() const noexcept { return mSplits; }
+    const std::string& lssPath() const noexcept { return mLssPath; }
+
+    const SplitEvent* findEvent(std::string_view id) const;
+
+    ImportResult importFromLss(const std::string& path);
+    void setEventForSplit(std::size_t index, std::string eventId);
+    void clearSplits();
+
+private:
+    Manager();
+    void load();
+    void save();
+    void captureSnapshot();
+
+    std::vector<SplitEvent>  mCatalog;
+    std::vector<MappedSplit> mSplits;
+    std::vector<bool>        mSnapshot;
+    std::string              mLssPath;
+    std::size_t mCursor = 0;
+    bool        mLoaded = false;
+    bool        mRunActive = false;
+};
+
+}  // namespace dusk::autosplit

--- a/include/dusk/livesplit.h
+++ b/include/dusk/livesplit.h
@@ -7,10 +7,12 @@ void onGameFrame();
 uint64_t getFrameCount();
 void start();
 void reset();
+void split();
 void connectLiveSplit(const char* host = "127.0.0.1", int port = 16834);
 void disconnectLiveSplit();
 bool consumeConnectedEvent();
 bool consumeDisconnectedEvent();
+bool isConnected();
 void updateLiveSplit();
 void shutdown();
 }

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -184,6 +184,7 @@ struct UserSettings {
         // Tools
         ConfigVar<bool> speedrunMode;
         ConfigVar<bool> liveSplitEnabled;
+        ConfigVar<bool> autosplitEnabled;
         ConfigVar<bool> showSpeedrunRTATimer;
         ConfigVar<bool> recordingMode;
         ConfigVar<bool> showInputViewer;

--- a/src/dusk/autosplit.cpp
+++ b/src/dusk/autosplit.cpp
@@ -1,0 +1,272 @@
+#include "dusk/autosplit.h"
+
+#include "dusk/io.hpp"
+#include "dusk/livesplit.h"
+#include "dusk/main.h"
+#include "dusk/settings.h"
+
+#include "d/d_com_inf_game.h"
+#include "d/d_item_data.h"
+#include "d/d_save.h"
+#include "d/actor/d_a_alink.h"
+#include "d/actor/d_a_player.h"
+
+#include "nlohmann/json.hpp"
+
+#include <filesystem>
+
+namespace dusk::autosplit {
+namespace {
+
+using json = nlohmann::json;
+
+constexpr auto kFileName = "autosplits.json";
+
+std::string xml_unescape(std::string_view s) {
+    std::string out;
+    out.reserve(s.size());
+    for (std::size_t i = 0; i < s.size();) {
+        if (s[i] == '&') {
+            if (s.compare(i, 5, "&amp;") == 0)  { out += '&';  i += 5; continue; }
+            if (s.compare(i, 4, "&lt;") == 0)   { out += '<';  i += 4; continue; }
+            if (s.compare(i, 4, "&gt;") == 0)   { out += '>';  i += 4; continue; }
+            if (s.compare(i, 6, "&quot;") == 0) { out += '"';  i += 6; continue; }
+            if (s.compare(i, 6, "&apos;") == 0) { out += '\''; i += 6; continue; }
+        }
+        out += s[i++];
+    }
+    return out;
+}
+
+std::string extract_name(std::string_view block) {
+    constexpr std::string_view kCdataOpen  = "<![CDATA[";
+    constexpr std::string_view kCdataClose = "]]>";
+    const auto open = block.find(kCdataOpen);
+    if (open != std::string_view::npos) {
+        const auto start = open + kCdataOpen.size();
+        const auto end = block.find(kCdataClose, start);
+        if (end != std::string_view::npos) {
+            return std::string(block.substr(start, end - start));
+        }
+    }
+    return xml_unescape(block);
+}
+
+std::vector<std::string> parse_lss_segment_names(std::string_view xml) {
+    constexpr std::string_view kSegmentsOpen  = "<Segments>";
+    constexpr std::string_view kSegmentsClose = "</Segments>";
+    constexpr std::string_view kSegmentOpen   = "<Segment>";
+    constexpr std::string_view kSegmentClose  = "</Segment>";
+    constexpr std::string_view kNameOpen      = "<Name>";
+    constexpr std::string_view kNameClose     = "</Name>";
+
+    std::vector<std::string> names;
+
+    const auto segsStart = xml.find(kSegmentsOpen);
+    if (segsStart == std::string_view::npos) return names;
+    const auto segsEnd = xml.find(kSegmentsClose, segsStart);
+    if (segsEnd == std::string_view::npos) return names;
+
+    const auto body = xml.substr(
+        segsStart + kSegmentsOpen.size(),
+        segsEnd - segsStart - kSegmentsOpen.size());
+
+    for (std::size_t i = 0;;) {
+        const auto sStart = body.find(kSegmentOpen, i);
+        if (sStart == std::string_view::npos) break;
+        const auto sEnd = body.find(kSegmentClose, sStart);
+        if (sEnd == std::string_view::npos) break;
+        const auto seg = body.substr(
+            sStart + kSegmentOpen.size(),
+            sEnd - sStart - kSegmentOpen.size());
+        const auto nStart = seg.find(kNameOpen);
+        if (nStart != std::string_view::npos) {
+            const auto nEnd = seg.find(kNameClose, nStart);
+            if (nEnd != std::string_view::npos) {
+                names.push_back(extract_name(seg.substr(
+                    nStart + kNameOpen.size(),
+                    nEnd - nStart - kNameOpen.size())));
+            }
+        }
+        i = sEnd + kSegmentClose.size();
+    }
+    return names;
+}
+
+}  // namespace
+
+Manager& Manager::get() {
+    static Manager instance;
+    return instance;
+}
+
+Manager::Manager() {
+    mCatalog = {
+        { "iron_boots", "Iron Boots",
+            [] { return dComIfGs_isItemFirstBit(dItemNo_HVY_BOOTS_e) != 0; } },
+        { "forest_temple", "Forest Temple Cleared",
+            [] { return dComIfGs_isEventBit(dSv_event_flag_c::M_022) != 0; } },
+        { "ganondorf", "Ganondorf Defeated",
+            [] {
+                const auto* link = static_cast<const daAlink_c*>(daPy_getPlayerActorClass());
+                return link != nullptr && link->mProcID == daAlink_c::PROC_GANON_FINISH;
+            } },
+    };
+}
+
+const SplitEvent* Manager::findEvent(std::string_view id) const {
+    for (const auto& ev : mCatalog) {
+        if (id == ev.id) return &ev;
+    }
+    return nullptr;
+}
+
+void Manager::load() {
+    if (mLoaded) return;
+    mLoaded = true;
+
+    const auto path = ConfigPath / kFileName;
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec)) return;
+
+    try {
+        auto bytes = io::FileStream::ReadAllBytes(path);
+        auto j = json::parse(bytes);
+        if (!j.is_object()) return;
+
+        if (j.contains("lssPath") && j["lssPath"].is_string()) {
+            mLssPath = j["lssPath"].get<std::string>();
+        }
+        if (j.contains("splits") && j["splits"].is_array()) {
+            for (const auto& entry : j["splits"]) {
+                if (!entry.is_object() || !entry.contains("name")) continue;
+                MappedSplit s;
+                s.name = entry["name"].get<std::string>();
+                if (entry.contains("eventId") && entry["eventId"].is_string()) {
+                    auto id = entry["eventId"].get<std::string>();
+                    if (findEvent(id) != nullptr) s.eventId = std::move(id);
+                }
+                mSplits.push_back(std::move(s));
+            }
+        }
+    } catch (const std::exception&) {}
+}
+
+void Manager::save() {
+    json j;
+    j["lssPath"] = mLssPath;
+    auto& arr = j["splits"] = json::array();
+    for (const auto& s : mSplits) {
+        arr.push_back({ {"name", s.name}, {"eventId", s.eventId} });
+    }
+    try {
+        io::FileStream::WriteAllText(ConfigPath / kFileName, j.dump(2));
+    } catch (const std::exception&) {}
+}
+
+void Manager::captureSnapshot() {
+    mSnapshot.assign(mSplits.size(), false);
+    for (std::size_t i = 0; i < mSplits.size(); ++i) {
+        if (const auto* ev = findEvent(mSplits[i].eventId); ev != nullptr) {
+            mSnapshot[i] = ev->check();
+        }
+    }
+}
+
+void Manager::onSpeedrunStart() {
+    load();
+    mCursor = 0;
+    captureSnapshot();
+    mRunActive = true;
+}
+
+void Manager::onSpeedrunReset() {
+    mRunActive = false;
+    mCursor = 0;
+    mSnapshot.clear();
+}
+
+void Manager::tick() {
+    load();
+    if (!IsGameLaunched || !mRunActive) return;
+
+    const auto& s = getSettings().game;
+    if (!s.speedrunMode.getValue() ||
+        !s.liveSplitEnabled.getValue() ||
+        !s.autosplitEnabled.getValue()) {
+        return;
+    }
+    if (!speedrun::isConnected()) return;
+
+    while (mCursor < mSplits.size()) {
+        const auto& split = mSplits[mCursor];
+        const auto* ev = split.eventId.empty() ? nullptr : findEvent(split.eventId);
+        if (ev == nullptr) return;
+
+        const bool now = ev->check();
+        if (now && !mSnapshot[mCursor]) {
+            speedrun::split();
+            mSnapshot[mCursor] = true;
+            ++mCursor;
+            continue;
+        }
+        return;
+    }
+}
+
+ImportResult Manager::importFromLss(const std::string& path) {
+    load();
+
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec)) return ImportResult::FileNotFound;
+
+    std::vector<u8> bytes;
+    try {
+        bytes = io::FileStream::ReadAllBytes(path.c_str());
+    } catch (const std::exception&) {
+        return ImportResult::ReadError;
+    }
+
+    const std::string_view xml(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    auto names = parse_lss_segment_names(xml);
+    if (names.empty()) return ImportResult::NoSegments;
+
+    std::vector<MappedSplit> next;
+    next.reserve(names.size());
+    for (std::size_t i = 0; i < names.size(); ++i) {
+        MappedSplit s;
+        s.name = std::move(names[i]);
+        if (i < mSplits.size() && mSplits[i].name == s.name) {
+            s.eventId = mSplits[i].eventId;
+        }
+        next.push_back(std::move(s));
+    }
+
+    mSplits = std::move(next);
+    mLssPath = path;
+    mCursor = 0;
+    mSnapshot.clear();
+    mRunActive = false;
+    save();
+    return ImportResult::Success;
+}
+
+void Manager::setEventForSplit(std::size_t index, std::string eventId) {
+    load();
+    if (index >= mSplits.size()) return;
+    if (!eventId.empty() && findEvent(eventId) == nullptr) return;
+    mSplits[index].eventId = std::move(eventId);
+    save();
+}
+
+void Manager::clearSplits() {
+    load();
+    mSplits.clear();
+    mLssPath.clear();
+    mCursor = 0;
+    mSnapshot.clear();
+    mRunActive = false;
+    save();
+}
+
+}  // namespace dusk::autosplit

--- a/src/dusk/livesplit.cpp
+++ b/src/dusk/livesplit.cpp
@@ -44,6 +44,7 @@
 #endif
 
 #include <cstdio>
+#include "dusk/autosplit.h"
 #include "dusk/livesplit.h"
 #include "f_op/f_op_overlap_mng.h"
 
@@ -130,6 +131,7 @@ void start() {
     startPending = true;
     frameCount = 0;
     wasLoading = false;
+    dusk::autosplit::Manager::get().onSpeedrunStart();
 }
 
 void reset() {
@@ -138,7 +140,12 @@ void reset() {
     frameCount = 0;
     wasLoading = false;
     sendCmd("reset");
+    dusk::autosplit::Manager::get().onSpeedrunReset();
 }
+
+void split() { sendCmd("split"); }
+
+bool isConnected() { return connected; }
 
 static void reconnect() {
     if (sock != INVALID_SOCKET) {

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -119,6 +119,7 @@ UserSettings g_userSettings = {
         // Tools
         .speedrunMode {"game.speedrunMode", false},
         .liveSplitEnabled {"game.liveSplitEnabled", false},
+        .autosplitEnabled {"game.autosplitEnabled", false},
         .showSpeedrunRTATimer {"game.showSpeedrunRTATimer", true},
         .recordingMode {"game.recordingMode", false},
         .showInputViewer {"game.showInputViewer", false},
@@ -238,6 +239,7 @@ void registerSettings() {
     Register(g_userSettings.game.enableResetKeybind);
     Register(g_userSettings.game.speedrunMode);
     Register(g_userSettings.game.liveSplitEnabled);
+    Register(g_userSettings.game.autosplitEnabled);
     Register(g_userSettings.game.showSpeedrunRTATimer);
     Register(g_userSettings.game.recordingMode);
     Register(g_userSettings.game.showInputViewer);

--- a/src/dusk/ui/autosplits.cpp
+++ b/src/dusk/ui/autosplits.cpp
@@ -1,0 +1,218 @@
+#include "autosplits.hpp"
+
+#include "Z2AudioLib/Z2SeMgr.h"
+#include "aurora/lib/window.hpp"
+#include "dusk/file_select.hpp"
+#include "fmt/format.h"
+#include "m_Do/m_Do_audio.h"
+#include "pane.hpp"
+#include "ui.hpp"
+
+#include <chrono>
+
+namespace dusk::ui {
+namespace {
+
+using autosplit::ImportResult;
+using autosplit::Manager;
+
+constexpr SDL_DialogFileFilter kLssFilters[] = {
+    {"LiveSplit splits", "lss"},
+    {"All files",        "*"},
+};
+
+void on_lss_picked(void* /*userdata*/, const char* path, const char* error) {
+    if (path == nullptr) {
+        if (error != nullptr) {
+            push_toast({
+                .title = "Import canceled",
+                .content = error,
+                .duration = std::chrono::seconds(3),
+            });
+        }
+        return;
+    }
+    const auto result = Manager::get().importFromLss(path);
+    switch (result) {
+    case ImportResult::Success:
+        push_toast({
+            .title = "Splits imported",
+            .content = fmt::format("{} splits loaded", Manager::get().splits().size()),
+            .duration = std::chrono::seconds(3),
+        });
+        break;
+    case ImportResult::FileNotFound:
+        push_toast({.title = "Import failed", .content = "File not found",
+            .duration = std::chrono::seconds(3)});
+        break;
+    case ImportResult::ReadError:
+        push_toast({.title = "Import failed", .content = "Could not read the file",
+            .duration = std::chrono::seconds(3)});
+        break;
+    case ImportResult::NoSegments:
+        push_toast({.title = "Import failed",
+            .content = "No <Segments> block found in this .lss file",
+            .duration = std::chrono::seconds(3)});
+        break;
+    }
+}
+
+void open_lss_picker() {
+    const auto& current = Manager::get().lssPath();
+    ShowFileSelect(&on_lss_picked, nullptr, aurora::window::get_sdl_window(),
+        kLssFilters, static_cast<int>(std::size(kLssFilters)),
+        current.empty() ? nullptr : current.c_str(), false);
+}
+
+Rml::String split_value_label(const autosplit::MappedSplit& split) {
+    if (split.eventId.empty()) return "—";
+    if (const auto* ev = Manager::get().findEvent(split.eventId)) {
+        return ev->displayName;
+    }
+    return "—";
+}
+
+void populate_catalog(Pane& pane, std::size_t splitIndex) {
+    pane.clear();
+    pane.add_section("Assign Event");
+
+    auto& mgr = Manager::get();
+    for (const auto& ev : mgr.catalog()) {
+        const std::string id(ev.id);
+        pane.add_button({
+            .text = ev.displayName,
+            .isSelected = [id, splitIndex] {
+                const auto& splits = Manager::get().splits();
+                return splitIndex < splits.size() && splits[splitIndex].eventId == id;
+            },
+        }).on_pressed([id, splitIndex] {
+            mDoAud_seStartMenu(kSoundClick);
+            Manager::get().setEventForSplit(splitIndex, id);
+        });
+    }
+
+    pane.add_section("Other");
+    pane.add_button({
+        .text = "Unmap",
+        .isSelected = [splitIndex] {
+            const auto& splits = Manager::get().splits();
+            return splitIndex < splits.size() && splits[splitIndex].eventId.empty();
+        },
+    }).on_pressed([splitIndex] {
+        mDoAud_seStartMenu(kSoundClick);
+        Manager::get().setEventForSplit(splitIndex, "");
+    });
+
+    pane.finalize();
+}
+
+void populate_left(Pane& leftPane, Pane& rightPane) {
+    leftPane.clear();
+    auto& mgr = Manager::get();
+
+    if (mgr.splits().empty()) {
+        leftPane.add_section("Import");
+        leftPane.register_control(
+            leftPane.add_button("Import Splits from LiveSplit...").on_pressed([] {
+                mDoAud_seStartMenu(kSoundClick);
+                open_lss_picker();
+            }),
+            rightPane, [](Pane& pane) {
+                pane.add_section("How it works");
+                pane.add_text(
+                    "Pick a .lss file containing the splits you are using on livesplit "
+                    "to map game events.");
+                pane.finalize();
+            });
+        leftPane.finalize();
+        return;
+    }
+
+    leftPane.add_section(fmt::format("Splits ({})", mgr.splits().size()));
+    for (std::size_t i = 0; i < mgr.splits().size(); ++i) {
+        auto& btn = leftPane.add_select_button({
+            .key = fmt::format("{:02}. {}", i + 1, mgr.splits()[i].name),
+            .getValue = [i] {
+                const auto& splits = Manager::get().splits();
+                if (i >= splits.size()) return Rml::String("—");
+                return split_value_label(splits[i]);
+            },
+        });
+        auto* btnPtr = &btn;
+        btn.listen(Rml::EventId::Submit, [i, &rightPane, btnPtr](Rml::Event& event) {
+            if (event.GetTargetElement() != btnPtr->root()) return;
+            populate_catalog(rightPane, i);
+        });
+        btn.on_nav_command([i, &rightPane](Rml::Event&, NavCommand cmd) {
+            if (cmd == NavCommand::Right) {
+                populate_catalog(rightPane, i);
+            }
+            return false;
+        });
+    }
+
+    leftPane.add_section("Actions");
+    leftPane.register_control(
+        leftPane.add_button("Re-import from LiveSplit...").on_pressed([] {
+            mDoAud_seStartMenu(kSoundClick);
+            open_lss_picker();
+        }),
+        rightPane, [](Pane& pane) {
+            pane.add_text("Re-import the .lss file. Mappings on segments whose name "
+                          "hasn't changed are preserved.");
+            pane.finalize();
+        });
+    leftPane.register_control(
+        leftPane.add_button("Clear Splits").on_pressed([] {
+            mDoAud_seStartMenu(kSoundClick);
+            Manager::get().clearSplits();
+        }),
+        rightPane, [](Pane& pane) {
+            pane.add_text("Remove all imported splits and their mappings.");
+            pane.finalize();
+        });
+
+    leftPane.finalize();
+
+    rightPane.add_section("Map a split");
+    rightPane.add_text("Click a split on the left to choose which game event triggers it.");
+    rightPane.finalize();
+}
+
+}  // namespace
+
+AutosplitsWindow::AutosplitsWindow() {
+    snapshot();
+    add_tab("Autosplits", [this](Rml::Element* content) {
+        auto& leftPane = add_child<Pane>(content, Pane::Type::Controlled);
+        auto& rightPane = add_child<Pane>(content, Pane::Type::Uncontrolled);
+        populate_left(leftPane, rightPane);
+    });
+}
+
+void AutosplitsWindow::snapshot() {
+    mSnapshot = Manager::get().splits();
+    mSnapshotPath = Manager::get().lssPath();
+}
+
+void AutosplitsWindow::update() {
+    const auto& current = Manager::get().splits();
+    bool dirty = current.size() != mSnapshot.size() ||
+                 Manager::get().lssPath() != mSnapshotPath;
+    if (!dirty) {
+        for (std::size_t i = 0; i < current.size(); ++i) {
+            if (current[i].name != mSnapshot[i].name ||
+                current[i].eventId != mSnapshot[i].eventId) {
+                dirty = true;
+                break;
+            }
+        }
+    }
+    if (dirty) {
+        snapshot();
+        refresh_active_tab();
+    }
+    Window::update();
+}
+
+}  // namespace dusk::ui

--- a/src/dusk/ui/autosplits.hpp
+++ b/src/dusk/ui/autosplits.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "dusk/autosplit.h"
+#include "window.hpp"
+
+#include <string>
+#include <vector>
+
+namespace dusk::ui {
+
+class AutosplitsWindow : public Window {
+public:
+    AutosplitsWindow();
+    void update() override;
+
+private:
+    void snapshot();
+
+    std::vector<autosplit::MappedSplit> mSnapshot;
+    std::string mSnapshotPath;
+};
+
+}  // namespace dusk::ui

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1,6 +1,7 @@
 #include "settings.hpp"
 
 #include "aurora/gfx.h"
+#include "autosplits.hpp"
 #include "bool_button.hpp"
 #include "controller_config.hpp"
 #include "dusk/app_info.hpp"
@@ -1132,6 +1133,29 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .key = "Show RTA",
                 .helpText = "Display the RTA timer. IGT is always visible.",
                 .isDisabled = [] { return !getSettings().game.speedrunMode; },
+            });
+        config_bool_select(leftPane, rightPane, getSettings().game.autosplitEnabled,
+            {
+                .key = "Autosplit",
+                .helpText = "Automatically send splits to LiveSplit when mapped events fire."
+                            " Use \"Configure Splits\" to import a .lss file and map each segment.",
+                .isDisabled = [] {
+                    return IsMobile || !getSettings().game.speedrunMode ||
+                           !getSettings().game.liveSplitEnabled;
+                },
+            });
+        leftPane.register_control(
+            leftPane.add_button({
+                .text = "Configure Splits",
+                .isDisabled = [] { return IsMobile; },
+            }).on_pressed([this] {
+                push(std::make_unique<AutosplitsWindow>());
+            }),
+            rightPane, [](Pane& pane) {
+                pane.clear();
+                pane.add_text(
+                    "Open the autosplit configuration window. Import a LiveSplit (.lss) "
+                    "file and assign a game event to each segment.");
             });
     });
 

--- a/src/f_ap/f_ap_game.cpp
+++ b/src/f_ap/f_ap_game.cpp
@@ -15,6 +15,7 @@
 #include "d/d_model.h"
 #include "d/d_tresure.h"
 #include "dusk/achievements.h"
+#include "dusk/autosplit.h"
 #include "dusk/frame_interpolation.h"
 #include "dusk/livesplit.h"
 #include "dusk/logging.h"
@@ -842,6 +843,7 @@ void fapGm_Execute() {
 #ifdef TARGET_PC
     dusk::speedrun::onGameFrame();
     dusk::AchievementSystem::get().tick();
+    dusk::autosplit::Manager::get().tick();
 #endif
 }
 


### PR DESCRIPTION
This is a proposal for how to implement an autosplit feature with LiveSplit.

I've thought about multiple ways to do this properly, and I think this is the most reliable approach.
The idea is to expose a list of events to runners that they can map to their splits.
Runners can then just import their splits file from LiveSplit and pick which event triggers each split — the split is then fired in-game through the LiveSplit server.

This is a base working implementation with a few events I've tested; we'll need to add a lot more events to push customization further and cover the different splits each runner may have.

There might also be a better way to register autosplit events in the codebase ?

One concern that remains is how we handle certain events — for example, getting the Iron Boots currently splits when the actual flag is set, which happens after the textbox disappears, and that's not the timing most runners use. Some runners split slightly before an event, others when the item appears on screen, others after.

I'm also not sure about the UI/UX side. It could be nice to filter events once the list grows, e.g. by common events across routes, or by category like "Items", "Locations", etc.

Will continue to finalize this if this have any validations and feedbacks !

<img width="2386" height="1644" alt="CleanShot 2026-05-14 at 01 55 08@2x" src="https://github.com/user-attachments/assets/10a260b1-50b8-440d-9ced-c2b46f289611" />
<img width="2544" height="1734" alt="CleanShot 2026-05-14 at 02 01 00@2x" src="https://github.com/user-attachments/assets/839cc5d2-7158-4a4a-9553-273b1eae64cf" />
<img width="2328" height="1646" alt="CleanShot 2026-05-14 at 02 01 48@2x" src="https://github.com/user-attachments/assets/d1a07f87-bd45-4a2c-9e23-b49ec79c25dd" />
