### PR TITLE
Added a "Turbo Speed" setting to manage the target speed of the game.

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -179,6 +179,7 @@ struct UserSettings {
 
         // Controls
         ConfigVar<bool> enableTurboKeybind;
+        ConfigVar<float> turboSpeed;
         ConfigVar<bool> enableResetKeybind;
 
         // Tools

--- a/libs/JSystem/src/JFramework/JFWDisplay.cpp
+++ b/libs/JSystem/src/JFramework/JFWDisplay.cpp
@@ -384,7 +384,7 @@ static void waitForTick(u32 p1, u16 p2) {
         return;
     }
     if (dusk::getTransientSettings().skipFrameRateLimit) {
-        p1 = OS_TIMER_CLOCK / 120;
+        p1 = (int)((OS_TIMER_CLOCK / 30) / dusk::getSettings().game.turboSpeed);
     }
     
     #if TARGET_PC

--- a/src/dusk/game_clock.cpp
+++ b/src/dusk/game_clock.cpp
@@ -63,12 +63,8 @@ MainLoopPacer advance_main_loop() {
     }
 
     int sim_ticks_to_run = 0;
-    clock::time_point projected_snapshot_time = s_current_snapshot_time;
     const clock::time_point render_time = now - kSimPeriodDuration;
-    while (sim_ticks_to_run < kMaxSimTicksPerFrame && projected_snapshot_time < render_time) {
-        projected_snapshot_time += kSimPeriodDuration;
-        sim_ticks_to_run++;
-    }
+    sim_ticks_to_run = std::min(kMaxSimTicksPerFrame, (int)std::floor(std::chrono::duration<float>(render_time - s_current_snapshot_time)/kSimPeriodDuration));
     out.sim_ticks_to_run = sim_ticks_to_run;
     return out;
 }

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -114,6 +114,7 @@ UserSettings g_userSettings = {
 
         // Controls
         .enableTurboKeybind {"game.enableTurboKeybind", false},
+        .turboSpeed {"game.turboSpeed", 4.0f},
         .enableResetKeybind {"game.enableResetKeybind", false},
 
         // Tools
@@ -235,6 +236,7 @@ void registerSettings() {
     Register(g_userSettings.game.noLowHpSound);
     Register(g_userSettings.game.midnasLamentNonStop);
     Register(g_userSettings.game.enableTurboKeybind);
+    Register(g_userSettings.game.turboSpeed);
     Register(g_userSettings.game.enableResetKeybind);
     Register(g_userSettings.game.speedrunMode);
     Register(g_userSettings.game.liveSplitEnabled);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -422,8 +422,9 @@ SelectButton& config_percent_select(Pane& leftPane, Pane& rightPane, ConfigVar<f
         .key = std::move(key),
         .getValue = [&var] { return float_setting_percent(var); },
         .setValue =
-            [&var, min, max](int value) {
-                var.setValue(std::clamp(value, min, max) / 100.0f);
+            [&var, min, max, step](int value) {
+                int over = value - min;
+                var.setValue((min + std::clamp(step? (over - (over % step) + (((over % step) >= (step+1)>>1)? step : 0)) : over, 0, max - min)) / 100.0f);
                 config::Save();
             },
         .isDisabled = std::move(isDisabled),
@@ -932,8 +933,11 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
 
         leftPane.add_section("Tools");
         addOption("Turbo Key", getSettings().game.enableTurboKeybind,
-            "Hold Tab to increase game speed by up to 4x.",
+            "Hold Tab to adjust game speed up to the selected factor.",
             [] { return getSettings().game.speedrunMode; });
+        config_percent_select(leftPane, rightPane, getSettings().game.turboSpeed,
+            "Turbo Speed", "Adjusts the target speed of the game.", 10, 2000, 5,
+            [] { return (!getSettings().game.enableTurboKeybind || getSettings().game.speedrunMode); });
         addOption("Reset Key (" + Rml::String{hotkeys::DO_RESET} + ")",
             getSettings().game.enableResetKeybind,
             "Press " + Rml::String{hotkeys::DO_RESET} + " to reset the game.");


### PR DESCRIPTION
Value can range from 10% to 2000% at 5% steps.

Additionally, Percentage fields in the settings now automatically snap to the defined step value (rounding around `(step+1)>>1`).

Also made a minor optimization as I stumbled upon it in `src/dusk/game_clock.cpp`. Do tell me if it's out of scope for the pull request and I'll remove it.

Tested and working (For 10% to 400% atleast. My computer can't run it any faster).

Closes #1276