### PR TITLE
Flake: Update GitHub revision and hash for aurora-src

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,12 +15,6 @@
 
       # Dependencies that are not packaged in nixpkgs (used by the Linux package build):
       buildSources = pkgs: {
-        aurora-src = pkgs.fetchFromGitHub {
-          owner = "encounter";
-          repo = "aurora";
-          rev = "3643a369ad47d8acca8d73dba462eab2ee2bd150";
-          hash = "sha256-eWLKgj5VNmgF4KH0RFoCEhaPAy0c/8CnVvkuIAsG1AY=";
-        };
         dawn-src = pkgs.fetchzip {
           url = "https://github.com/encounter/dawn-build/releases/download/v20260423.175430/dawn-linux-x86_64.tar.gz";
           hash = "sha256-HXfKTLHtMPwupnFnaflCARtXVPuS/0PoCePXidjE5xs=";
@@ -59,9 +53,6 @@
           name = "dusklight";
           src = ./.;
           postUnpack = ''
-            mkdir -p $sourceRoot/extern/aurora
-            cp -r ${srcs.aurora-src}/. $sourceRoot/extern/aurora/
-            chmod -R u+w $sourceRoot/extern/aurora
             sed -i '/add_subdirectory(tests)/d' $sourceRoot/extern/aurora/CMakeLists.txt
           '';
           # Remove last line to re-enable tests

--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,8 @@
         aurora-src = pkgs.fetchFromGitHub {
           owner = "encounter";
           repo = "aurora";
-          rev = "63606a43265a3bc18dafd500ab4d7a2108f109e6";
-          hash = "sha256-xBvnAwGwNzav67Ac6oUz7RqDUwqgL2bsME3OOMn8Tqw=";
+          rev = "3643a369ad47d8acca8d73dba462eab2ee2bd150";
+          hash = "sha256-eWLKgj5VNmgF4KH0RFoCEhaPAy0c/8CnVvkuIAsG1AY=";
         };
         dawn-src = pkgs.fetchzip {
           url = "https://github.com/encounter/dawn-build/releases/download/v20260423.175430/dawn-linux-x86_64.tar.gz";


### PR DESCRIPTION
Fixes Build Error due to Aurora being out of date in the flake.