### PR TITLE
Add Fast Run cheat

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -169,7 +169,7 @@ struct UserSettings {
         ConfigVar<bool> alwaysGreatspin;
         ConfigVar<bool> enableFastIronBoots;
         ConfigVar<bool> canTransformAnywhere;
-        ConfigVar<bool> fastWalk;
+        ConfigVar<bool> fastRun;
         ConfigVar<bool> fastRoll;
         ConfigVar<bool> fastSpinner;
         ConfigVar<bool> freeMagicArmor;

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -169,6 +169,7 @@ struct UserSettings {
         ConfigVar<bool> alwaysGreatspin;
         ConfigVar<bool> enableFastIronBoots;
         ConfigVar<bool> canTransformAnywhere;
+        ConfigVar<bool> fastWalk;
         ConfigVar<bool> fastRoll;
         ConfigVar<bool> fastSpinner;
         ConfigVar<bool> freeMagicArmor;

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -9843,6 +9843,11 @@ void daAlink_c::setNormalSpeedF(f32 i_speed, f32 i_deceleration) {
         max_speed = mMoveValue * (mMaxSpeed * mMoveValue);
     } else {
         max_speed = mStickValue * (mMaxSpeed * mStickValue);
+#if TARGET_PC
+        if (dusk::getSettings().game.fastWalk && !checkWolf() && mProcID == PROC_MOVE) {
+            max_speed *= 2.0f;
+        }
+#endif
     }
 
     if (checkWolfSwimDashAnime() || checkUnderMove0BckNoArc(ANM_SWIM_DASH) || getZoraSwim()) {

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -9844,7 +9844,7 @@ void daAlink_c::setNormalSpeedF(f32 i_speed, f32 i_deceleration) {
     } else {
         max_speed = mStickValue * (mMaxSpeed * mStickValue);
 #if TARGET_PC
-        if (dusk::getSettings().game.fastWalk && !checkWolf() && mProcID == PROC_MOVE) {
+        if (dusk::getSettings().game.fastRun && !checkWolf() && mProcID == PROC_MOVE) {
             max_speed *= 2.0f;
         }
 #endif

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -104,6 +104,7 @@ UserSettings g_userSettings = {
         .alwaysGreatspin {"game.alwaysGreatspin", false},
         .enableFastIronBoots {"game.enableFastIronBoots", false},
         .canTransformAnywhere {"game.canTransformAnywhere", false},
+        .fastWalk {"game.fastWalk", false},
         .fastRoll {"game.fastRoll", false},
         .fastSpinner {"game.fastSpinner", false},
         .freeMagicArmor {"game.freeMagicArmor", false},
@@ -225,6 +226,7 @@ void registerSettings() {
     Register(g_userSettings.game.disableCutscenePillarboxing);
     Register(g_userSettings.game.enableFastIronBoots);
     Register(g_userSettings.game.canTransformAnywhere);
+    Register(g_userSettings.game.fastWalk);
     Register(g_userSettings.game.fastRoll);
     Register(g_userSettings.game.freeMagicArmor);
     Register(g_userSettings.game.restoreWiiGlitches);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -104,7 +104,7 @@ UserSettings g_userSettings = {
         .alwaysGreatspin {"game.alwaysGreatspin", false},
         .enableFastIronBoots {"game.enableFastIronBoots", false},
         .canTransformAnywhere {"game.canTransformAnywhere", false},
-        .fastWalk {"game.fastWalk", false},
+        .fastRun {"game.fastRun", false},
         .fastRoll {"game.fastRoll", false},
         .fastSpinner {"game.fastSpinner", false},
         .freeMagicArmor {"game.freeMagicArmor", false},
@@ -226,7 +226,7 @@ void registerSettings() {
     Register(g_userSettings.game.disableCutscenePillarboxing);
     Register(g_userSettings.game.enableFastIronBoots);
     Register(g_userSettings.game.canTransformAnywhere);
-    Register(g_userSettings.game.fastWalk);
+    Register(g_userSettings.game.fastRun);
     Register(g_userSettings.game.fastRoll);
     Register(g_userSettings.game.freeMagicArmor);
     Register(g_userSettings.game.restoreWiiGlitches);

--- a/src/dusk/speedrun.cpp
+++ b/src/dusk/speedrun.cpp
@@ -31,6 +31,7 @@ void resetForSpeedrunMode() {
     getSettings().game.alwaysGreatspin.setSpeedrunValue(false);
     getSettings().game.enableFastIronBoots.setSpeedrunValue(false);
     getSettings().game.canTransformAnywhere.setSpeedrunValue(false);
+    getSettings().game.fastWalk.setSpeedrunValue(false);
     getSettings().game.fastRoll.setSpeedrunValue(false);
     getSettings().game.fastSpinner.setSpeedrunValue(false);
     getSettings().game.freeMagicArmor.setSpeedrunValue(false);

--- a/src/dusk/speedrun.cpp
+++ b/src/dusk/speedrun.cpp
@@ -31,7 +31,7 @@ void resetForSpeedrunMode() {
     getSettings().game.alwaysGreatspin.setSpeedrunValue(false);
     getSettings().game.enableFastIronBoots.setSpeedrunValue(false);
     getSettings().game.canTransformAnywhere.setSpeedrunValue(false);
-    getSettings().game.fastWalk.setSpeedrunValue(false);
+    getSettings().game.fastRun.setSpeedrunValue(false);
     getSettings().game.fastRoll.setSpeedrunValue(false);
     getSettings().game.fastSpinner.setSpeedrunValue(false);
     getSettings().game.freeMagicArmor.setSpeedrunValue(false);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -199,6 +199,7 @@ void reset_for_speedrun_mode() {
     getSettings().game.enableFastIronBoots.setSpeedrunValue(false);
     getSettings().game.canTransformAnywhere.setSpeedrunValue(false);
     getSettings().game.fastRoll.setSpeedrunValue(false);
+    getSettings().game.fastWalk.setSpeedrunValue(false);
     getSettings().game.fastSpinner.setSpeedrunValue(false);
     getSettings().game.freeMagicArmor.setSpeedrunValue(false);
     getSettings().game.invincibleEnemies.setSpeedrunValue(false);
@@ -1170,6 +1171,8 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             "Allows transforming even if NPCs are looking.");
         addCheat("Fast Roll", getSettings().game.fastRoll,
             "Makes Link's roll animation and movement twice as fast.");
+        addCheat("Fast Walk", getSettings().game.fastWalk,
+            "Makes Link's walking speed twice as fast.");
         addCheat("Fast Spinner", getSettings().game.fastSpinner,
             "Speeds up Spinner movement while holding R.");
         addCheat("Free Magic Armor", getSettings().game.freeMagicArmor,

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -199,7 +199,7 @@ void reset_for_speedrun_mode() {
     getSettings().game.enableFastIronBoots.setSpeedrunValue(false);
     getSettings().game.canTransformAnywhere.setSpeedrunValue(false);
     getSettings().game.fastRoll.setSpeedrunValue(false);
-    getSettings().game.fastWalk.setSpeedrunValue(false);
+    getSettings().game.fastRun.setSpeedrunValue(false);
     getSettings().game.fastSpinner.setSpeedrunValue(false);
     getSettings().game.freeMagicArmor.setSpeedrunValue(false);
     getSettings().game.invincibleEnemies.setSpeedrunValue(false);
@@ -1171,8 +1171,8 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             "Allows transforming even if NPCs are looking.");
         addCheat("Fast Roll", getSettings().game.fastRoll,
             "Makes Link's roll animation and movement twice as fast.");
-        addCheat("Fast Walk", getSettings().game.fastWalk,
-            "Makes Link's walking speed twice as fast.");
+        addCheat("Fast Run", getSettings().game.fastRun,
+            "Makes Link's running speed twice as fast.");
         addCheat("Fast Spinner", getSettings().game.fastSpinner,
             "Speeds up Spinner movement while holding R.");
         addCheat("Free Magic Armor", getSettings().game.freeMagicArmor,


### PR DESCRIPTION
## Summary

Adds a new `Fast Run` cheat that makes Link’s normal running movement twice as fast when enabled.

## Changes

- Added a new `game.fastRun` user setting.
- Registered `fastRun` with the settings system.
- Added `Fast Run` to the Cheats settings UI.
- Disabled `Fast Run` when speedrun mode resets cheat settings.
- Applied the speed multiplier in `daAlink_c::setNormalSpeedF()` for normal human movement.

## Behavior

When `Fast Run` is enabled, Link’s normal `PROC_MOVE` movement speed cap is multiplied by `2.0x`.

The cheat is intentionally scoped to normal human movement:
- Does not apply to wolf movement.
- Does not apply to sumo movement.
- Does not apply to lock-on movement.
- Does not directly modify animation playback speed.