### PR TITLE
Add Windows ARM 64 Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,12 +221,12 @@ jobs:
             msvc_arch: amd64
             vcpkg_arch: x64
             artifact_arch: x86_64
-          # - name: MSVC arm64
-          #   runner: windows-11-arm
-          #   preset: arm64-msvc
-          #   msvc_arch: arm64
-          #   vcpkg_arch: arm64
-          #   artifact_arch: arm64
+          - name: MSVC arm64
+            runner: windows-11-arm
+            preset: arm64-msvc
+            msvc_arch: arm64
+            vcpkg_arch: arm64
+            artifact_arch: arm64
           # - name: Clang x86_64
           #   runner: windows-latest
           #   preset: clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,11 +113,90 @@ set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "_cmake")
 if (CMAKE_SYSTEM_NAME STREQUAL Linux)
   set(DAWN_USE_WAYLAND ON CACHE BOOL "Enable support for Wayland surface" FORCE)
 endif ()
+# Force-enable Dawn's D3D backends on Windows. Aurora's vendor branch leaves
+# these to Dawn's defaults, which silently disable D3D12 in some host
+# configurations (observed on Windows ARM64), leaving only the Vulkan
+# backend. Aurora's package/system branches call _aurora_dawn_set_platform_backends()
+# which sets these to ON — mirror that for the vendor path here.
+if (WIN32)
+    set(DAWN_ENABLE_D3D11 ON CACHE BOOL "Enable Dawn D3D11 backend" FORCE)
+    set(DAWN_ENABLE_D3D12 ON CACHE BOOL "Enable Dawn D3D12 backend" FORCE)
+endif ()
+# Additional Dawn vendor-build options that Aurora's branch leaves unset.
+# These mirror a known-working standalone Dawn build config; without them,
+# vendored Dawn on Windows ARM64 ships with a non-functional D3D12 backend.
+set(DAWN_USE_GLFW OFF CACHE BOOL "" FORCE)
+set(TINT_BUILD_IR_BINARY OFF CACHE BOOL "" FORCE)
+if (WIN32)
+    # Ensure Dawn (built via add_subdirectory) honors
+    # CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded set by our CI preset, so its
+    # debug info format matches the rest of the project.
+    set(CMAKE_POLICY_CMP0141 NEW CACHE STRING "" FORCE)
+endif ()
+# On Windows-on-ARM hosts CMake can leave CMAKE_SYSTEM_PROCESSOR=AMD64 when
+# cmake.exe runs as x64 under emulation, which makes aurora's prebuilt-package
+# providers fetch the wrong architecture. Trust the toolchain instead.
+if (WIN32)
+    set(_dusk_arm64_target FALSE)
+    if (MSVC_C_ARCHITECTURE_ID STREQUAL "ARM64"
+            OR MSVC_CXX_ARCHITECTURE_ID STREQUAL "ARM64"
+            OR CMAKE_C_COMPILER_ARCHITECTURE_ID STREQUAL "ARM64"
+            OR CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "ARM64"
+            OR CMAKE_GENERATOR_PLATFORM MATCHES "^[Aa][Rr][Mm]64$"
+            OR "$ENV{VSCMD_ARG_TGT_ARCH}" STREQUAL "arm64"
+            OR VCPKG_TARGET_TRIPLET MATCHES "^arm64-")
+        set(_dusk_arm64_target TRUE)
+    endif ()
+    message(STATUS "dusklight: WIN32 arch detection — "
+        "CMAKE_SYSTEM_PROCESSOR='${CMAKE_SYSTEM_PROCESSOR}', "
+        "MSVC_C_ARCHITECTURE_ID='${MSVC_C_ARCHITECTURE_ID}', "
+        "VSCMD_ARG_TGT_ARCH='$ENV{VSCMD_ARG_TGT_ARCH}', "
+        "arm64_target=${_dusk_arm64_target}")
+    if (_dusk_arm64_target AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+        message(STATUS "dusklight: forcing CMAKE_SYSTEM_PROCESSOR=ARM64 "
+            "(was '${CMAKE_SYSTEM_PROCESSOR}')")
+        set(CMAKE_SYSTEM_PROCESSOR "ARM64" CACHE STRING "Processor architecture" FORCE)
+    endif ()
+endif ()
 set(AURORA_ENABLE_DVD ON CACHE BOOL "Enable DVD API support" FORCE)
 set(AURORA_ENABLE_CARD ON CACHE BOOL "Enable CARD API support" FORCE)
 set(AURORA_ENABLE_RMLUI ON CACHE BOOL "Enable RmlUi UI support" FORCE)
 add_subdirectory(extern/aurora EXCLUDE_FROM_ALL)
 target_compile_definitions(aurora_mtx PRIVATE MTX_USE_PS=1)
+
+# When Dawn is built from source as a monolithic SHARED library on Windows,
+# CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON would auto-export every internal symbol
+# (Dawn + Tint + Abseil + SPIRV-Tools), blowing past MSVC's 65535-object
+# import library limit (LNK1189). Dawn already annotates its public API with
+# __declspec(dllexport), so suppress the global auto-export on this target.
+# Also enable link-time dead-code stripping and COMDAT folding: CMake's default
+# RelWithDebInfo flags include /INCREMENTAL, which disables /OPT:REF and
+# /OPT:ICF — without these the vendored Dawn DLL is ~4x larger than necessary.
+if (WIN32 AND TARGET webgpu_dawn)
+    get_target_property(_dusk_webgpu_dawn_type webgpu_dawn TYPE)
+    if (_dusk_webgpu_dawn_type STREQUAL "SHARED_LIBRARY")
+        set_target_properties(webgpu_dawn PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS OFF)
+        target_link_options(webgpu_dawn PRIVATE
+            $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>
+            $<$<NOT:$<CONFIG:Debug>>:/OPT:REF>
+            $<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>
+        )
+    endif ()
+endif ()
+
+# aurora.cpp builds its PreferredBackendOrder array from #ifdef
+# DAWN_ENABLE_BACKEND_* macros set by aurora_core.cmake. That CMake gate
+# reads DAWN_ENABLE_D3D12 from cache — when Dawn is vendored, the value
+# can be missing or out of scope at aurora_core configure time, leaving
+# only the Vulkan/Null backends in the renderer picker even though the
+# D3D backends are compiled into webgpu_dawn.dll. Force the macros on
+# aurora_core directly so the picker matches the DLL's actual contents.
+if (WIN32 AND TARGET aurora_core)
+    target_compile_definitions(aurora_core PRIVATE
+        DAWN_ENABLE_BACKEND_D3D11
+        DAWN_ENABLE_BACKEND_D3D12
+    )
+endif ()
 
 add_subdirectory(libs/freeverb)
 
@@ -569,6 +648,39 @@ endif ()
 
 include(extern/aurora/cmake/AuroraCopyRuntimeDLLs.cmake)
 aurora_copy_runtime_dlls(dusklight)
+
+# When Dawn is built from source on Windows, dxcompiler.dll and dxil.dll
+# (LoadLibrary'd by Dawn's D3D backend for HLSL→DXIL compilation) are not
+# produced. Fetch official Microsoft DXC binaries for the target architecture
+# and stage them next to dusklight.exe.
+if (WIN32 AND AURORA_DAWN_PROVIDER STREQUAL "vendor")
+    set(_dusk_dxc_arch "")
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+        set(_dusk_dxc_arch "arm64")
+    elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(AMD64|amd64|x86_64)$")
+        set(_dusk_dxc_arch "x64")
+    elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(X86|x86|i686)$")
+        set(_dusk_dxc_arch "x86")
+    endif ()
+    if (_dusk_dxc_arch)
+        message(STATUS "dusklight: Fetching Microsoft DXC binaries (${_dusk_dxc_arch})")
+        include(FetchContent)
+        FetchContent_Declare(dusk_dxc
+            URL "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.9.2602/dxc_2026_02_20.zip"
+            URL_HASH SHA256=a1e89031421cf3c1fca6627766ab3020ca4f962ac7e2caa7fab2b33a8436151e
+            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        )
+        FetchContent_MakeAvailable(dusk_dxc)
+        foreach (_dll IN ITEMS dxcompiler.dll dxil.dll)
+            add_custom_command(TARGET dusklight POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${dusk_dxc_SOURCE_DIR}/bin/${_dusk_dxc_arch}/${_dll}"
+                    $<TARGET_FILE_DIR:dusklight>
+                COMMENT "Staging ${_dll} (${_dusk_dxc_arch}) for Dawn D3D backend"
+            )
+        endforeach ()
+    endif ()
+endif ()
 
 if (DUSK_SELECTED_OPT)
     if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -490,7 +490,14 @@
       "inherits": [
         "x-windows-ci",
         "windows-arm64-msvc"
-      ]
+      ],
+      "cacheVariables": {
+        "CMAKE_SYSTEM_PROCESSOR": "ARM64",
+        "CMAKE_TOOLCHAIN_FILE": "",
+        "AURORA_NOD_PROVIDER": "vendor",
+        "AURORA_DAWN_PROVIDER": "vendor",
+        "DAWN_USE_BUILT_DXC": "ON"
+      }
     }
   ],
   "buildPresets": [

--- a/libs/freeverb/denormals.h
+++ b/libs/freeverb/denormals.h
@@ -17,6 +17,19 @@ inline void denormals_restore(denormal_state saved) { _mm_setcsr(saved); }
 
 #include <cstdint>
 using denormal_state = uint64_t;
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
+inline denormal_state denormals_enable()
+{
+    denormal_state saved = static_cast<denormal_state>(_ReadStatusReg(ARM64_FPCR));
+    _WriteStatusReg(ARM64_FPCR, saved | (1ULL << 24)); // FZ
+    return saved;
+}
+inline void denormals_restore(denormal_state saved)
+{
+    _WriteStatusReg(ARM64_FPCR, saved);
+}
+#else
 inline denormal_state denormals_enable()
 {
     denormal_state saved;
@@ -28,6 +41,7 @@ inline void denormals_restore(denormal_state saved)
 {
     asm volatile("msr fpcr, %0" :: "r"(saved));
 }
+#endif
 
 #elif defined(__arm__) || defined(_M_ARM)
 


### PR DESCRIPTION
With the rising popularity of Windows ARM 64 devices, such as the latest Surface / Snapdragon X laptops, recently released Snapdragon X2 devices and soon to be released Nvidia N1X SOC users are increasingly expecting native applications.

Built and tested the GitHub build Windows ARM artifact from my fork (https://github.com/talynone/dusklight/actions/runs/25963915954) using my Snapdragon X2 Elite Extreme based Asus Zenbook A16 running Windows 11 ARM 26H1. Tested both DirectX12 (default/auto) and Vulkan(glitchy/buggy due to immature Qualcomm Vulkan drivers). 

Notes:

Most of the changes dealt with building dawn for Windows ARM and making sure DirectX12 support was enabled/working.

The Windows ARM artifact built from the dawn-build repo currently produces x64 libs, I have a pull request that fixes that:
https://github.com/encounter/dawn-build/pull/2

denormals.h: Microsoft's MSVC compiler doesn't accept GCC inline assembly syntax, so the file failed to compile for Windows ARM64 builds.

The fix adds an MSVC-specific code path alongside the existing GCC one. It uses Microsoft's _ReadStatusReg / _WriteStatusReg compiler intrinsics (from <intrin.h>) with the ARM64_FPCR register identifier to do the exact same read-modify-write on the same hardware register — just through Microsoft's API instead of inline assembly. Compiler selection is done with #if defined(_MSC_VER) && !defined(__clang__) so clang-cl (which speaks both dialects) continues to use the GCC path. No behavior change on any existing platform.
   
Here's screenshot evidence of it running as a native Windows ARM 64 application:
<img width="1182" height="466" alt="image" src="https://github.com/user-attachments/assets/d3a89ca6-5e4e-4382-b481-ef39581bdabd" />
