### PR TITLE
Infinite Rupee now set to max Rupees

### DIFF
--- a/src/f_ap/f_ap_game.cpp
+++ b/src/f_ap/f_ap_game.cpp
@@ -807,7 +807,7 @@ static void duskExecute() {
     }
 
     if (dusk::getSettings().game.infiniteRupees) {
-        dComIfGs_setRupee(9999);
+        dComIfGs_setRupee(dComIfGs_getRupeeMax());
     }
 
     if (dusk::getSettings().game.infiniteOxygen) {


### PR DESCRIPTION
Instead of forcing 9999 rupees, force the rupees to the maximum your wallet can hold.

This makes it so users might have to give rupees for Malo Mart multiple times, but it removes the issue where getting 1 rupee after disabling the cheat will scroll your rupees all the way back down to the maximum your wallet can hold.