### PR TITLE
Update controller bindings menu.

### DIFF
--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -37,7 +37,7 @@ Rml::String current_controller_name(int port) {
 Rml::String controller_index_name(u32 index) {
     const char* name = PADGetNameForControllerIndex(index);
     if (name == nullptr) {
-        return fmt::format("Controller {}", index + 1);
+        return fmt::format("Device: {}", index + 1);
     }
     return name;
 }
@@ -124,7 +124,7 @@ Rml::String native_axis_name(const PADAxisMapping& mapping, SDL_Gamepad* gamepad
         return native_button_name(gamepad, static_cast<u32>(mapping.nativeButton));
     }
 
-    return "Not bound";
+    return "Not Bound";
 }
 
 bool is_dpad_button(PADButton button) {
@@ -162,7 +162,7 @@ bool keyboard_escape_pressed() {
 
 Rml::String keyboard_key_name(s32 scancode) {
     if (scancode == PAD_KEY_INVALID) {
-        return "Not bound";
+        return "Not Bound";
     }
     switch (scancode) {
     case PAD_KEY_MOUSE_LEFT:
@@ -303,7 +303,7 @@ void ControllerConfigWindow::build_port_tab(Rml::Element* content, int port) {
             });
     };
 
-    addPageButton(Page::Controller, "Controller", [port] { return current_controller_name(port); }, [] { return false; });
+    addPageButton(Page::Controller, "Device", [port] { return current_controller_name(port); }, [] { return false; });
     addPageButton(Page::Buttons, "Buttons", [] { return Rml::String(">"); }, [] { return false; });
     addPageButton(Page::Triggers, "Triggers", [] { return Rml::String(">"); }, [] { return false; });
     addPageButton(Page::Sticks, "Sticks", [] { return Rml::String(">"); }, [] { return false; });
@@ -365,7 +365,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                     [port] { return PADGetIndexForPort(port) < 0 && !keyboard_active(port); },
             })
             .on_pressed([this, port] {
-                mDoAud_seStartMenu(kSoundItemChange);
+                mDoAud_seStartMenu(kSoundClick);
                 cancel_pending_binding();
                 PADClearPort(port);
                 PADSetKeyboardActive(static_cast<u32>(port), FALSE);
@@ -378,7 +378,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                             .isSelected = [port] { return keyboard_active(port); },
                         })
             .on_pressed([this, port] {
-                mDoAud_seStartMenu(kSoundItemChange);
+                mDoAud_seStartMenu(kSoundClick);
                 cancel_pending_binding();
                 PADClearPort(port);
                 PADSetKeyboardActive(static_cast<u32>(port), TRUE);
@@ -388,7 +388,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
 
         const u32 controllerCount = PADCount();
         if (controllerCount == 0) {
-            pane.add_text("No controllers detected");
+            pane.add_text("No Device Detected");
             break;
         }
 
@@ -400,7 +400,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                             [port, i] { return PADGetIndexForPort(port) == static_cast<s32>(i); },
                     })
                 .on_pressed([this, port, i] {
-                    mDoAud_seStartMenu(kSoundItemChange);
+                    mDoAud_seStartMenu(kSoundClick);
                     cancel_pending_binding();
                     PADSetKeyboardActive(static_cast<u32>(port), FALSE);
                     PADSetPortForIndex(i, port);
@@ -425,17 +425,18 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                     PADKeyButtonBinding* bindings =
                                         PADGetKeyButtonBindings(static_cast<u32>(port), &count);
                                     if (bindings == nullptr) {
-                                        return Rml::String("Not bound");
+                                        return Rml::String("Not Bound");
                                     }
                                     for (u32 i = 0; i < PAD_BUTTON_COUNT; ++i) {
                                         if (bindings[i].padButton == button) {
                                             return keyboard_key_name(bindings[i].scancode);
                                         }
                                     }
-                                    return Rml::String("Not bound");
+                                    return Rml::String("Not Bound");
                                 },
                         })
                     .on_pressed([this, port, button] {
+                        mDoAud_seStartMenu(kSoundClick);
                         cancel_pending_binding();
                         mPendingPort = port;
                         mPendingBindingArmed = false;
@@ -462,7 +463,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
         u32 buttonCount = 0;
         PADButtonMapping* mappings = PADGetButtonMappings(port, &buttonCount);
         if (mappings == nullptr) {
-            pane.add_text("No controller selected");
+            pane.add_text("No Device Selected");
             break;
         }
 
@@ -486,6 +487,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                            },
                                    })
                 .on_pressed([this, port, &mapping] {
+                    mDoAud_seStartMenu(kSoundClick);
                     cancel_pending_binding();
                     mPendingPort = port;
                     mPendingBindingArmed = false;
@@ -512,6 +514,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                            },
                                    })
                 .on_pressed([this, port, &mapping] {
+                    mDoAud_seStartMenu(kSoundClick);
                     cancel_pending_binding();
                     mPendingPort = port;
                     mPendingBindingArmed = false;
@@ -535,17 +538,18 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                     PADKeyButtonBinding* bindings =
                                         PADGetKeyButtonBindings(static_cast<u32>(port), &count);
                                     if (bindings == nullptr) {
-                                        return Rml::String("Not bound");
+                                        return Rml::String("Not Bound");
                                     }
                                     for (u32 i = 0; i < PAD_BUTTON_COUNT; ++i) {
                                         if (bindings[i].padButton == button) {
                                             return keyboard_key_name(bindings[i].scancode);
                                         }
                                     }
-                                    return Rml::String("Not bound");
+                                    return Rml::String("Not Bound");
                                 },
                         })
                     .on_pressed([this, port, button] {
+                        mDoAud_seStartMenu(kSoundClick);
                         cancel_pending_binding();
                         mPendingPort = port;
                         mPendingBindingArmed = false;
@@ -566,17 +570,18 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                     PADKeyAxisBinding* bindings =
                                         PADGetKeyAxisBindings(static_cast<u32>(port), &count);
                                     if (bindings == nullptr) {
-                                        return Rml::String("Not bound");
+                                        return Rml::String("Not Bound");
                                     }
                                     for (u32 i = 0; i < PAD_AXIS_COUNT; ++i) {
                                         if (bindings[i].padAxis == axis) {
                                             return keyboard_key_name(bindings[i].scancode);
                                         }
                                     }
-                                    return Rml::String("Not bound");
+                                    return Rml::String("Not Bound");
                                 },
                         })
                     .on_pressed([this, port, axis] {
+                        mDoAud_seStartMenu(kSoundClick);
                         cancel_pending_binding();
                         mPendingPort = port;
                         mPendingBindingArmed = false;
@@ -599,7 +604,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
         u32 buttonCount = 0;
         PADButtonMapping* buttons = PADGetButtonMappings(port, &buttonCount);
         if (axes == nullptr && buttons == nullptr) {
-            pane.add_text("No controller selected");
+            pane.add_text("No Device Selected");
             break;
         }
 
@@ -623,6 +628,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                                },
                                        })
                     .on_pressed([this, port, &mapping] {
+                        mDoAud_seStartMenu(kSoundClick);
                         cancel_pending_binding();
                         mPendingPort = port;
                         mPendingBindingArmed = false;
@@ -650,6 +656,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                                },
                                        })
                     .on_pressed([this, port, &mapping] {
+                        mDoAud_seStartMenu(kSoundClick);
                         cancel_pending_binding();
                         mPendingPort = port;
                         mPendingBindingArmed = false;
@@ -706,17 +713,18 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                     PADKeyAxisBinding* bindings =
                                         PADGetKeyAxisBindings(static_cast<u32>(port), &count);
                                     if (bindings == nullptr) {
-                                        return Rml::String("Not bound");
+                                        return Rml::String("Not Bound");
                                     }
                                     for (u32 i = 0; i < PAD_AXIS_COUNT; ++i) {
                                         if (bindings[i].padAxis == axis) {
                                             return keyboard_key_name(bindings[i].scancode);
                                         }
                                     }
-                                    return Rml::String("Not bound");
+                                    return Rml::String("Not Bound");
                                 },
                         })
                     .on_pressed([this, port, axis] {
+                        mDoAud_seStartMenu(kSoundClick);
                         cancel_pending_binding();
                         mPendingPort = port;
                         mPendingBindingArmed = false;
@@ -741,7 +749,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
         u32 axisCount = 0;
         PADAxisMapping* axes = PADGetAxisMappings(port, &axisCount);
         if (axes == nullptr) {
-            pane.add_text("No controller selected");
+            pane.add_text("No Device Selected");
             break;
         }
 
@@ -762,6 +770,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                            },
                                    })
                 .on_pressed([this, port, &mapping] {
+                    mDoAud_seStartMenu(kSoundClick);
                     cancel_pending_binding();
                     mPendingPort = port;
                     mPendingBindingArmed = false;
@@ -907,6 +916,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                 },
                         })
                     .on_pressed([this, port, actionBind] {
+                        mDoAud_seStartMenu(kSoundClick);
                         cancel_pending_binding();
                         mPendingPort = port;
                         mPendingBindingArmed = false;
@@ -926,7 +936,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
         u32 buttonCount = 0;
         PADButtonMapping* mappings = PADGetButtonMappings(port, &buttonCount);
         if (mappings == nullptr) {
-            pane.add_text("No controller selected");
+            pane.add_text("No Device Selected");
             break;
         }
 
@@ -950,6 +960,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                                },
                        })
                 .on_pressed([this, port, actionBind] {
+                    mDoAud_seStartMenu(kSoundClick);
                     cancel_pending_binding();
                     mPendingPort = port;
                     mPendingBindingArmed = false;
@@ -1058,6 +1069,7 @@ void ControllerConfigWindow::poll_pending_binding() {
 }
 
 void ControllerConfigWindow::finish_pending_binding(int completedPort) {
+    mDoAud_seStartMenu(kSoundBindingChanged);
     mPendingButtonMapping = nullptr;
     mPendingAxisMapping = nullptr;
     mPendingActionBinding = nullptr;
@@ -1110,11 +1122,11 @@ bool ControllerConfigWindow::pending_input_neutral() const {
 }
 
 Rml::String ControllerConfigWindow::pending_button_label() const {
-    return mPendingBindingArmed ? "Press a button..." : "Waiting...";
+    return mPendingBindingArmed ? "Press a Key or Button..." : "Waiting...";
 }
 
 Rml::String ControllerConfigWindow::pending_axis_label() const {
-    return mPendingBindingArmed ? "Move axis or press a button..." : "Waiting...";
+    return mPendingBindingArmed ? "Move Axis or press a Key or Button..." : "Waiting...";
 }
 
 void ControllerConfigWindow::cancel_pending_binding() {
@@ -1143,7 +1155,7 @@ void ControllerConfigWindow::finish_pending_key_binding() {
 }
 
 Rml::String ControllerConfigWindow::pending_key_label() const {
-    return mPendingBindingArmed ? "Press a key or mouse button..." : "Waiting...";
+    return mPendingBindingArmed ? "Press a Key or Mouse Button..." : "Waiting...";
 }
 
 void ControllerConfigWindow::stop_rumble_test() {
@@ -1159,7 +1171,7 @@ void ControllerConfigWindow::stop_rumble_test() {
 
 Rml::String native_button_name(SDL_Gamepad* gamepad, u32 buttonUntyped) {
     if (buttonUntyped == PAD_NATIVE_BUTTON_INVALID) {
-        return "Not bound";
+        return "Not Bound";
     }
 
     auto button = static_cast<SDL_GamepadButton>(buttonUntyped);

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -349,7 +349,13 @@ void ControllerConfigWindow::build_port_tab(Rml::Element* content, int port) {
         rightPane, [](Pane& pane) {
             pane.add_text("Treat analog trigger movement as digital L and R button input.");
         });
-
+    leftPane.register_control(leftPane.add_button("Restore Default Controls").on_pressed([this, port] {
+            PADRestoreDefaultMapping(port);
+        }),
+            rightPane, [](Pane& pane) {
+                pane.clear();
+                pane.add_text("Restores all controller configurations for the currently selected controller to defaults.");
+        });
     render_page(rightPane, port, mPage);
 }
 
@@ -631,30 +637,32 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
             }
         }
 
-        pane.add_section("Digital");
-        if (buttons != nullptr) {
-            for (u32 i = 0; i < buttonCount; ++i) {
-                PADButtonMapping& mapping = buttons[i];
-                if (mapping.padButton != PAD_TRIGGER_L && mapping.padButton != PAD_TRIGGER_R) {
-                    continue;
+        if (getSettings().backend.enableAdvancedSettings) {
+            pane.add_section("Digital");
+            if (buttons != nullptr) {
+                for (u32 i = 0; i < buttonCount; ++i) {
+                    PADButtonMapping& mapping = buttons[i];
+                    if (mapping.padButton != PAD_TRIGGER_L && mapping.padButton != PAD_TRIGGER_R) {
+                        continue;
+                    }
+                    pane.add_select_button({
+                                               .key = PADGetButtonName(mapping.padButton),
+                                               .getValue =
+                                                   [this, &mapping, gamepad] {
+                                                       if (mPendingButtonMapping == &mapping) {
+                                                           return pending_button_label();
+                                                       }
+                                                       return native_button_name(
+                                                           gamepad, mapping.nativeButton);
+                                                   },
+                                           })
+                        .on_pressed([this, port, &mapping] {
+                            cancel_pending_binding();
+                            mPendingPort = port;
+                            mPendingBindingArmed = false;
+                            mPendingButtonMapping = &mapping;
+                        });
                 }
-                pane.add_select_button({
-                                           .key = PADGetButtonName(mapping.padButton),
-                                           .getValue =
-                                               [this, &mapping, gamepad] {
-                                                   if (mPendingButtonMapping == &mapping) {
-                                                       return pending_button_label();
-                                                   }
-                                                   return native_button_name(
-                                                       gamepad, mapping.nativeButton);
-                                               },
-                                       })
-                    .on_pressed([this, port, &mapping] {
-                        cancel_pending_binding();
-                        mPendingPort = port;
-                        mPendingBindingArmed = false;
-                        mPendingButtonMapping = &mapping;
-                    });
             }
         }
 

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -354,7 +354,7 @@ void ControllerConfigWindow::build_port_tab(Rml::Element* content, int port) {
         }),
             rightPane, [](Pane& pane) {
                 pane.clear();
-                pane.add_text("Restores all controller configurations for the currently selected controller to defaults.");
+                pane.add_text("Restores all binding configurations for the currently selected device to their defaults.");
         });
     render_page(rightPane, port, mPage);
 }

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -37,7 +37,7 @@ Rml::String current_controller_name(int port) {
 Rml::String controller_index_name(u32 index) {
     const char* name = PADGetNameForControllerIndex(index);
     if (name == nullptr) {
-        return fmt::format("Device: {}", index + 1);
+        return fmt::format("Device {}", index + 1);
     }
     return name;
 }

--- a/src/dusk/ui/overlay.cpp
+++ b/src/dusk/ui/overlay.cpp
@@ -103,13 +103,13 @@ Rml::Element* create_controller_warning(Rml::Element* parent) {
 
     auto* heading = append(elem, "heading");
     auto* title = append(heading, "span");
-    title->SetInnerRML("No controller assigned");
+    title->SetInnerRML("No Device Assigned");
     auto* icon = append(heading, "icon");
     icon->SetClass("warning", true);
 
     auto* message = append(elem, "message");
     auto* content = append(message, "span");
-    content->SetInnerRML("Configure controller port 1 in Settings.");
+    content->SetInnerRML("Configure <b>Port 1</b> in Settings.");
 
     return elem;
 }

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -829,18 +829,18 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 });
         };
 
-        leftPane.add_section("Controller");
-        leftPane.register_control(leftPane.add_button("Configure Controller").on_pressed([this] {
+        leftPane.add_section("Inputs");
+        leftPane.register_control(leftPane.add_button("Configure Inputs").on_pressed([this] {
             push(std::make_unique<ControllerConfigWindow>(mPrelaunch));
         }),
             rightPane, [](Pane& pane) {
                 pane.clear();
-                pane.add_text("Open controller binding configuration.");
+                pane.add_text("Open input binding configuration.");
             });
         config_bool_select(leftPane, rightPane, getSettings().game.allowBackgroundInput,
             {
-                .key = "Allow Background Input",
-                .helpText = "Allow controller input even when the game window is not focused.",
+                .key = "Allow Background Inputs",
+                .helpText = "Allow inputs even when the game window is not focused.",
                 .onChange = [](bool value) { aurora_set_background_input(value); },
             });
 
@@ -1247,7 +1247,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                     });
                 pane.add_button(
                     {
-                        .text = "Controller",
+                        .text = "Missing Device",
                         .isSelected =
                             [] { return getSettings().game.enableControllerToasts.getValue(); },
                     })

--- a/src/dusk/ui/ui.cpp
+++ b/src/dusk/ui/ui.cpp
@@ -130,7 +130,7 @@ void handle_event(const SDL_Event& event) noexcept {
             if (getSettings().game.enableControllerToasts) {
                 const char* name = SDL_GetGamepadName(gamepad);
                 Rml::String content = fmt::format("<span>{}</span>", name ? name : "[Unknown]");
-                Rml::String title = "Controller connected";
+                Rml::String title = "Device Connected";
                 if (const char* icon = connection_state_icon(SDL_GetGamepadConnectionState(gamepad))) {
                     title = fmt::format(
                         "<row><span>{}</span> <icon class=\"connection\">&#x{};</icon></row>", title,
@@ -163,7 +163,7 @@ void handle_event(const SDL_Event& event) noexcept {
             const char* name = SDL_GetGamepadNameForID(event.gdevice.which);
             push_toast({
                 .type = "controller",
-                .title = "Controller disconnected",
+                .title = "Device Disconnected",
                 .content = name ? name : "[Unknown]",
                 .duration = std::chrono::seconds(4),
             });

--- a/src/dusk/ui/ui.hpp
+++ b/src/dusk/ui/ui.hpp
@@ -26,6 +26,8 @@ struct Toast {
 constexpr u32 kSoundClick = Z2SE_SY_CURSOR_OK;
 // "Play" button clicked/pressed
 constexpr u32 kSoundPlay = Z2SE_SY_ITEM_COMBINE_ON;
+// Input binding changed
+constexpr u32 kSoundBindingChanged = Z2SE_SY_ITEM_SET_X;
 
 // Menu button pressed (open/close menu bar or hide/show the active window)
 constexpr u32 kSoundMenuOpen = Z2SE_SY_MENU_SUB_IN;
@@ -49,6 +51,8 @@ constexpr u32 kSoundItemDisable = Z2SE_SUBJ_VIEW_OUT;
 
 // Achievement unlocked
 constexpr u32 kSoundAchievementUnlock = Z2SE_NAVI_FLY;
+// Warning prompt
+constexpr u32 kSoundWarning = Z2SE_SY_COW_GET_IN;
 
 struct Insets {
     float top = 0.0f;


### PR DESCRIPTION
Adds a button that resets the current controller to the default configuration provided by aurora.
Additionally, only renders the panels for Digital L and R if the user has enabled the advanced menu, as there is very little reason a normal user would ever bind these buttons.