### PR TITLE
feat: FPS Limiter

### DIFF
--- a/include/dusk/frame_interpolation.h
+++ b/include/dusk/frame_interpolation.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include "settings.h"
 
 class camera_process_class;
 class view_class;
@@ -18,7 +19,7 @@ void begin_record();
 void end_record();
 void begin_sim_tick();
 uint64_t sim_tick_seq();
-void begin_frame(bool enabled, bool is_sim_frame, float step);
+void begin_frame(FrameInterpMode mode, bool is_sim_frame, float step);
 void interpolate();
 float get_interpolation_step();
 

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -72,6 +72,7 @@ struct UserSettings {
         ConfigVar<bool> lockAspectRatio;
         ConfigVar<bool> enableFpsOverlay;
         ConfigVar<int> fpsOverlayCorner;
+        ConfigVar<int> maxFrameRate;
     } video;
 
     struct {

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -73,6 +73,7 @@ struct UserSettings {
         ConfigVar<bool> enableFpsOverlay;
         ConfigVar<int> fpsOverlayCorner;
         ConfigVar<int> maxFrameRate;
+        ConfigVar<int> maxFrameRatePreset;
     } video;
 
     struct {

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -36,8 +36,8 @@ enum class GyroMode : u8 {
 
 enum class FrameInterpMode : u8 {
     Off = 0,
-    Unlimited = 1,
-    Capped = 2,
+    Capped = 1,
+    Unlimited = 2,
 };
 
 namespace config {

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -34,6 +34,12 @@ enum class GyroMode : u8 {
     Mouse = 1,
 };
 
+enum class FrameInterpMode : u8 {
+    Off = 0,
+    Capped = 1,
+    Unlimited = 2,
+};
+
 namespace config {
 template <>
 struct ConfigEnumRange<BloomMode> {
@@ -58,6 +64,12 @@ struct ConfigEnumRange<GyroMode> {
     static constexpr auto min = GyroMode::Sensor;
     static constexpr auto max = GyroMode::Mouse;
 };
+
+template <>
+struct ConfigEnumRange<FrameInterpMode> {
+    static constexpr auto min = FrameInterpMode::Off;
+    static constexpr auto max = FrameInterpMode::Unlimited;
+};
 }
 
 // Persistent user settings
@@ -73,7 +85,6 @@ struct UserSettings {
         ConfigVar<bool> enableFpsOverlay;
         ConfigVar<int> fpsOverlayCorner;
         ConfigVar<int> maxFrameRate;
-        ConfigVar<int> maxFrameRatePreset;
     } video;
 
     struct {
@@ -125,7 +136,7 @@ struct UserSettings {
         ConfigVar<BloomMode> bloomMode;
         ConfigVar<float> bloomMultiplier;
         ConfigVar<bool> disableWaterRefraction;
-        ConfigVar<bool> enableFrameInterpolation;
+        ConfigVar<FrameInterpMode> enableFrameInterpolation;
         ConfigVar<int> internalResolutionScale;
         ConfigVar<int> shadowResolutionMultiplier;
         ConfigVar<bool> enableDepthOfField;

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -36,8 +36,8 @@ enum class GyroMode : u8 {
 
 enum class FrameInterpMode : u8 {
     Off = 0,
-    Capped = 1,
-    Unlimited = 2,
+    Unlimited = 1,
+    Capped = 2,
 };
 
 namespace config {
@@ -70,7 +70,7 @@ struct ConfigEnumRange<FrameInterpMode> {
     static constexpr auto min = FrameInterpMode::Off;
     static constexpr auto max = FrameInterpMode::Unlimited;
 };
-}
+}  // namespace config
 
 // Persistent user settings
 

--- a/include/dusk/time.h
+++ b/include/dusk/time.h
@@ -18,7 +18,6 @@
 #include <intrin.h>
 #endif
 #ifdef __APPLE__
-#include <pthread/qos.h>
 #include <mach/mach_time.h>
 #endif
 

--- a/include/dusk/time.h
+++ b/include/dusk/time.h
@@ -17,16 +17,21 @@
 #include <shellapi.h>
 #include <intrin.h>
 #endif
+#ifdef __APPLE__
+#include <pthread/qos.h>
+#endif
 
 class Limiter {
 public:
   using duration_t = Uint64;
 
-  void Reset() { m_oldTime = SDL_GetTicksNS(); }
+  void Reset() { 
+    m_oldTime = SDL_GetTicksNS(); 
+  }
 
-  void Sleep(duration_t targetFrameTime) {
+  duration_t Sleep(duration_t targetFrameTime) {
     if (targetFrameTime == 0) {
-      return;
+      return 0;
     }
 
     const Uint64 start = SDL_GetTicksNS();
@@ -41,6 +46,8 @@ public:
       }
     }
     Reset();
+
+    return adjustedSleepTime;
   }
 
   duration_t SleepTime(duration_t targetFrameTime) {
@@ -99,7 +106,20 @@ private:
     } while (current.QuadPart - start.QuadPart < ticksToWait);
   }
 #else
-  void NanoSleep(const duration_t duration) { SDL_DelayPrecise(duration); }
+  void NanoSleep(const duration_t duration) { 
+#if defined(__APPLE__)
+    const Uint64 start = SDL_GetTicksNS();
+    while ((SDL_GetTicksNS() - start) < duration) {
+        #if defined(__arm__) || defined(__aarch64__)
+        asm volatile("yield" ::: "memory"); // yields to the hardware, not the scheduler.
+        #else
+        _mm_pause();
+        #endif
+    }
+#else
+    SDL_DelayPrecise(duration); 
+#endif
+  }
 #endif
 };
 

--- a/include/dusk/time.h
+++ b/include/dusk/time.h
@@ -115,7 +115,7 @@ private:
       uint64_t total_mach_ticks = (duration * timebase_info.denom) / timebase_info.numer;
       uint64_t target_mach = start_mach + total_mach_ticks;
 
-      uint64_t buffer_ns = 2 '000' 000ULL;
+      uint64_t buffer_ns = 2'000'000ULL;
       uint64_t buffer_mach_ticks = (buffer_ns * timebase_info.denom) / timebase_info.numer;
 
       if (total_mach_ticks > buffer_mach_ticks) {

--- a/include/dusk/time.h
+++ b/include/dusk/time.h
@@ -81,8 +81,6 @@ private:
     if (!initialized || numSleeps++ % 1000 == 0) {
       LARGE_INTEGER freq;
       if (QueryPerformanceFrequency(&freq) == 0) {
-        /// Todo: Make this log work again possibly.
-        //DuskLog.warn("QueryPerformanceFrequency failed: {}", GetLastError());
         return;
       }
       countPerNs = static_cast<double>(freq.QuadPart) / 1e9;
@@ -106,19 +104,18 @@ private:
 #endif
     } while (current.QuadPart - start.QuadPart < ticksToWait);
   }
-#else
-  void NanoSleep(const duration_t duration) { 
-#if defined(__APPLE__)
+#elif defined (__APPLE__)
+  void NanoSleep(const duration_t duration) {
       // Hybrid approach using Apple Mach
       uint64_t start_mach = mach_absolute_time();
-      
+
       mach_timebase_info_data_t timebase_info;
       mach_timebase_info(&timebase_info);
-      
+
       uint64_t total_mach_ticks = (duration * timebase_info.denom) / timebase_info.numer;
       uint64_t target_mach = start_mach + total_mach_ticks;
-      
-      uint64_t buffer_ns = 2'000'000ULL;
+
+      uint64_t buffer_ns = 2 '000' 000ULL;
       uint64_t buffer_mach_ticks = (buffer_ns * timebase_info.denom) / timebase_info.numer;
 
       if (total_mach_ticks > buffer_mach_ticks) {
@@ -127,16 +124,15 @@ private:
       }
 
       while (mach_absolute_time() < target_mach) {
-          #if defined(__aarch64__) || defined(__arm__)
-          asm volatile("yield" ::: "memory"); // Hardware hint, not a scheduler hint.
-          #else
-          _mm_pause();
-          #endif
-      }
+#if defined(__aarch64__) || defined(__arm__)
+          asm volatile("yield" ::: "memory");  // Hardware hint, not a scheduler hint.
 #else
-    SDL_DelayPrecise(duration); 
+          _mm_pause();
 #endif
+      }
   }
+#else
+  void NanoSleep(const duration_t duration) { SDL_DelayPrecise(duration); }
 #endif
 };
 

--- a/include/dusk/time.h
+++ b/include/dusk/time.h
@@ -19,6 +19,7 @@
 #endif
 #ifdef __APPLE__
 #include <pthread/qos.h>
+#include <mach/mach_time.h>
 #endif
 
 class Limiter {
@@ -81,7 +82,8 @@ private:
     if (!initialized || numSleeps++ % 1000 == 0) {
       LARGE_INTEGER freq;
       if (QueryPerformanceFrequency(&freq) == 0) {
-        DuskLog.warn("QueryPerformanceFrequency failed: {}", GetLastError());
+        /// Todo: Make this log work again possibly.
+        //DuskLog.warn("QueryPerformanceFrequency failed: {}", GetLastError());
         return;
       }
       countPerNs = static_cast<double>(freq.QuadPart) / 1e9;
@@ -108,14 +110,30 @@ private:
 #else
   void NanoSleep(const duration_t duration) { 
 #if defined(__APPLE__)
-    const Uint64 start = SDL_GetTicksNS();
-    while ((SDL_GetTicksNS() - start) < duration) {
-        #if defined(__arm__) || defined(__aarch64__)
-        asm volatile("yield" ::: "memory"); // yields to the hardware, not the scheduler.
-        #else
-        _mm_pause();
-        #endif
-    }
+      // Hybrid approach using Apple Mach
+      uint64_t start_mach = mach_absolute_time();
+      
+      mach_timebase_info_data_t timebase_info;
+      mach_timebase_info(&timebase_info);
+      
+      uint64_t total_mach_ticks = (duration * timebase_info.denom) / timebase_info.numer;
+      uint64_t target_mach = start_mach + total_mach_ticks;
+      
+      uint64_t buffer_ns = 2'000'000ULL;
+      uint64_t buffer_mach_ticks = (buffer_ns * timebase_info.denom) / timebase_info.numer;
+
+      if (total_mach_ticks > buffer_mach_ticks) {
+          uint64_t sleep_until_mach = target_mach - buffer_mach_ticks;
+          mach_wait_until(sleep_until_mach);
+      }
+
+      while (mach_absolute_time() < target_mach) {
+          #if defined(__aarch64__) || defined(__arm__)
+          asm volatile("yield" ::: "memory"); // Hardware hint, not a scheduler hint.
+          #else
+          _mm_pause();
+          #endif
+      }
 #else
     SDL_DelayPrecise(duration); 
 #endif

--- a/libs/JSystem/src/JFramework/JFWDisplay.cpp
+++ b/libs/JSystem/src/JFramework/JFWDisplay.cpp
@@ -382,7 +382,7 @@ static void waitForTick(u32 p1, u16 p2) {
 
     // RULE 1: If we are interpolating, the OUTER main loop handles the frame rate cap.
     // Inner JFWDisplay ticks must return immediately to keep the simulation pacing accurate!
-    if (dusk::getSettings().game.enableFrameInterpolation && !dusk::getTransientSettings().skipFrameRateLimit) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off && !dusk::getTransientSettings().skipFrameRateLimit) {
         dusk::frameUsagePct = 0.f; 
         return; 
     }

--- a/libs/JSystem/src/JFramework/JFWDisplay.cpp
+++ b/libs/JSystem/src/JFramework/JFWDisplay.cpp
@@ -380,7 +380,14 @@ static void waitPrecise(Limiter& limiter, Limiter::duration_t targetNs) {
 static void waitForTick(u32 p1, u16 p2) {
 #if TARGET_PC
     if (dusk::getSettings().game.enableFrameInterpolation && !dusk::getTransientSettings().skipFrameRateLimit) {
-        dusk::frameUsagePct = 0.f;
+        const int frameRateCap = dusk::getSettings().video.maxFrameRate.getValue();
+        if (frameRateCap > 0) {
+            static Limiter limiter;
+            waitPrecise(limiter, static_cast<Limiter::duration_t>(
+                                     1000000000ULL / static_cast<u32>(frameRateCap)));
+        } else {
+            dusk::frameUsagePct = 0.f;
+        }
         return;
     }
     if (dusk::getTransientSettings().skipFrameRateLimit) {

--- a/libs/JSystem/src/JFramework/JFWDisplay.cpp
+++ b/libs/JSystem/src/JFramework/JFWDisplay.cpp
@@ -370,7 +370,7 @@ constexpr auto FRAME_PERIOD = std::chrono::duration_cast<std::chrono::nanosecond
 constexpr auto RETRACE_PERIOD = FRAME_PERIOD / 2;
 
 static void waitPrecise(Limiter& limiter, Limiter::duration_t targetNs) {
-    Limiter::duration_t sleepTime = limiter.Sleep(targetNs);
+   const auto sleepTime = limiter.Sleep(targetNs);
     dusk::frameUsagePct =
         100.0f * (1.0f - static_cast<float>(sleepTime) / static_cast<float>(targetNs));
 }
@@ -380,9 +380,7 @@ static void waitForTick(u32 p1, u16 p2) {
 #if TARGET_PC
     static Limiter limiter;
 
-    // RULE 1: If we are interpolating, the OUTER main loop handles the frame rate cap.
-    // Inner JFWDisplay ticks must return immediately to keep the simulation pacing accurate!
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off && !dusk::getTransientSettings().skipFrameRateLimit) {
+    if (dusk::frame_interp::is_enabled() && !dusk::getTransientSettings().skipFrameRateLimit) {
         dusk::frameUsagePct = 0.f; 
         return; 
     }

--- a/libs/JSystem/src/JFramework/JFWDisplay.cpp
+++ b/libs/JSystem/src/JFramework/JFWDisplay.cpp
@@ -370,35 +370,30 @@ constexpr auto FRAME_PERIOD = std::chrono::duration_cast<std::chrono::nanosecond
 constexpr auto RETRACE_PERIOD = FRAME_PERIOD / 2;
 
 static void waitPrecise(Limiter& limiter, Limiter::duration_t targetNs) {
-    const auto sleepTime = limiter.SleepTime(targetNs);
+    Limiter::duration_t sleepTime = limiter.Sleep(targetNs);
     dusk::frameUsagePct =
         100.0f * (1.0f - static_cast<float>(sleepTime) / static_cast<float>(targetNs));
-    limiter.Sleep(targetNs);
 }
 #endif
 
 static void waitForTick(u32 p1, u16 p2) {
 #if TARGET_PC
+    static Limiter limiter;
+
+    // RULE 1: If we are interpolating, the OUTER main loop handles the frame rate cap.
+    // Inner JFWDisplay ticks must return immediately to keep the simulation pacing accurate!
     if (dusk::getSettings().game.enableFrameInterpolation && !dusk::getTransientSettings().skipFrameRateLimit) {
-        const int frameRateCap = dusk::getSettings().video.maxFrameRate.getValue();
-        if (frameRateCap > 0) {
-            static Limiter limiter;
-            waitPrecise(limiter, static_cast<Limiter::duration_t>(
-                                     1000000000ULL / static_cast<u32>(frameRateCap)));
-        } else {
-            dusk::frameUsagePct = 0.f;
-        }
-        return;
+        dusk::frameUsagePct = 0.f; 
+        return; 
     }
+
     if (dusk::getTransientSettings().skipFrameRateLimit) {
         p1 = OS_TIMER_CLOCK / 120;
     }
     
-    #if TARGET_PC
     if (fopOvlpM_IsPeek() && dusk::getTransientSettings().stateShareLoadActive) {
         return;
     }
-    #endif
 
     ZoneScopedC(tracy::Color::DimGray);
 #endif

--- a/libs/JSystem/src/JStudio/JStudio/jstudio-object.cpp
+++ b/libs/JSystem/src/JStudio/JStudio/jstudio-object.cpp
@@ -655,7 +655,7 @@ value_or_fun:
 
 value:
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation && u <= 5 &&
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off && u <= 5 &&
         (operation == data::UNK_0x2 || operation == data::UNK_0x3 || operation == data::UNK_0x12))
     {
         dusk::frame_interp::request_presentation_sync();
@@ -666,7 +666,7 @@ value:
 
 value_n:
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation &&
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off &&
         (pN == TAdaptor_camera::sauVariableValue_3_POSITION_XYZ || pN == TAdaptor_camera::sauVariableValue_3_TARGET_POSITION_XYZ) &&
         (operation == data::UNK_0x2 || operation == data::UNK_0x3 || operation == data::UNK_0x12))
     {

--- a/libs/JSystem/src/JStudio/JStudio/jstudio-object.cpp
+++ b/libs/JSystem/src/JStudio/JStudio/jstudio-object.cpp
@@ -655,7 +655,7 @@ value_or_fun:
 
 value:
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off && u <= 5 &&
+    if (dusk::frame_interp::is_enabled() && u <= 5 &&
         (operation == data::UNK_0x2 || operation == data::UNK_0x3 || operation == data::UNK_0x12))
     {
         dusk::frame_interp::request_presentation_sync();
@@ -666,7 +666,7 @@ value:
 
 value_n:
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off &&
+    if (dusk::frame_interp::is_enabled() &&
         (pN == TAdaptor_camera::sauVariableValue_3_POSITION_XYZ || pN == TAdaptor_camera::sauVariableValue_3_TARGET_POSITION_XYZ) &&
         (operation == data::UNK_0x2 || operation == data::UNK_0x3 || operation == data::UNK_0x12))
     {

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -5990,7 +5990,7 @@ void daAlink_c::setItemMatrix(int param_0) {
 
         mDoMtx_stack_c::XrotS(-0x8000);
 #ifdef TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation) {
+        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
             Mtx boot_mtx;
             mDoMtx_concat(mpLinkModel->getAnmMtx(0x18), mDoMtx_stack_c::get(), boot_mtx);
             mpLinkBootModels[1]->setAnmMtx(1, boot_mtx);
@@ -19772,7 +19772,7 @@ int daAlink_c::draw() {
                 dComIfGd_getOpaListDark()->entryImm(mpHookChain, 0);
 
 #if TARGET_PC
-                if (dusk::getSettings().game.enableFrameInterpolation &&
+                if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off &&
                     mEquipItem == dItemNo_IRONBALL_e &&
                     mIronBallChainPos != NULL && mIronBallChainAngle != NULL)
                 {

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -5990,7 +5990,7 @@ void daAlink_c::setItemMatrix(int param_0) {
 
         mDoMtx_stack_c::XrotS(-0x8000);
 #ifdef TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+        if (dusk::frame_interp::is_enabled()) {
             Mtx boot_mtx;
             mDoMtx_concat(mpLinkModel->getAnmMtx(0x18), mDoMtx_stack_c::get(), boot_mtx);
             mpLinkBootModels[1]->setAnmMtx(1, boot_mtx);
@@ -19772,7 +19772,7 @@ int daAlink_c::draw() {
                 dComIfGd_getOpaListDark()->entryImm(mpHookChain, 0);
 
 #if TARGET_PC
-                if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off &&
+                if (dusk::frame_interp::is_enabled() &&
                     mEquipItem == dItemNo_IRONBALL_e &&
                     mIronBallChainPos != NULL && mIronBallChainAngle != NULL)
                 {

--- a/src/d/actor/d_a_b_gnd.cpp
+++ b/src/d/actor/d_a_b_gnd.cpp
@@ -397,7 +397,7 @@ static int daB_GND_Draw(b_gnd_class* i_this) {
         i_this->field_0x21e8.update(2, l_color, &a_this->tevStr);
         dComIfGd_set3DlineMat(&i_this->field_0x21e8);
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+        if (dusk::frame_interp::is_enabled()) {
             if (i_this->mReinsInterpCurrValid) {
                 memcpy(i_this->mReinsInterpPrev, i_this->mReinsInterpCurr, sizeof(i_this->mReinsInterpCurr));
                 memcpy(i_this->mReinsTexInterpPrev, i_this->mReinsTexInterpCurr, sizeof(i_this->mReinsTexInterpCurr));

--- a/src/d/actor/d_a_b_gnd.cpp
+++ b/src/d/actor/d_a_b_gnd.cpp
@@ -397,7 +397,7 @@ static int daB_GND_Draw(b_gnd_class* i_this) {
         i_this->field_0x21e8.update(2, l_color, &a_this->tevStr);
         dComIfGd_set3DlineMat(&i_this->field_0x21e8);
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation) {
+        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
             if (i_this->mReinsInterpCurrValid) {
                 memcpy(i_this->mReinsInterpPrev, i_this->mReinsInterpCurr, sizeof(i_this->mReinsInterpCurr));
                 memcpy(i_this->mReinsTexInterpPrev, i_this->mReinsTexInterpCurr, sizeof(i_this->mReinsTexInterpCurr));

--- a/src/d/actor/d_a_e_db.cpp
+++ b/src/d/actor/d_a_e_db.cpp
@@ -116,7 +116,7 @@ static int daE_DB_Draw(e_db_class* i_this) {
     i_this->stalkLine.update(12, l_color, &actor->tevStr);
     dComIfGd_set3DlineMat(&i_this->stalkLine);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         if (i_this->mStalkLineInterpCurrValid) {
             memcpy(i_this->mStalkLineInterpPrev, i_this->mStalkLineInterpCurr, sizeof(i_this->mStalkLineInterpCurr));
             i_this->mStalkLineInterpPrevValid = true;

--- a/src/d/actor/d_a_e_db.cpp
+++ b/src/d/actor/d_a_e_db.cpp
@@ -116,7 +116,7 @@ static int daE_DB_Draw(e_db_class* i_this) {
     i_this->stalkLine.update(12, l_color, &actor->tevStr);
     dComIfGd_set3DlineMat(&i_this->stalkLine);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         if (i_this->mStalkLineInterpCurrValid) {
             memcpy(i_this->mStalkLineInterpPrev, i_this->mStalkLineInterpCurr, sizeof(i_this->mStalkLineInterpCurr));
             i_this->mStalkLineInterpPrevValid = true;

--- a/src/d/actor/d_a_e_hb.cpp
+++ b/src/d/actor/d_a_e_hb.cpp
@@ -103,7 +103,7 @@ static int daE_HB_Draw(e_hb_class* i_this) {
     i_this->stalkLine.update(12, l_color, &actor->tevStr);
     dComIfGd_set3DlineMat(&i_this->stalkLine);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         if (i_this->mStalkLineInterpCurrValid) {
             memcpy(i_this->mStalkLineInterpPrev, i_this->mStalkLineInterpCurr, sizeof(i_this->mStalkLineInterpCurr));
             i_this->mStalkLineInterpPrevValid = true;

--- a/src/d/actor/d_a_e_hb.cpp
+++ b/src/d/actor/d_a_e_hb.cpp
@@ -103,7 +103,7 @@ static int daE_HB_Draw(e_hb_class* i_this) {
     i_this->stalkLine.update(12, l_color, &actor->tevStr);
     dComIfGd_set3DlineMat(&i_this->stalkLine);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         if (i_this->mStalkLineInterpCurrValid) {
             memcpy(i_this->mStalkLineInterpPrev, i_this->mStalkLineInterpCurr, sizeof(i_this->mStalkLineInterpCurr));
             i_this->mStalkLineInterpPrevValid = true;

--- a/src/d/actor/d_a_e_mb.cpp
+++ b/src/d/actor/d_a_e_mb.cpp
@@ -105,7 +105,7 @@ static int daE_MB_Draw(e_mb_class* i_this) {
     i_this->mRopeMat.update(16, l_color, &a_this->tevStr);
     dComIfGd_set3DlineMat(&i_this->mRopeMat);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         if (i_this->mRopeInterpCurrValid) {
             memcpy(i_this->mRopeInterpPrev, i_this->mRopeInterpCurr, sizeof(i_this->mRopeInterpCurr));
             i_this->mRopeInterpPrevValid = true;

--- a/src/d/actor/d_a_e_mb.cpp
+++ b/src/d/actor/d_a_e_mb.cpp
@@ -105,7 +105,7 @@ static int daE_MB_Draw(e_mb_class* i_this) {
     i_this->mRopeMat.update(16, l_color, &a_this->tevStr);
     dComIfGd_set3DlineMat(&i_this->mRopeMat);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         if (i_this->mRopeInterpCurrValid) {
             memcpy(i_this->mRopeInterpPrev, i_this->mRopeInterpCurr, sizeof(i_this->mRopeInterpCurr));
             i_this->mRopeInterpPrevValid = true;

--- a/src/d/actor/d_a_e_s1.cpp
+++ b/src/d/actor/d_a_e_s1.cpp
@@ -154,7 +154,7 @@ static int daE_S1_Draw(e_s1_class* i_this) {
     dComIfGd_set3DlineMatDark(&i_this->mLineMat);
 
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         if (i_this->mHairInterpCurrValid) {
             memcpy(i_this->mHairInterpPrev, i_this->mHairInterpCurr, sizeof(i_this->mHairInterpCurr));
             i_this->mHairInterpPrevValid = true;

--- a/src/d/actor/d_a_e_s1.cpp
+++ b/src/d/actor/d_a_e_s1.cpp
@@ -154,7 +154,7 @@ static int daE_S1_Draw(e_s1_class* i_this) {
     dComIfGd_set3DlineMatDark(&i_this->mLineMat);
 
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         if (i_this->mHairInterpCurrValid) {
             memcpy(i_this->mHairInterpPrev, i_this->mHairInterpCurr, sizeof(i_this->mHairInterpCurr));
             i_this->mHairInterpPrevValid = true;

--- a/src/d/actor/d_a_e_wb.cpp
+++ b/src/d/actor/d_a_e_wb.cpp
@@ -535,7 +535,7 @@ static int daE_WB_Draw(e_wb_class* i_this) {
         i_this->himo_tex.update(2, l_color, &actor->tevStr);
         dComIfGd_set3DlineMat(&i_this->himo_tex);
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation) {
+        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
             if (i_this->himo_interp_curr_valid) {
                 memcpy(i_this->himo_mat_interp_prev, i_this->himo_mat_interp_curr, sizeof(i_this->himo_mat_interp_curr));
                 memcpy(i_this->himo_tex_interp_prev, i_this->himo_tex_interp_curr, sizeof(i_this->himo_tex_interp_curr));

--- a/src/d/actor/d_a_e_wb.cpp
+++ b/src/d/actor/d_a_e_wb.cpp
@@ -535,7 +535,7 @@ static int daE_WB_Draw(e_wb_class* i_this) {
         i_this->himo_tex.update(2, l_color, &actor->tevStr);
         dComIfGd_set3DlineMat(&i_this->himo_tex);
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+        if (dusk::frame_interp::is_enabled()) {
             if (i_this->himo_interp_curr_valid) {
                 memcpy(i_this->himo_mat_interp_prev, i_this->himo_mat_interp_curr, sizeof(i_this->himo_mat_interp_curr));
                 memcpy(i_this->himo_tex_interp_prev, i_this->himo_tex_interp_curr, sizeof(i_this->himo_tex_interp_curr));

--- a/src/d/actor/d_a_e_yd.cpp
+++ b/src/d/actor/d_a_e_yd.cpp
@@ -107,7 +107,7 @@ static s32 daE_YD_Draw(e_yd_class* i_this) {
     i_this->mLineMat.update(12, l_color, &i_this->actor.tevStr);
     dComIfGd_set3DlineMat(&i_this->mLineMat);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         if (i_this->mLineMatInterpCurrValid) {
             memcpy(i_this->mLineMatInterpPrev, i_this->mLineMatInterpCurr, sizeof(i_this->mLineMatInterpCurr));
             i_this->mLineMatInterpPrevValid = true;

--- a/src/d/actor/d_a_e_yd.cpp
+++ b/src/d/actor/d_a_e_yd.cpp
@@ -107,7 +107,7 @@ static s32 daE_YD_Draw(e_yd_class* i_this) {
     i_this->mLineMat.update(12, l_color, &i_this->actor.tevStr);
     dComIfGd_set3DlineMat(&i_this->mLineMat);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         if (i_this->mLineMatInterpCurrValid) {
             memcpy(i_this->mLineMatInterpPrev, i_this->mLineMatInterpCurr, sizeof(i_this->mLineMatInterpCurr));
             i_this->mLineMatInterpPrevValid = true;

--- a/src/d/actor/d_a_e_yg.cpp
+++ b/src/d/actor/d_a_e_yg.cpp
@@ -183,7 +183,7 @@ static int daE_YG_Draw(e_yg_class* i_this) {
     dComIfGd_set3DlineMatDark(&i_this->mLineMat);
 
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         if (i_this->mTentacleInterpCurrValid) {
             memcpy(i_this->mTentacleInterpPrev, i_this->mTentacleInterpCurr, sizeof(i_this->mTentacleInterpCurr));
             i_this->mTentacleInterpPrevValid = true;

--- a/src/d/actor/d_a_e_yg.cpp
+++ b/src/d/actor/d_a_e_yg.cpp
@@ -183,7 +183,7 @@ static int daE_YG_Draw(e_yg_class* i_this) {
     dComIfGd_set3DlineMatDark(&i_this->mLineMat);
 
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         if (i_this->mTentacleInterpCurrValid) {
             memcpy(i_this->mTentacleInterpPrev, i_this->mTentacleInterpCurr, sizeof(i_this->mTentacleInterpCurr));
             i_this->mTentacleInterpPrevValid = true;

--- a/src/d/actor/d_a_e_yh.cpp
+++ b/src/d/actor/d_a_e_yh.cpp
@@ -135,7 +135,7 @@ static int daE_YH_Draw(e_yh_class* i_this) {
     i_this->mLine.update(12, l_color, &a_this->tevStr);
     dComIfGd_set3DlineMat(&i_this->mLine);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         if (i_this->mLineInterpCurrValid) {
             memcpy(i_this->mLineInterpPrev, i_this->mLineInterpCurr, sizeof(i_this->mLineInterpCurr));
             i_this->mLineInterpPrevValid = true;

--- a/src/d/actor/d_a_e_yh.cpp
+++ b/src/d/actor/d_a_e_yh.cpp
@@ -135,7 +135,7 @@ static int daE_YH_Draw(e_yh_class* i_this) {
     i_this->mLine.update(12, l_color, &a_this->tevStr);
     dComIfGd_set3DlineMat(&i_this->mLine);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         if (i_this->mLineInterpCurrValid) {
             memcpy(i_this->mLineInterpPrev, i_this->mLineInterpCurr, sizeof(i_this->mLineInterpCurr));
             i_this->mLineInterpPrevValid = true;

--- a/src/d/actor/d_a_horse.cpp
+++ b/src/d/actor/d_a_horse.cpp
@@ -3165,7 +3165,7 @@ void daHorse_c::setReinPosNormalSubstance() {
 #if TARGET_PC
 void daHorse_c::lerpControlPoints(f32 alpha) {
     // FRAME INTERP NOTE: Currently only lerping points for Epona's reins. Need a more global solution.
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off || !s_horseReinSimPrevValid || !s_horseReinSimCurrValid) {
+    if (!dusk::frame_interp::is_enabled() || !s_horseReinSimPrevValid || !s_horseReinSimCurrValid) {
         return;
     }
     const int nCurr = s_horseReinSimNumCurr;

--- a/src/d/actor/d_a_horse.cpp
+++ b/src/d/actor/d_a_horse.cpp
@@ -3165,7 +3165,7 @@ void daHorse_c::setReinPosNormalSubstance() {
 #if TARGET_PC
 void daHorse_c::lerpControlPoints(f32 alpha) {
     // FRAME INTERP NOTE: Currently only lerping points for Epona's reins. Need a more global solution.
-    if (!dusk::getSettings().game.enableFrameInterpolation || !s_horseReinSimPrevValid || !s_horseReinSimCurrValid) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off || !s_horseReinSimPrevValid || !s_horseReinSimCurrValid) {
         return;
     }
     const int nCurr = s_horseReinSimNumCurr;

--- a/src/d/actor/d_a_obj_fchain.cpp
+++ b/src/d/actor/d_a_obj_fchain.cpp
@@ -325,7 +325,7 @@ int daObjFchain_c::draw() {
         dComIfGd_getOpaListDark()->entryImm(&mShape, 0);
 
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+        if (dusk::frame_interp::is_enabled()) {
             if (mChainInterpCurrValid) {
                 memcpy(mChainInterpPrev, mChainInterpCurr, sizeof(mChainInterpCurr));
                 mChainInterpPrevValid = true;

--- a/src/d/actor/d_a_obj_fchain.cpp
+++ b/src/d/actor/d_a_obj_fchain.cpp
@@ -325,7 +325,7 @@ int daObjFchain_c::draw() {
         dComIfGd_getOpaListDark()->entryImm(&mShape, 0);
 
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation) {
+        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
             if (mChainInterpCurrValid) {
                 memcpy(mChainInterpPrev, mChainInterpCurr, sizeof(mChainInterpCurr));
                 mChainInterpPrevValid = true;

--- a/src/d/actor/d_a_obj_klift00.cpp
+++ b/src/d/actor/d_a_obj_klift00.cpp
@@ -493,7 +493,7 @@ int daObjKLift00_c::Draw() {
     dComIfGd_setList();
 
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         if (mChainInterpCurrValid) {
             memcpy(mChainInterpPrev, mChainInterpCurr, mNumChains * sizeof(cXyz));
             mChainInterpPrevValid = true;

--- a/src/d/actor/d_a_obj_klift00.cpp
+++ b/src/d/actor/d_a_obj_klift00.cpp
@@ -493,7 +493,7 @@ int daObjKLift00_c::Draw() {
     dComIfGd_setList();
 
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         if (mChainInterpCurrValid) {
             memcpy(mChainInterpPrev, mChainInterpCurr, mNumChains * sizeof(cXyz));
             mChainInterpPrevValid = true;

--- a/src/d/actor/d_a_title.cpp
+++ b/src/d/actor/d_a_title.cpp
@@ -170,7 +170,7 @@ int daTitle_c::Execute() {
     }
 
 #ifdef TARGET_PC
-    if (!dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off) {
 #endif
         dMenu_Collect3D_c::setViewPortOffsetY(0.0f);
 #ifdef TARGET_PC
@@ -354,7 +354,7 @@ void daTitle_c::fastLogoDispInit() {
     mProcID = 5;
 
 #ifdef TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         dusk::frame_interp::request_presentation_sync();
     }
 #endif

--- a/src/d/actor/d_a_title.cpp
+++ b/src/d/actor/d_a_title.cpp
@@ -354,7 +354,7 @@ void daTitle_c::fastLogoDispInit() {
     mProcID = 5;
 
 #ifdef TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         dusk::frame_interp::request_presentation_sync();
     }
 #endif

--- a/src/d/actor/d_a_title.cpp
+++ b/src/d/actor/d_a_title.cpp
@@ -170,7 +170,7 @@ int daTitle_c::Execute() {
     }
 
 #ifdef TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off) {
+    if (!dusk::frame_interp::is_enabled()) {
 #endif
         dMenu_Collect3D_c::setViewPortOffsetY(0.0f);
 #ifdef TARGET_PC

--- a/src/d/d_camera.cpp
+++ b/src/d/d_camera.cpp
@@ -10431,7 +10431,7 @@ bool dCamera_c::eventCamera(s32 param_0) {
 #endif
 
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation) {
+        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
             switch (var_r29) {
                 case 3:
                 case 4:
@@ -11322,7 +11322,7 @@ static int camera_execute(camera_process_class* i_this) {
 #ifdef TARGET_PC
     widezoom_correction(i_this, i_this->mCamera.TrimHeight());
 
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         dusk::frame_interp::add_interpolation_callback([](bool _, void* pUserWork) {
             const auto i_this = static_cast<camera_process_class*>(pUserWork);
             const auto camera = &i_this->mCamera;

--- a/src/d/d_camera.cpp
+++ b/src/d/d_camera.cpp
@@ -10431,7 +10431,7 @@ bool dCamera_c::eventCamera(s32 param_0) {
 #endif
 
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+        if (dusk::frame_interp::is_enabled()) {
             switch (var_r29) {
                 case 3:
                 case 4:
@@ -11322,7 +11322,7 @@ static int camera_execute(camera_process_class* i_this) {
 #ifdef TARGET_PC
     widezoom_correction(i_this, i_this->mCamera.TrimHeight());
 
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         dusk::frame_interp::add_interpolation_callback([](bool _, void* pUserWork) {
             const auto i_this = static_cast<camera_process_class*>(pUserWork);
             const auto camera = &i_this->mCamera;

--- a/src/d/d_menu_dmap.cpp
+++ b/src/d/d_menu_dmap.cpp
@@ -2624,7 +2624,7 @@ void dMenu_Dmap_c::zoomIn_proc() {
 
 void dMenu_Dmap_c::zoomOut_init_proc() {
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         mpDrawBg->resetScrollArrowMask();
     }
 #endif

--- a/src/d/d_menu_dmap.cpp
+++ b/src/d/d_menu_dmap.cpp
@@ -991,7 +991,7 @@ void dMenu_DmapBg_c::draw() {
             -35.0f + (local_224.x - local_218.x),
             -35.0f + (local_224.y - local_218.y));
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off) {
+        if (!dusk::frame_interp::is_enabled()) {
             field_0xdda = 0;
         }
 #else

--- a/src/d/d_menu_dmap.cpp
+++ b/src/d/d_menu_dmap.cpp
@@ -991,7 +991,7 @@ void dMenu_DmapBg_c::draw() {
             -35.0f + (local_224.x - local_218.x),
             -35.0f + (local_224.y - local_218.y));
 #if TARGET_PC
-        if (!dusk::getSettings().game.enableFrameInterpolation) {
+        if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off) {
             field_0xdda = 0;
         }
 #else
@@ -2624,7 +2624,7 @@ void dMenu_Dmap_c::zoomIn_proc() {
 
 void dMenu_Dmap_c::zoomOut_init_proc() {
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         mpDrawBg->resetScrollArrowMask();
     }
 #endif

--- a/src/d/d_menu_fmap.cpp
+++ b/src/d/d_menu_fmap.cpp
@@ -1146,7 +1146,7 @@ void dMenu_Fmap_c::zoom_spot_to_region_init() {
     field_0x1ec = 1.0f;
 #if TARGET_PC
     // Frame interp note: field_0x122d used to be set every draw, causing flickering. Do it here instead.
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         mpDraw2DBack->resetScrollArrowMask();
     }
 #endif

--- a/src/d/d_menu_fmap.cpp
+++ b/src/d/d_menu_fmap.cpp
@@ -1146,7 +1146,7 @@ void dMenu_Fmap_c::zoom_spot_to_region_init() {
     field_0x1ec = 1.0f;
 #if TARGET_PC
     // Frame interp note: field_0x122d used to be set every draw, causing flickering. Do it here instead.
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         mpDraw2DBack->resetScrollArrowMask();
     }
 #endif

--- a/src/d/d_menu_fmap2D.cpp
+++ b/src/d/d_menu_fmap2D.cpp
@@ -437,7 +437,7 @@ void dMenu_Fmap2DBack_c::draw() {
     if (field_0x122d) {
         mpMeterHaihai->drawHaihai(field_0x122d);
 #if TARGET_PC
-        if (!dusk::getSettings().game.enableFrameInterpolation) {
+        if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off) {
             field_0x122d = 0;
         }
 #else

--- a/src/d/d_menu_fmap2D.cpp
+++ b/src/d/d_menu_fmap2D.cpp
@@ -437,7 +437,7 @@ void dMenu_Fmap2DBack_c::draw() {
     if (field_0x122d) {
         mpMeterHaihai->drawHaihai(field_0x122d);
 #if TARGET_PC
-        if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off) {
+        if (!dusk::frame_interp::is_enabled()) {
             field_0x122d = 0;
         }
 #else

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -56,6 +56,20 @@ static T sanitizeEnumValue(const ConfigVar<T>& cVar, T value) {
 
 template<ConfigValue T>
 void ConfigImpl<T>::loadFromJson(ConfigVar<T>& cVar, const json& jsonValue) {
+    if constexpr (std::is_enum_v<T>) {
+        using Underlying = std::underlying_type_t<T>;
+
+        // Backwards-compatibility: if this CVar used to be a bool and the saved
+        // config contains a boolean for it, accept the boolean and map it to
+        // the enum (false->0, true->1).
+        if (jsonValue.is_boolean()) {
+            const bool b = jsonValue.get<bool>();
+            const Underlying raw = b ? static_cast<Underlying>(1) : static_cast<Underlying>(0);
+            cVar.setValue(sanitizeEnumValue(cVar, static_cast<T>(raw)), false);
+            return;
+        }
+    }
+
     cVar.setValue(sanitizeEnumValue(cVar, jsonValue.get<T>()), false);
 }
 

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -158,6 +158,7 @@ namespace dusk::config {
     template class ConfigImpl<dusk::DiscVerificationState>;
     template class ConfigImpl<dusk::GameLanguage>;
     template class ConfigImpl<dusk::GyroMode>;
+    template class ConfigImpl<dusk::FrameInterpMode>;
 }
 
 void dusk::config::Register(ConfigVarBase& configVar) {

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -57,14 +57,17 @@ static T sanitizeEnumValue(const ConfigVar<T>& cVar, T value) {
 template<ConfigValue T>
 void ConfigImpl<T>::loadFromJson(ConfigVar<T>& cVar, const json& jsonValue) {
     if constexpr (std::is_enum_v<T>) {
-        using Underlying = std::underlying_type_t<T>;
-
-        // Backwards-compatibility: if this CVar used to be a bool and the saved
-        // config contains a boolean for it, accept the boolean and map it to
-        // the enum (false->0, true->1).
         if (jsonValue.is_boolean()) {
+            using Underlying = std::underlying_type_t<T>;
             const bool b = jsonValue.get<bool>();
-            const Underlying raw = b ? static_cast<Underlying>(1) : static_cast<Underlying>(0);
+
+            Underlying raw;
+            if constexpr (std::is_same_v<T, dusk::FrameInterpMode>) {
+                raw = b ? static_cast<Underlying>(2) : static_cast<Underlying>(0);
+            } else {
+                raw = b ? static_cast<Underlying>(1) : static_cast<Underlying>(0);
+            }
+
             cVar.setValue(sanitizeEnumValue(cVar, static_cast<T>(raw)), false);
             return;
         }

--- a/src/dusk/frame_interpolation.cpp
+++ b/src/dusk/frame_interpolation.cpp
@@ -142,8 +142,8 @@ uint64_t sim_tick_seq() {
     return g_sim_tick_seq;
 }
 
-void begin_frame(bool enabled, bool is_sim_frame, float step) {
-    g_enabled = enabled;
+void begin_frame(FrameInterpMode mode, bool is_sim_frame, float step) {
+    g_enabled = mode != FrameInterpMode::Off;
     g_is_sim_frame = is_sim_frame;
     g_step = std::clamp(step, 0.0f, 1.0f);
 }

--- a/src/dusk/game_clock.cpp
+++ b/src/dusk/game_clock.cpp
@@ -45,7 +45,7 @@ MainLoopPacer advance_main_loop() {
     MainLoopPacer out{};
     out.presentation_dt_seconds = presentation_dt;
 
-    const bool should_interpolate = dusk::getSettings().game.enableFrameInterpolation &&
+    const bool should_interpolate = dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off &&
                                     !dusk::getTransientSettings().skipFrameRateLimit;
     out.is_interpolating = should_interpolate;
     out.sim_pace = sim_pace();

--- a/src/dusk/game_clock.cpp
+++ b/src/dusk/game_clock.cpp
@@ -46,7 +46,8 @@ MainLoopPacer advance_main_loop() {
     MainLoopPacer out{};
     out.presentation_dt_seconds = presentation_dt;
 
-    const bool should_interpolate = dusk::getSettings().game.enableFrameInterpolation != dusk::FrameInterpMode::Off &&
+    const bool should_interpolate = dusk::getSettings().game.enableFrameInterpolation.getValue() !=
+                                        dusk::FrameInterpMode::Off &&
                                     !dusk::getTransientSettings().skipFrameRateLimit;
     out.is_interpolating = should_interpolate;
     out.sim_pace = sim_pace();

--- a/src/dusk/game_clock.cpp
+++ b/src/dusk/game_clock.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cmath>
 #include <unordered_map>
+#include <dusk/frame_interpolation.h>
 
 namespace dusk::game_clock {
 
@@ -45,7 +46,7 @@ MainLoopPacer advance_main_loop() {
     MainLoopPacer out{};
     out.presentation_dt_seconds = presentation_dt;
 
-    const bool should_interpolate = dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off &&
+    const bool should_interpolate = dusk::getSettings().game.enableFrameInterpolation != dusk::FrameInterpMode::Off &&
                                     !dusk::getTransientSettings().skipFrameRateLimit;
     out.is_interpolating = should_interpolate;
     out.sim_pace = sim_pace();

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -10,6 +10,7 @@ UserSettings g_userSettings = {
         .lockAspectRatio {"video.lockAspectRatio", false},
         .enableFpsOverlay {"game.enableFpsOverlay", false},
         .fpsOverlayCorner {"game.fpsOverlayCorner", 0},
+        .maxFrameRate {"video.maxFrameRate", 240},
     },
 
     .audio = {
@@ -177,6 +178,7 @@ void registerSettings() {
     Register(g_userSettings.video.lockAspectRatio);
     Register(g_userSettings.video.enableFpsOverlay);
     Register(g_userSettings.video.fpsOverlayCorner);
+    Register(g_userSettings.video.maxFrameRate);
 
     // Audio
     Register(g_userSettings.audio.masterVolume);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -11,7 +11,6 @@ UserSettings g_userSettings = {
         .enableFpsOverlay {"game.enableFpsOverlay", false},
         .fpsOverlayCorner {"game.fpsOverlayCorner", 0},
         .maxFrameRate {"video.maxFrameRate", 240},
-        .maxFrameRatePreset {"video.maxFrameRatePreset", 4},
     },
 
     .audio = {
@@ -60,7 +59,7 @@ UserSettings g_userSettings = {
         .bloomMode {"game.bloomMode", BloomMode::Dusk},
         .bloomMultiplier {"game.bloomMultiplier", 1.0f},
         .disableWaterRefraction {"game.disableWaterRefraction", false},
-        .enableFrameInterpolation {"game.enableFrameInterpolation", false},
+        .enableFrameInterpolation {"game.enableFrameInterpolation", FrameInterpMode::Off},
         .internalResolutionScale {"game.internalResolutionScale", 0},
         .shadowResolutionMultiplier {"game.shadowResolutionMultiplier", 1},
         .enableDepthOfField {"game.enableDepthOfField", true},
@@ -180,7 +179,6 @@ void registerSettings() {
     Register(g_userSettings.video.enableFpsOverlay);
     Register(g_userSettings.video.fpsOverlayCorner);
     Register(g_userSettings.video.maxFrameRate);
-    Register(g_userSettings.video.maxFrameRatePreset);
 
     // Audio
     Register(g_userSettings.audio.masterVolume);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -11,6 +11,7 @@ UserSettings g_userSettings = {
         .enableFpsOverlay {"game.enableFpsOverlay", false},
         .fpsOverlayCorner {"game.fpsOverlayCorner", 0},
         .maxFrameRate {"video.maxFrameRate", 240},
+        .maxFrameRatePreset {"video.maxFrameRatePreset", 4},
     },
 
     .audio = {
@@ -179,6 +180,7 @@ void registerSettings() {
     Register(g_userSettings.video.enableFpsOverlay);
     Register(g_userSettings.video.fpsOverlayCorner);
     Register(g_userSettings.video.maxFrameRate);
+    Register(g_userSettings.video.maxFrameRatePreset);
 
     // Audio
     Register(g_userSettings.audio.masterVolume);

--- a/src/dusk/ui/preset.cpp
+++ b/src/dusk/ui/preset.cpp
@@ -40,7 +40,7 @@ void applyPresetDusk() {
     s.game.enableQuickTransform.setValue(true);
     s.game.instantSaves.setValue(true);
     s.game.midnasLamentNonStop.setValue(true);
-    s.game.enableFrameInterpolation.setValue(true);
+    s.game.enableFrameInterpolation.setValue(FrameInterpMode::Unlimited);
     s.game.sunsSong.setValue(true);
     s.game.bloomMode.setValue(BloomMode::Dusk);
     s.game.internalResolutionScale.setValue(0);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -59,6 +59,8 @@ constexpr std::array kFpsOverlayCornerNames = {
     "Bottom Right",
 };
 
+constexpr std::array kFrameRateCapValues = {60, 120, 144, 240, 360};
+
 constexpr std::array kGyroInputModeLabels = {
     "Sensor",
     "Mouse",
@@ -800,6 +802,54 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             {
                 .key = "Unlock Framerate",
                 .helpText = kUnlockFramerateHelpText,
+            });
+        leftPane.register_control(
+            leftPane.add_select_button({
+                .key = "Max Frame Rate",
+                .getValue =
+                    [] {
+                        const int cap = getSettings().video.maxFrameRate.getValue();
+                        if (cap <= 0) {
+                            return Rml::String{"Unlimited"};
+                        }
+                        return Rml::String{std::to_string(cap) + " FPS"};
+                    },
+                .isDisabled =
+                    [] { return !getSettings().game.enableFrameInterpolation.getValue(); },
+                .isModified =
+                    [] {
+                        const auto& cap = getSettings().video.maxFrameRate;
+                        return cap.getValue() != cap.getDefaultValue();
+                    },
+            }),
+            rightPane, [](Pane& pane) {
+                pane.add_button(
+                        {
+                            .text = "Unlimited",
+                            .isSelected =
+                                [] { return getSettings().video.maxFrameRate.getValue() <= 0; },
+                        })
+                    .on_pressed([] {
+                        mDoAud_seStartMenu(kSoundItemChange);
+                        getSettings().video.maxFrameRate.setValue(0);
+                        config::Save();
+                    });
+                for (const int value : kFrameRateCapValues) {
+                    pane.add_button(
+                            {
+                                .text = std::to_string(value) + " FPS",
+                                .isSelected =
+                                    [value] {
+                                        return getSettings().video.maxFrameRate.getValue() == value;
+                                    },
+                            })
+                        .on_pressed([value] {
+                            mDoAud_seStartMenu(kSoundItemChange);
+                            getSettings().video.maxFrameRate.setValue(value);
+                            config::Save();
+                        });
+                }
+                pane.add_rml("<br/>Cap the interpolated frame rate.");
             });
         config_bool_select(leftPane, rightPane, getSettings().game.enableDepthOfField,
             {

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -59,7 +59,25 @@ constexpr std::array kFpsOverlayCornerNames = {
     "Bottom Right",
 };
 
-constexpr std::array kFrameRateCapValues = {60, 120, 144, 240, 360};
+constexpr std::array kMaxFrameRatePresets = {
+    "Unlimited",
+    "60 FPS",
+    "120 FPS",
+    "144 FPS",
+    "240 FPS",
+    "360 FPS",
+    "Custom"
+};
+
+constexpr std::array kMaxFrameRateValues = {
+    0,
+    60,
+    120,
+    144,
+    240,
+    360,
+    69,
+};
 
 constexpr std::array kGyroInputModeLabels = {
     "Sensor",
@@ -442,6 +460,31 @@ SelectButton& config_percent_select(Pane& leftPane, Pane& rightPane, ConfigVar<f
     return button;
 }
 
+SelectButton& config_int_select(Pane& leftPane, Pane& rightPane, ConfigVar<int>& var,
+    Rml::String key, Rml::String helpText, int min, int max, int step = 5,
+    std::function<bool()> isDisabled = {}, std::string suffix = "") {
+    auto& button = leftPane.add_child<NumberButton>(NumberButton::Props{
+        .key = std::move(key),
+        .getValue = [&var] { return var; },
+        .setValue =
+            [&var, min, max](int value) {
+                var.setValue(std::clamp(value, min, max));
+                config::Save();
+            },
+        .isDisabled = std::move(isDisabled),
+        .isModified = [&var] { return var.getValue() != var.getDefaultValue(); },
+        .min = min,
+        .max = max,
+        .step = step,
+        .suffix = suffix,
+    });
+    leftPane.register_control(button, rightPane, [helpText = std::move(helpText)](Pane& pane) {
+        pane.clear();
+        pane.add_text(helpText);
+    });
+    return button;
+}
+
 template <typename T>
 void graphics_tuner_control(Window& window, Pane& leftPane, Pane& rightPane, ConfigVar<T>& var,
     const GraphicsTunerProps& props, bool prelaunch) {
@@ -808,47 +851,62 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .key = "Max Frame Rate",
                 .getValue =
                     [] {
-                        const int cap = getSettings().video.maxFrameRate.getValue();
-                        if (cap <= 0) {
-                            return Rml::String{"Unlimited"};
-                        }
-                        return Rml::String{std::to_string(cap) + " FPS"};
+                        const int capPreset = getSettings().video.maxFrameRatePreset.getValue();
+                        return kMaxFrameRatePresets[capPreset];
                     },
                 .isDisabled =
                     [] { return !getSettings().game.enableFrameInterpolation.getValue(); },
                 .isModified =
                     [] {
-                        const auto& cap = getSettings().video.maxFrameRate;
+                        const auto& cap = getSettings().video.maxFrameRatePreset;
                         return cap.getValue() != cap.getDefaultValue();
                     },
             }),
             rightPane, [](Pane& pane) {
-                pane.add_button(
-                        {
-                            .text = "Unlimited",
-                            .isSelected =
-                                [] { return getSettings().video.maxFrameRate.getValue() <= 0; },
-                        })
-                    .on_pressed([] {
-                        mDoAud_seStartMenu(kSoundItemChange);
-                        getSettings().video.maxFrameRate.setValue(0);
-                        config::Save();
-                    });
-                for (const int value : kFrameRateCapValues) {
+                for (size_t idx = 0; idx < kMaxFrameRatePresets.size(); idx++) {
                     pane.add_button(
                             {
-                                .text = std::to_string(value) + " FPS",
+                                .text = kMaxFrameRatePresets[idx],
                                 .isSelected =
-                                    [value] {
-                                        return getSettings().video.maxFrameRate.getValue() == value;
+                                    [idx] {
+                                        return getSettings().video.maxFrameRatePreset.getValue() == idx;
                                     },
                             })
-                        .on_pressed([value] {
+                        .on_pressed([idx] {
                             mDoAud_seStartMenu(kSoundItemChange);
-                            getSettings().video.maxFrameRate.setValue(value);
+                            getSettings().video.maxFrameRatePreset.setValue(idx);
+
+                            if (idx != 6) {
+                                getSettings().video.maxFrameRate.setValue(kMaxFrameRateValues[idx]);
+                            }
+
                             config::Save();
                         });
                 }
+                pane.add_child<NumberButton>(NumberButton::Props{
+                        .key = "Custom FPS Cap",
+                        .getValue = [] { return getSettings().video.maxFrameRate.getValue(); },
+                        .setValue =
+                            [](int value) {
+                                getSettings().video.maxFrameRate.setValue(std::clamp(value, 60, 1000));
+                                config::Save();
+                            },
+                        .isDisabled = [] { return getSettings().video.maxFrameRatePreset != 6; },
+                        .isModified = [] { 
+                            return getSettings().video.maxFrameRate.getValue() !=
+                               getSettings().video.maxFrameRate.getDefaultValue();
+                        },
+                        .min = 60,
+                        .max = 999,
+                        .step = 1,
+                        .suffix = " FPS",
+                    });
+
+                    /*
+                    leftPane, rightPane, getSettings().game.freeCameraSensitivity,
+                    "Free Camera Sensitivity", "Adjusts twin-stick camera sensitivity.", 50, 200, 5,
+                    [] { return !getSettings().game.freeCamera; }
+                    */
                 pane.add_rml("<br/>Cap the interpolated frame rate.");
             });
         config_bool_select(leftPane, rightPane, getSettings().game.enableDepthOfField,

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -61,8 +61,8 @@ constexpr std::array kFpsOverlayCornerNames = {
 
 constexpr std::array kInterpolationModes = {
     "Off",
-    "Unlimited",
     "Capped",
+    "Unlimited",
 };
 
 constexpr std::array kGyroInputModeLabels = {

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -876,7 +876,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                             mDoAud_seStartMenu(kSoundItemChange);
                             getSettings().video.maxFrameRatePreset.setValue(idx);
 
-                            if (idx != 6) {
+                            if (idx != kMaxFrameRatePresets.size()-1) {
                                 getSettings().video.maxFrameRate.setValue(kMaxFrameRateValues[idx]);
                             }
 
@@ -891,7 +891,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                                 getSettings().video.maxFrameRate.setValue(std::clamp(value, 60, 1000));
                                 config::Save();
                             },
-                        .isDisabled = [] { return getSettings().video.maxFrameRatePreset != 6; },
+                        .isDisabled = [] { return getSettings().video.maxFrameRatePreset != kMaxFrameRatePresets.size()-1; },
                         .isModified = [] { 
                             return getSettings().video.maxFrameRate.getValue() !=
                                getSettings().video.maxFrameRate.getDefaultValue();

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -61,8 +61,8 @@ constexpr std::array kFpsOverlayCornerNames = {
 
 constexpr std::array kInterpolationModes = {
     "Off",
+    "Unlimited",
     "Capped",
-    "Unlimited"
 };
 
 constexpr std::array kGyroInputModeLabels = {

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -59,24 +59,10 @@ constexpr std::array kFpsOverlayCornerNames = {
     "Bottom Right",
 };
 
-constexpr std::array kMaxFrameRatePresets = {
-    "Unlimited",
-    "60 FPS",
-    "120 FPS",
-    "144 FPS",
-    "240 FPS",
-    "360 FPS",
-    "Custom"
-};
-
-constexpr std::array kMaxFrameRateValues = {
-    0,
-    60,
-    120,
-    144,
-    240,
-    360,
-    69,
+constexpr std::array kInterpolationModes = {
+    "Off",
+    "Capped",
+    "Unlimited"
 };
 
 constexpr std::array kGyroInputModeLabels = {
@@ -377,7 +363,7 @@ const Rml::String kBloomHelpText =
 const Rml::String kBloomBrightnessHelpText =
     "Configure bloom intensity. Higher values make bright areas glow more strongly.";
 const Rml::String kUnlockFramerateHelpText =
-    "Uses inter-frame interpolation to enable higher frame rates.<br/><br/>May introduce minor "
+    "<br/>Uses inter-frame interpolation to enable higher frame rates.<br/><br/>May introduce minor "
     "visual artifacts or animation glitches.";
 
 int float_setting_percent(ConfigVar<float>& var) {
@@ -841,74 +827,39 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             }, mPrelaunch);
 
         leftPane.add_section("Rendering");
-        config_bool_select(leftPane, rightPane, getSettings().game.enableFrameInterpolation,
-            {
-                .key = "Unlock Framerate",
-                .helpText = kUnlockFramerateHelpText,
-            });
         leftPane.register_control(
             leftPane.add_select_button({
-                .key = "Max Frame Rate",
+                .key = "Unlock Framerate",
                 .getValue =
                     [] {
-                        const int capPreset = getSettings().video.maxFrameRatePreset.getValue();
-                        return kMaxFrameRatePresets[capPreset];
+                        return kInterpolationModes[static_cast<u8>(getSettings().game.enableFrameInterpolation.getValue())];
                     },
-                .isDisabled =
-                    [] { return !getSettings().game.enableFrameInterpolation.getValue(); },
                 .isModified =
                     [] {
-                        const auto& cap = getSettings().video.maxFrameRatePreset;
-                        return cap.getValue() != cap.getDefaultValue();
+                        return getSettings().game.enableFrameInterpolation.getValue() !=
+                               getSettings().game.enableFrameInterpolation.getDefaultValue();
                     },
             }),
             rightPane, [](Pane& pane) {
-                for (size_t idx = 0; idx < kMaxFrameRatePresets.size(); idx++) {
-                    pane.add_button(
-                            {
-                                .text = kMaxFrameRatePresets[idx],
-                                .isSelected =
-                                    [idx] {
-                                        return getSettings().video.maxFrameRatePreset.getValue() == idx;
-                                    },
-                            })
-                        .on_pressed([idx] {
+                for (int i = 0; i < kInterpolationModes.size(); i++) {
+                    pane.add_button({
+                            .text = kInterpolationModes[i],
+                            .isSelected =
+                                [i] {
+                                    return getSettings().game.enableFrameInterpolation.getValue() == static_cast<FrameInterpMode>(i);
+                                },
+                        })
+                        .on_pressed([i] {
                             mDoAud_seStartMenu(kSoundItemChange);
-                            getSettings().video.maxFrameRatePreset.setValue(idx);
-
-                            if (idx != kMaxFrameRatePresets.size()-1) {
-                                getSettings().video.maxFrameRate.setValue(kMaxFrameRateValues[idx]);
-                            }
-
+                            getSettings().game.enableFrameInterpolation.setValue(static_cast<FrameInterpMode>(i));
                             config::Save();
                         });
                 }
-                pane.add_child<NumberButton>(NumberButton::Props{
-                        .key = "Custom FPS Cap",
-                        .getValue = [] { return getSettings().video.maxFrameRate.getValue(); },
-                        .setValue =
-                            [](int value) {
-                                getSettings().video.maxFrameRate.setValue(std::clamp(value, 60, 1000));
-                                config::Save();
-                            },
-                        .isDisabled = [] { return getSettings().video.maxFrameRatePreset != kMaxFrameRatePresets.size()-1; },
-                        .isModified = [] { 
-                            return getSettings().video.maxFrameRate.getValue() !=
-                               getSettings().video.maxFrameRate.getDefaultValue();
-                        },
-                        .min = 60,
-                        .max = 999,
-                        .step = 1,
-                        .suffix = " FPS",
-                    });
-
-                    /*
-                    leftPane, rightPane, getSettings().game.freeCameraSensitivity,
-                    "Free Camera Sensitivity", "Adjusts twin-stick camera sensitivity.", 50, 200, 5,
-                    [] { return !getSettings().game.freeCamera; }
-                    */
-                pane.add_rml("<br/>Cap the interpolated frame rate.");
+                pane.add_rml(kUnlockFramerateHelpText);
             });
+        config_int_select(leftPane, rightPane, getSettings().video.maxFrameRate,
+            "Framerate Cap", "Limit the framerate to the specified value.", 30, 540, 1,
+            [] { return getSettings().game.enableFrameInterpolation.getValue() != FrameInterpMode::Capped; });
         config_bool_select(leftPane, rightPane, getSettings().game.enableDepthOfField,
             {
                 .key = "Enable Depth of Field",

--- a/src/m_Do/m_Do_ext.cpp
+++ b/src/m_Do/m_Do_ext.cpp
@@ -2822,7 +2822,7 @@ void mDoExt_3DlineMat1_c::update(int param_0, f32 param_1, GXColor& param_2, u16
         }
 
 #if TARGET_PC
-        const cXyz& lineEye = (presentationEye != nullptr && dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) ? *presentationEye : sp_3c->lookat.eye;
+        const cXyz& lineEye = (presentationEye != nullptr && dusk::frame_interp::is_enabled()) ? *presentationEye : sp_3c->lookat.eye;
         sp_13c = *local_r27 - lineEye;
 #else
         sp_13c = *local_r27 - sp_3c->lookat.eye;
@@ -2982,7 +2982,7 @@ void mDoExt_3DlineMat1_c::update(int param_0, GXColor& param_2, dKy_tevstr_c* pa
         local_r27 = sp_38[0].field_0x0;
         size_p = sp_38->field_0x4;
 #if TARGET_PC
-        if (presentationEye != nullptr && dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off && size_p == NULL) {
+        if (presentationEye != nullptr && dusk::frame_interp::is_enabled() && size_p == NULL) {
             sp_38 += 1;
             continue;
         }
@@ -3001,7 +3001,7 @@ void mDoExt_3DlineMat1_c::update(int param_0, GXColor& param_2, dKy_tevstr_c* pa
         local_f30 = sp_130.abs();
         local_f31 += local_f30 * 0.1f;
 #if TARGET_PC
-        const cXyz& lineEye = (presentationEye != nullptr && dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) ? *presentationEye : stack_3c->lookat.eye;
+        const cXyz& lineEye = (presentationEye != nullptr && dusk::frame_interp::is_enabled()) ? *presentationEye : stack_3c->lookat.eye;
         sp_13c = local_r27[0] - lineEye;
 #else
         sp_13c = local_r27[0] - stack_3c->lookat.eye;

--- a/src/m_Do/m_Do_ext.cpp
+++ b/src/m_Do/m_Do_ext.cpp
@@ -2410,7 +2410,7 @@ void mDoExt_3DlineMat0_c::draw() {
     }
 
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off)
+    if (!dusk::frame_interp::is_enabled())
 #endif
     {
         field_0x16 ^= (u8)1;
@@ -2740,7 +2740,7 @@ void mDoExt_3DlineMat1_c::draw() {
     }
     GXSetTexCoordScaleManually(GX_TEXCOORD0, 0, 0, 0);
 #if TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off)
+    if (!dusk::frame_interp::is_enabled())
 #endif
     {
         mIsDrawn ^= (u8)1;
@@ -3077,7 +3077,7 @@ void mDoExt_3DlineMat1_c::update(int param_0, GXColor& param_2, dKy_tevstr_c* pa
 
 #if TARGET_PC
 void mDoExt_3DlineMat1_c::refreshGeometryForPresentationEye(const cXyz& eye) {
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off) {
+    if (!dusk::frame_interp::is_enabled()) {
         return;
     }
     if (mInterpLineKind == 1) {

--- a/src/m_Do/m_Do_ext.cpp
+++ b/src/m_Do/m_Do_ext.cpp
@@ -2410,7 +2410,7 @@ void mDoExt_3DlineMat0_c::draw() {
     }
 
 #if TARGET_PC
-    if (!dusk::getSettings().game.enableFrameInterpolation)
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off)
 #endif
     {
         field_0x16 ^= (u8)1;
@@ -2740,7 +2740,7 @@ void mDoExt_3DlineMat1_c::draw() {
     }
     GXSetTexCoordScaleManually(GX_TEXCOORD0, 0, 0, 0);
 #if TARGET_PC
-    if (!dusk::getSettings().game.enableFrameInterpolation)
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off)
 #endif
     {
         mIsDrawn ^= (u8)1;
@@ -2822,7 +2822,7 @@ void mDoExt_3DlineMat1_c::update(int param_0, f32 param_1, GXColor& param_2, u16
         }
 
 #if TARGET_PC
-        const cXyz& lineEye = (presentationEye != nullptr && dusk::getSettings().game.enableFrameInterpolation) ? *presentationEye : sp_3c->lookat.eye;
+        const cXyz& lineEye = (presentationEye != nullptr && dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) ? *presentationEye : sp_3c->lookat.eye;
         sp_13c = *local_r27 - lineEye;
 #else
         sp_13c = *local_r27 - sp_3c->lookat.eye;
@@ -2982,7 +2982,7 @@ void mDoExt_3DlineMat1_c::update(int param_0, GXColor& param_2, dKy_tevstr_c* pa
         local_r27 = sp_38[0].field_0x0;
         size_p = sp_38->field_0x4;
 #if TARGET_PC
-        if (presentationEye != nullptr && dusk::getSettings().game.enableFrameInterpolation && size_p == NULL) {
+        if (presentationEye != nullptr && dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off && size_p == NULL) {
             sp_38 += 1;
             continue;
         }
@@ -3001,7 +3001,7 @@ void mDoExt_3DlineMat1_c::update(int param_0, GXColor& param_2, dKy_tevstr_c* pa
         local_f30 = sp_130.abs();
         local_f31 += local_f30 * 0.1f;
 #if TARGET_PC
-        const cXyz& lineEye = (presentationEye != nullptr && dusk::getSettings().game.enableFrameInterpolation) ? *presentationEye : stack_3c->lookat.eye;
+        const cXyz& lineEye = (presentationEye != nullptr && dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) ? *presentationEye : stack_3c->lookat.eye;
         sp_13c = local_r27[0] - lineEye;
 #else
         sp_13c = local_r27[0] - stack_3c->lookat.eye;
@@ -3077,7 +3077,7 @@ void mDoExt_3DlineMat1_c::update(int param_0, GXColor& param_2, dKy_tevstr_c* pa
 
 #if TARGET_PC
 void mDoExt_3DlineMat1_c::refreshGeometryForPresentationEye(const cXyz& eye) {
-    if (!dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Off) {
         return;
     }
     if (mInterpLineKind == 1) {

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -2063,7 +2063,7 @@ static void captureScreenPerspDrawInfo(JPADrawInfo& info) {
 static void drawItem3D() {
     ZoneScoped;
 #ifdef TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation) {
+    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
         // FRAME INTERP NOTE: Title screen needs 0.0f while everything else that runs through this is -100.0f.
         if (fopAcM_SearchByName(fpcNm_TITLE_e) != nullptr) {
             dMenu_Collect3D_c::setViewPortOffsetY(0.0f);
@@ -2241,7 +2241,7 @@ int mDoGph_Painter() {
 #endif
             dKy_setLight();
 #if TARGET_PC
-            if (dusk::getSettings().game.enableFrameInterpolation) {
+            if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
                 dKy_setLight_again();
             }
 #endif
@@ -2296,7 +2296,7 @@ int mDoGph_Painter() {
             }
 
 #if TARGET_PC
-            if (dusk::getSettings().game.enableFrameInterpolation) {
+            if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
                 // FRAME INTERP NOTE: Currently only recalculating points for Epona's reins. Need a more global solution.
                 if (daHorse_c* horse = dComIfGp_getHorseActor()) {
                     horse->lerpControlPoints(dusk::frame_interp::get_interpolation_step());

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -2063,7 +2063,7 @@ static void captureScreenPerspDrawInfo(JPADrawInfo& info) {
 static void drawItem3D() {
     ZoneScoped;
 #ifdef TARGET_PC
-    if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+    if (dusk::frame_interp::is_enabled()) {
         // FRAME INTERP NOTE: Title screen needs 0.0f while everything else that runs through this is -100.0f.
         if (fopAcM_SearchByName(fpcNm_TITLE_e) != nullptr) {
             dMenu_Collect3D_c::setViewPortOffsetY(0.0f);
@@ -2241,7 +2241,7 @@ int mDoGph_Painter() {
 #endif
             dKy_setLight();
 #if TARGET_PC
-            if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+            if (dusk::frame_interp::is_enabled()) {
                 dKy_setLight_again();
             }
 #endif
@@ -2296,7 +2296,7 @@ int mDoGph_Painter() {
             }
 
 #if TARGET_PC
-            if (dusk::getSettings().game.enableFrameInterpolation.getValue() != dusk::FrameInterpMode::Off) {
+            if (dusk::frame_interp::is_enabled()) {
                 // FRAME INTERP NOTE: Currently only recalculating points for Epona's reins. Need a more global solution.
                 if (daHorse_c* horse = dComIfGp_getHorseActor()) {
                     horse->lerpControlPoints(dusk::frame_interp::get_interpolation_step());

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -320,7 +320,7 @@ void main01(void) {
         static double last_fps_setting = 0.0;
         static Limiter::duration_t outer_target_ns = 0;
 
-        if (dusk::getSettings().game.enableFrameInterpolation && !dusk::getTransientSettings().skipFrameRateLimit) {
+        if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Capped && !dusk::getTransientSettings().skipFrameRateLimit) {
             double current_fps = dusk::getSettings().video.maxFrameRate.getValue();
             if (current_fps != last_fps_setting) {
                 last_fps_setting = current_fps;

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -316,8 +316,6 @@ void main01(void) {
             mDoAud_Execute();
         }
 
-        aurora_end_frame();
-
         static Limiter main_loop_limiter;
         static double last_fps_setting = 0.0;
         static Limiter::duration_t outer_target_ns = 0;
@@ -339,6 +337,9 @@ void main01(void) {
         } else {
             main_loop_limiter.Reset();
         }
+
+        aurora_end_frame();
+
 
         FrameMark;
 

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -28,6 +28,7 @@
 #include "d/d_s_logo.h"
 #include "d/d_s_menu.h"
 #include "d/d_s_play.h"
+#include "dusk/time.h"
 #include "f_ap/f_ap_game.h"
 #include "f_op/f_op_msg.h"
 #include "m_Do/m_Do_MemCard.h"
@@ -316,6 +317,28 @@ void main01(void) {
         }
 
         aurora_end_frame();
+
+        static Limiter main_loop_limiter;
+        static double last_fps_setting = 0.0;
+        static Limiter::duration_t outer_target_ns = 0;
+
+        if (dusk::getSettings().game.enableFrameInterpolation && !dusk::getTransientSettings().skipFrameRateLimit) {
+            double current_fps = dusk::getSettings().video.maxFrameRate.getValue();
+            if (current_fps != last_fps_setting) {
+                last_fps_setting = current_fps;
+                outer_target_ns = static_cast<Limiter::duration_t>(1'000'000'000.0 / current_fps);
+            }
+
+            if (outer_target_ns > 0 && current_fps != 0.0) {
+                Limiter::duration_t sleepTime = main_loop_limiter.Sleep(outer_target_ns);
+                dusk::frameUsagePct =
+                    100.0f * (1.0f - static_cast<float>(sleepTime) / static_cast<float>(outer_target_ns));
+            } else {
+                main_loop_limiter.Reset();
+            }
+        } else {
+            main_loop_limiter.Reset();
+        }
 
         FrameMark;
 

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -280,8 +280,9 @@ void main01(void) {
         const auto pacing = dusk::game_clock::advance_main_loop();
         if (pacing.is_interpolating) {
             if (pacing.sim_ticks_to_run > 0) {
-                dusk::frame_interp::begin_frame(true, true, 0.0f);
+                dusk::frame_interp::begin_frame(dusk::getSettings().game.enableFrameInterpolation, true, 0.0f);
                 dusk::frame_interp::set_ui_tick_pending(true);
+
                 for (int sim_tick = 0; sim_tick < pacing.sim_ticks_to_run; ++sim_tick) {
                     dusk::frame_interp::begin_sim_tick();
                     mDoCPd_c::read();
@@ -292,7 +293,7 @@ void main01(void) {
                 }
             }
 
-            dusk::frame_interp::begin_frame(true, false,
+            dusk::frame_interp::begin_frame(dusk::getSettings().game.enableFrameInterpolation, false,
                                             dusk::game_clock::sample_interpolation_step());
             dusk::frame_interp::interpolate();
             dusk::frame_interp::begin_presentation_camera();
@@ -302,7 +303,7 @@ void main01(void) {
             dusk::frame_interp::end_presentation_camera();
             dusk::frame_interp::set_ui_tick_pending(false);
         } else {
-            dusk::frame_interp::begin_frame(false, true, 0.0f);
+            dusk::frame_interp::begin_frame(dusk::FrameInterpMode::Off, true, 0.0f);
             dusk::frame_interp::set_ui_tick_pending(true);
 
             // Game Inputs

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -318,22 +318,17 @@ void main01(void) {
 
         static Limiter main_loop_limiter;
         static double last_fps_setting = 0.0;
-        static Limiter::duration_t outer_target_ns = 0;
+        static Limiter::duration_t target_ns = 0;
 
         if (dusk::getSettings().game.enableFrameInterpolation.getValue() == dusk::FrameInterpMode::Capped && !dusk::getTransientSettings().skipFrameRateLimit) {
             double current_fps = dusk::getSettings().video.maxFrameRate.getValue();
             if (current_fps != last_fps_setting) {
                 last_fps_setting = current_fps;
-                outer_target_ns = static_cast<Limiter::duration_t>(1'000'000'000.0 / current_fps);
+                target_ns = static_cast<Limiter::duration_t>(1'000'000'000.0 / current_fps);
             }
 
-            if (outer_target_ns > 0 && current_fps != 0.0) {
-                Limiter::duration_t sleepTime = main_loop_limiter.Sleep(outer_target_ns);
-                dusk::frameUsagePct =
-                    100.0f * (1.0f - static_cast<float>(sleepTime) / static_cast<float>(outer_target_ns));
-            } else {
-                main_loop_limiter.Reset();
-            }
+            Limiter::duration_t sleepTime = main_loop_limiter.Sleep(target_ns);
+            dusk::frameUsagePct = 100.0f * (1.0f - static_cast<float>(sleepTime) / static_cast<float>(target_ns));
         } else {
             main_loop_limiter.Reset();
         }


### PR DESCRIPTION
Based on work from #1451
Closes #747, #1437 

Implements a frame limiter. Huge thanks to @SailorSnoW who laid the ground work.
This PR moves their limiting logic into the main execution loop and fixes some inconsistencies to improve frametime stability.

# Changes over SailorSnoWs PR
- Moved limiter out of waitForTick. This worked better for Framepacing from my experience.
- Fixed limiter calculating overhead twice with `waitPrecise()`
- More sophisticated `nanoSleep()` which uses a hybrid approach on MacOS.