### PR TITLE
Fix game mode on MacOS <26

### DIFF
--- a/platforms/macos/Info.plist.in
+++ b/platforms/macos/Info.plist.in
@@ -28,7 +28,9 @@
 	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.adventure-games</string>
 	<key>LSSupportsGameMode</key>
-    <true/>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
fix #998 

Apparently, macOS <26 also requires the game category to be set for Game Mode to activate automatically.

Tested on macOS 14.5.