### PR TITLE
Rework No Heart Drops Code

### DIFF
--- a/src/d/actor/d_a_obj_item.cpp
+++ b/src/d/actor/d_a_obj_item.cpp
@@ -268,6 +268,11 @@ int daItem_c::_daItem_create() {
     }
 
     m_itemNo = daItem_prm::getItemNo(this);
+#if TARGET_PC
+    if (dusk::getSettings().game.noHeartDrops && isHeart(m_itemNo)) {
+        return cPhs_ERROR_e;
+    }
+#endif
     BOOL flag = dItem_data::chkFlag(m_itemNo, 2);
 
 #if DEBUG

--- a/src/f_op/f_op_actor_mng.cpp
+++ b/src/f_op/f_op_actor_mng.cpp
@@ -1390,12 +1390,6 @@ fpc_ProcID fopAcM_createItemForPresentDemo(cXyz const* i_pos, int i_itemNo, u8 p
     JUT_ASSERT(3214, 0 <= i_itemNo && i_itemNo < 256);
     dComIfGp_event_setGtItm(i_itemNo);
 
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return fpcM_ERROR_PROCESS_ID_e;
-    }
-    #endif
-
     if (i_itemNo == dItemNo_NONE_e) {
         OS_REPORT("プレゼントデモ用なのに「ハズレ」です！[%d]\n", i_itemNo); // Even though it is for a Present Demo, it is a 'Miss'!
         return fpcM_ERROR_PROCESS_ID_e;
@@ -1409,12 +1403,6 @@ fpc_ProcID fopAcM_createItemForTrBoxDemo(cXyz const* i_pos, int i_itemNo, int i_
    
    JUT_ASSERT(3259, 0 <= i_itemNo && i_itemNo < 256);
    dComIfGp_event_setGtItm(i_itemNo);
-
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return fpcM_ERROR_PROCESS_ID_e;
-    }
-    #endif
 
     if (i_itemNo == dItemNo_NONE_e) {
         OS_REPORT("ゲットデモ用なのに「ハズレ」です！[%d]\n", i_itemNo); // Even though it is for a Get Demo, it is a 'Miss'!
@@ -1541,12 +1529,6 @@ fpc_ProcID fopAcM_createItemFromTable(cXyz const* i_pos, int i_itemNo, int i_ite
     JUT_ASSERT(3655, 0 <= i_itemNo && i_itemNo <= 255 && (-1 <= i_itemBitNo && i_itemBitNo < (dSv_info_c::DAN_ITEM + dSv_info_c::MEMORY_ITEM + dSv_info_c::ZONE_ITEM )) || i_itemBitNo == 255);
     // clang-format on
 
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return fpcM_ERROR_PROCESS_ID_e;
-    }
-    #endif
-
     u8 tableNum;
     ItemTableList* tableList;
     tableList = (ItemTableList*)dComIfGp_getItemTable();
@@ -1590,12 +1572,6 @@ fpc_ProcID fopAcM_createDemoItem(const cXyz* i_pos, int i_itemNo, int i_itemBitN
     JUT_ASSERT(3824, 0 <= i_itemNo && i_itemNo < 256 && (-1 <= i_itemBitNo && i_itemBitNo < (dSv_info_c::DAN_ITEM + dSv_info_c::MEMORY_ITEM + dSv_info_c::ZONE_ITEM )) || i_itemBitNo == 255);
     // clang-format on
 
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return fpcM_ERROR_PROCESS_ID_e;
-    }
-    #endif
-
     if (i_itemNo == dItemNo_NONE_e) {
         return fpcM_ERROR_PROCESS_ID_e;
     }
@@ -1607,12 +1583,6 @@ fpc_ProcID fopAcM_createDemoItem(const cXyz* i_pos, int i_itemNo, int i_itemBitN
 fpc_ProcID fopAcM_createItemForBoss(const cXyz* i_pos, int i_itemNo, int i_roomNo,
                                     const csXyz* i_angle, const cXyz* i_scale, f32 i_speedF,
                                     f32 i_speedY, int param_8) {
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return fpcM_ERROR_PROCESS_ID_e;
-    }
-    #endif
-
     int _ = -1;
     u32 params = 0xFFFF0000 | param_8 << 8 | (i_itemNo & 0xFF);
 
@@ -1629,12 +1599,6 @@ fpc_ProcID fopAcM_createItemForBoss(const cXyz* i_pos, int i_itemNo, int i_roomN
 fpc_ProcID fopAcM_createItemForMidBoss(const cXyz* i_pos, int i_itemNo, int i_roomNo,
                                        const csXyz* i_angle, const cXyz* i_scale, int param_6,
                                        int param_7) {
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return fpcM_ERROR_PROCESS_ID_e;
-    }
-    #endif
-
     UNUSED(i_angle);
     UNUSED(param_6);
     fpc_ProcID ret = -1;
@@ -1646,12 +1610,6 @@ fpc_ProcID fopAcM_createItemForMidBoss(const cXyz* i_pos, int i_itemNo, int i_ro
 fopAc_ac_c* fopAcM_createItemForDirectGet(const cXyz* i_pos, int i_itemNo, int i_roomNo,
                                           const csXyz* i_angle, const cXyz* i_scale, f32 i_speedF,
                                           f32 i_speedY) {
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return NULL;
-    }
-    #endif
-
     fopAc_ac_c* item = fopAcM_fastCreateItem(i_pos, i_itemNo, i_roomNo, i_angle, i_scale, &i_speedF, &i_speedY, -1,
                                  0x7, NULL);
     fopAc_ac_c* ret = item;
@@ -1661,12 +1619,6 @@ fopAc_ac_c* fopAcM_createItemForDirectGet(const cXyz* i_pos, int i_itemNo, int i
 fopAc_ac_c* fopAcM_createItemForSimpleDemo(const cXyz* i_pos, int i_itemNo, int i_roomNo,
                                            const csXyz* i_angle, const cXyz* i_scale, f32 i_speedF,
                                            f32 i_speedY) {
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return NULL;
-    }
-    #endif
-
     fopAc_ac_c* item = fopAcM_fastCreateItem(i_pos, i_itemNo, i_roomNo, i_angle, i_scale, &i_speedF, &i_speedY, -1,
                                  0x4, NULL);
     fopAc_ac_c* ret = item;
@@ -1678,12 +1630,6 @@ fpc_ProcID fopAcM_createItem(const cXyz* i_pos, int i_itemNo, int i_itemBitNo, i
     // clang-format off
     JUT_ASSERT(4067, 0 <= i_itemNo && i_itemNo < 256 && (-1 <= i_itemBitNo && i_itemBitNo < (dSv_info_c::DAN_ITEM + dSv_info_c::MEMORY_ITEM + dSv_info_c::ZONE_ITEM )) || i_itemBitNo == 255);
     // clang-format on
-
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return fpcM_ERROR_PROCESS_ID_e;
-    }
-    #endif
 
     if (i_itemNo == dItemNo_NONE_e) {
         return fpcM_ERROR_PROCESS_ID_e;
@@ -1748,12 +1694,6 @@ fopAc_ac_c* fopAcM_fastCreateItem2(const cXyz* i_pos, int i_itemNo, int i_itemBi
     // clang-format off
     JUT_ASSERT(4202, 0 <= i_itemNo && i_itemNo < 256 && (-1 <= i_itemBitNo && i_itemBitNo < (dSv_info_c::DAN_ITEM + dSv_info_c::MEMORY_ITEM + dSv_info_c::ZONE_ITEM )) || i_itemBitNo == 255);
     // clang-format on
-
-    #if TARGET_PC
-    if (dusk::getSettings().game.noHeartDrops && isHeart(i_itemNo)) {
-        return NULL;
-    }
-    #endif
 
     csXyz item_angle(csXyz::Zero);
 


### PR DESCRIPTION
- Checks the setting once in `daItem_c::_daItem_create` instead of in every `fopAcM_` helper for creating an item 
- No longer prevents hearts from being created as demo items (should never happen anyways? and would probably break)
- Fixes table entries passed to `fopAcM_createItemFromTable` being incorrectly treated as item IDs
- Prevents any freestanding hearts placed directly in the map with the dzr/dzs from spawning
- Fixes #1377/#1063/should cover more edge cases

Worth doing more testing to validate the behavior changes/make sure no new issues are introduced.