### PR TITLE
Soft reset hotkey on release

### DIFF
--- a/src/dusk/imgui/ImGuiConsole.cpp
+++ b/src/dusk/imgui/ImGuiConsole.cpp
@@ -263,7 +263,7 @@ namespace dusk {
         }
 
         if (getSettings().game.enableResetKeybind && ImGui::GetIO().KeyCtrl &&
-            ImGui::IsKeyPressed(ImGuiKey_R) && !fpcM_SearchByName(fpcNm_LOGO_SCENE_e))
+            ImGui::IsKeyReleased(ImGuiKey_R) && !fpcM_SearchByName(fpcNm_LOGO_SCENE_e))
         {
             JUTGamePad::C3ButtonReset::sResetSwitchPushing = true;
         }


### PR DESCRIPTION
changes the control+r soft reset keybind to activate on release rather than when pressed to match the gamecubes console reset button for speedruns.

from zsr for forest back in time: "Hold the console reset button, and when the continue prompt appears (it has a small delay before it's usable, wait a bit until then) release the console reset button and press A on the same frame."

tested locally and works as intended 