### PR TITLE
fix rein interpolation jitter by rolling snapshot once per sim tick

### DIFF
--- a/include/dusk/frame_interpolation.h
+++ b/include/dusk/frame_interpolation.h
@@ -17,6 +17,7 @@ void ensure_initialized();
 void begin_record();
 void end_record();
 void begin_sim_tick();
+uint64_t sim_tick_seq();
 void begin_frame(bool enabled, bool is_sim_frame, float step);
 void interpolate();
 float get_interpolation_step();

--- a/src/d/actor/d_a_horse.cpp
+++ b/src/d/actor/d_a_horse.cpp
@@ -22,6 +22,7 @@
 
 #if TARGET_PC
 #include "dusk/dusk.h"
+#include "dusk/frame_interpolation.h"
 
 namespace {
 // FRAME INTERP NOTE: Sim tick control point snapshots for interpolation
@@ -32,6 +33,7 @@ int s_horseReinSimNumPrev;
 int s_horseReinSimNumCurr;
 bool s_horseReinSimPrevValid;
 bool s_horseReinSimCurrValid;
+uint64_t s_horseReinSimRolledSeq;
 }  // namespace
 #endif
 
@@ -3033,10 +3035,14 @@ void daHorse_c::copyReinPos() {
     }
 #if TARGET_PC
     if (field_0x1204 > 0) {
-        if (s_horseReinSimCurrValid && s_horseReinSimNumCurr > 0) {
-            memcpy(s_horseReinSimPrev, s_horseReinSimCurr, s_horseReinSimNumCurr * sizeof(cXyz));
-            s_horseReinSimNumPrev = s_horseReinSimNumCurr;
-            s_horseReinSimPrevValid = true;
+        const uint64_t simSeq = dusk::frame_interp::sim_tick_seq();
+        if (simSeq != s_horseReinSimRolledSeq) {
+            s_horseReinSimRolledSeq = simSeq;
+            if (s_horseReinSimCurrValid && s_horseReinSimNumCurr > 0) {
+                memcpy(s_horseReinSimPrev, s_horseReinSimCurr, s_horseReinSimNumCurr * sizeof(cXyz));
+                s_horseReinSimNumPrev = s_horseReinSimNumCurr;
+                s_horseReinSimPrevValid = true;
+            }
         }
         memcpy(s_horseReinSimCurr, m_reinLine.getPos(0), field_0x1204 * sizeof(cXyz));
         s_horseReinSimNumCurr = field_0x1204;

--- a/src/dusk/frame_interpolation.cpp
+++ b/src/dusk/frame_interpolation.cpp
@@ -21,6 +21,7 @@ bool g_sync_presentation = false;
 float g_step = 0.0f;
 bool g_is_sim_frame = false;
 bool g_ui_tick_pending = false;
+uint64_t g_sim_tick_seq = 0;
 
 Recording g_current_recording;
 Recording g_previous_recording;
@@ -135,6 +136,11 @@ void begin_sim_tick() {
 
     s_interpolationCallBackWork.clear();
     s_cam_prev = std::move(s_cam_curr);
+    ++g_sim_tick_seq;
+}
+
+uint64_t sim_tick_seq() {
+    return g_sim_tick_seq;
 }
 
 void begin_frame(bool enabled, bool is_sim_frame, float step) {


### PR DESCRIPTION
fix #1415 

this aim to ensure the interp snapshot rolls once per sim tick