### PR TITLE
Fix fast tears going out of bounds

### DIFF
--- a/src/d/actor/d_a_obj_drop.cpp
+++ b/src/d/actor/d_a_obj_drop.cpp
@@ -299,7 +299,8 @@ int daObjDrop_c::modeParentWait() {
 
 #if TARGET_PC
 static inline BOOL checkGetCargoRide() {
-    if ((daPy_getPlayerActorClass()->checkCargoCarry() && strcmp(dComIfGp_getStartStageName(), "F_SP112") == 0) ||
+    if (daPy_getPlayerActorClass()->checkCargoCarry() &&
+        strcmp(dComIfGp_getStartStageName(), "F_SP112") == 0 &&
         dComIfGs_isLightDropGetFlag(dComIfGp_getStartStageDarkArea()))
     {
         return true;


### PR DESCRIPTION
Incorrect decomp from TPHD making the tears think you're always in the Zora River ride

Fixes https://github.com/TwilitRealm/dusklight/issues/1047