### PR TITLE
fix goron mines elevator path index on Android ARM

### DIFF
--- a/src/d/actor/d_a_obj_dmelevator.cpp
+++ b/src/d/actor/d_a_obj_dmelevator.cpp
@@ -596,7 +596,11 @@ void daObjDmElevator_c::moveInit() {
 
 int daObjDmElevator_c::moveProc() {
     dPath* path = dPath_GetRoomPath(getPathID(), fopAcM_GetRoomNo(this));
+#ifdef TARGET_PC
+    dPnt* pdVar3 = dPath_GetPnt(path, field_0x5e0 + (s8)field_0x5e1);
+#else
     dPnt* pdVar3 = dPath_GetPnt(path, field_0x5e0 + (char)field_0x5e1);
+#endif
 
     cXyz path_point(pdVar3->m_position);
     if (path_point.y > current.pos.y) {
@@ -607,7 +611,11 @@ int daObjDmElevator_c::moveProc() {
 
     int uVar1 = cLib_chasePos(&current.pos, path_point, fabsf(speedF));
 
+#ifdef TARGET_PC
+    if (field_0x5e0 + (int)(s8)field_0x5e1 == 1) {
+#else
     if (field_0x5e0 + (int)(char)field_0x5e1 == 1) {
+#endif
         const float fVar6 = current.pos.abs(path_point);
         uVar1 = ((u32)(char)((fVar6 < 200.0f) << 3) << 0x1c) >> 0x1f;
     }


### PR DESCRIPTION
fix https://github.com/TwilitRealm/dusklight/issues/1105

On platforms where plain char is unsigned, the -1 direction value widens to 255 instead of staying −1, so the path index becomes 256 instead of 0 and the chaos happen then.

idk if this is something we are aware of, but that may include other problems in the codebase on ARM devices I think.

Tested on an Android ARM device with the issue savestate.