### PR TITLE
Fix item wheel wrong frame with interp

### DIFF
--- a/src/d/d_menu_window.cpp
+++ b/src/d/d_menu_window.cpp
@@ -26,6 +26,10 @@
 #include "f_op/f_op_overlap_mng.h"
 #include "m_Do/m_Do_controller_pad.h"
 
+#ifdef TARGET_PC
+#include "dusk/frame_interpolation.h"
+#endif
+
 class dDlst_MENU_CAPTURE_c : public dDlst_base_c {
 public:
     virtual void draw() {
@@ -1088,6 +1092,10 @@ void dMw_c::dMw_ring_create(u8 i_origin) {
     }
 
     mpCapture->setCaptureFlag();
+
+#ifdef TARGET_PC
+    dusk::frame_interp::request_presentation_sync();
+#endif
 }
 
 bool dMw_c::dMw_ring_delete() {


### PR DESCRIPTION
so basically, there was a known problem where the frame on the wheel buffer was wrong when framerate was >30, really confusing for runners coming to dusk as it break cue frame on tricks. In my case, I needed to use the frame before the expected one for the forest bit. 

This aim to fix this using the same presentation-sync method to force the game frame matching console.

Maybe a double-check is required on other tricks/cases.

Here is the trick with the good frame using that fix

https://github.com/user-attachments/assets/aba637db-5f58-4bcf-82ad-4ab84dae7639

