### PR TITLE
Fix LiveSplit not starting when TV settings screen is skipped

### DIFF
--- a/src/d/d_bright_check.cpp
+++ b/src/d/d_bright_check.cpp
@@ -143,13 +143,12 @@ void dBrightCheck_c::modeMove() {
     if (mDoCPd_c::getTrigA(PAD_1) || mDoCPd_c::getTrigStart(PAD_1)) {
         mDoAud_seStart(Z2SE_ENTER_GAME, NULL, 0, 0);
 #ifdef TARGET_PC
-        dusk::speedrun::start();
-
         if (dusk::getSettings().game.speedrunMode && !dusk::getSettings().game.hideTvSettingsScreen) {
             // start a new run if a run isn't already in progress
             if (!dusk::m_speedrunInfo.m_isRunStarted) {
                 dusk::resetForSpeedrunMode();
                 dusk::m_speedrunInfo.startRun();
+                dusk::speedrun::start();
             }
         }
 

--- a/src/d/d_s_name.cpp
+++ b/src/d/d_s_name.cpp
@@ -10,6 +10,7 @@
 #include "d/d_meter2_info.h"
 #include "d/d_s_name.h"
 #include "dusk/imgui/ImGuiConsole.hpp"
+#include "dusk/livesplit.h"
 #include "dusk/memory.h"
 #include "dusk/speedrun.h"
 #include "dusk/settings.h"
@@ -422,6 +423,7 @@ void dScnName_c::changeGameScene() {
             if (!dusk::m_speedrunInfo.m_isRunStarted) {
                 dusk::resetForSpeedrunMode();
                 dusk::m_speedrunInfo.startRun();
+                dusk::speedrun::start();
             }
         }
 


### PR DESCRIPTION
fix https://github.com/TwilitRealm/dusklight/issues/1225

Also unifies the LiveSplit timer start behavior with the in-game timer