### PR TITLE
Add frame rate cap setting + default

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -72,6 +72,7 @@ struct UserSettings {
         ConfigVar<bool> lockAspectRatio;
         ConfigVar<bool> enableFpsOverlay;
         ConfigVar<int> fpsOverlayCorner;
+        ConfigVar<int> maxFrameRate;
     } video;
 
     struct {

--- a/libs/JSystem/src/JFramework/JFWDisplay.cpp
+++ b/libs/JSystem/src/JFramework/JFWDisplay.cpp
@@ -380,7 +380,14 @@ static void waitPrecise(Limiter& limiter, Limiter::duration_t targetNs) {
 static void waitForTick(u32 p1, u16 p2) {
 #if TARGET_PC
     if (dusk::getSettings().game.enableFrameInterpolation && !dusk::getTransientSettings().skipFrameRateLimit) {
-        dusk::frameUsagePct = 0.f;
+        const int frameRateCap = dusk::getSettings().video.maxFrameRate.getValue();
+        if (frameRateCap > 0) {
+            static Limiter limiter;
+            waitPrecise(limiter, static_cast<Limiter::duration_t>(
+                                     1000000000ULL / static_cast<u32>(frameRateCap)));
+        } else {
+            dusk::frameUsagePct = 0.f;
+        }
         return;
     }
     if (dusk::getTransientSettings().skipFrameRateLimit) {

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -10,6 +10,7 @@ UserSettings g_userSettings = {
         .lockAspectRatio {"video.lockAspectRatio", false},
         .enableFpsOverlay {"game.enableFpsOverlay", false},
         .fpsOverlayCorner {"game.fpsOverlayCorner", 0},
+        .maxFrameRate {"video.maxFrameRate", 240},
     },
 
     .audio = {
@@ -177,6 +178,7 @@ void registerSettings() {
     Register(g_userSettings.video.lockAspectRatio);
     Register(g_userSettings.video.enableFpsOverlay);
     Register(g_userSettings.video.fpsOverlayCorner);
+    Register(g_userSettings.video.maxFrameRate);
 
     // Audio
     Register(g_userSettings.audio.masterVolume);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -59,6 +59,8 @@ constexpr std::array kFpsOverlayCornerNames = {
     "Bottom Right",
 };
 
+constexpr std::array kFrameRateCapValues = {60, 120, 144, 240, 360};
+
 constexpr std::array kGyroInputModeLabels = {
     "Sensor",
     "Mouse",
@@ -800,6 +802,54 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             {
                 .key = "Unlock Framerate",
                 .helpText = kUnlockFramerateHelpText,
+            });
+        leftPane.register_control(
+            leftPane.add_select_button({
+                .key = "Max Frame Rate",
+                .getValue =
+                    [] {
+                        const int cap = getSettings().video.maxFrameRate.getValue();
+                        if (cap <= 0) {
+                            return Rml::String{"Unlimited"};
+                        }
+                        return Rml::String{std::to_string(cap) + " FPS"};
+                    },
+                .isDisabled =
+                    [] { return !getSettings().game.enableFrameInterpolation.getValue(); },
+                .isModified =
+                    [] {
+                        const auto& cap = getSettings().video.maxFrameRate;
+                        return cap.getValue() != cap.getDefaultValue();
+                    },
+            }),
+            rightPane, [](Pane& pane) {
+                pane.add_button(
+                        {
+                            .text = "Unlimited",
+                            .isSelected =
+                                [] { return getSettings().video.maxFrameRate.getValue() <= 0; },
+                        })
+                    .on_pressed([] {
+                        mDoAud_seStartMenu(kSoundItemChange);
+                        getSettings().video.maxFrameRate.setValue(0);
+                        config::Save();
+                    });
+                for (const int value : kFrameRateCapValues) {
+                    pane.add_button(
+                            {
+                                .text = std::to_string(value) + " FPS",
+                                .isSelected =
+                                    [value] {
+                                        return getSettings().video.maxFrameRate.getValue() == value;
+                                    },
+                            })
+                        .on_pressed([value] {
+                            mDoAud_seStartMenu(kSoundItemChange);
+                            getSettings().video.maxFrameRate.setValue(value);
+                            config::Save();
+                        });
+                }
+                pane.add_rml("<br/>Cap the interpolated frame rate.");
             });
         config_bool_select(leftPane, rightPane, getSettings().game.enableDepthOfField,
             {


### PR DESCRIPTION
started by #1446 and fix https://github.com/TwilitRealm/dusklight/issues/747

this approach use the existing limiter. 

Also switched the default to 240, subjective choice for the default value, but at least this is never a good practice to make a framerate unlimited by default, especially for low-end hardware where a sane default cap feels safer.