### PR TITLE
Bold Back Button Name in Popup

### DIFF
--- a/res/rml/overlay.rcss
+++ b/res/rml/overlay.rcss
@@ -58,7 +58,7 @@ toast:active {
     background-color: rgba(45, 43, 26, 80%);
 }*/
 
-toast b {
+b {
     font-weight: bold;
 }
 

--- a/res/rml/overlay.rcss
+++ b/res/rml/overlay.rcss
@@ -58,6 +58,10 @@ toast:active {
     background-color: rgba(45, 43, 26, 80%);
 }*/
 
+toast b {
+    font-weight: bold;
+}
+
 toast heading {
     display: flex;
     gap: 18dp;

--- a/src/dusk/ui/overlay.cpp
+++ b/src/dusk/ui/overlay.cpp
@@ -147,7 +147,7 @@ Rml::String back_button_name() {
 #if defined(TARGET_ANDROID) || (defined(__APPLE__) && TARGET_OS_IOS && !TARGET_OS_MACCATALYST)
 constexpr auto kMenuNotificationPrefix = "3-finger tap or";
 #else
-constexpr auto kMenuNotificationPrefix = "Press F1 or";
+constexpr auto kMenuNotificationPrefix = "Press <b>F1</b> or";
 #endif
 
 Rml::Element* create_menu_notification(Rml::Element* parent) {
@@ -169,7 +169,7 @@ Rml::Element* create_menu_notification(Rml::Element* parent) {
     append(row, "span")->SetInnerRML(kMenuNotificationPrefix);
     auto* icon = append(row, "icon");
     icon->SetClass("controller", true);
-    append(row, "span")->SetInnerRML(escape(padButton));
+    append(row, "span")->SetInnerRML("<b>" + escape(padButton) + "</b>");
     append(row, "span")->SetInnerRML("to open menu");
 
     return elem;


### PR DESCRIPTION
Makes it stand out more, especially when the back button is called something else that's just a common word. Looks like this on my DS4:
<img width="442" height="122" alt="image" src="https://github.com/user-attachments/assets/15697396-c3b1-47cf-aa11-08d1db1137d5" />
