### PR TITLE
Add "Output Resampling" option

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -15,6 +15,11 @@ enum class BloomMode : int {
     Dusk = 2,
 };
 
+enum class Resampler : int {
+    Bilinear = 0,
+    Area = 1,
+};
+
 enum class GameLanguage : u8 {
     English = OS_LANGUAGE_ENGLISH,
     German = OS_LANGUAGE_GERMAN,
@@ -39,6 +44,12 @@ template <>
 struct ConfigEnumRange<BloomMode> {
     static constexpr auto min = BloomMode::Off;
     static constexpr auto max = BloomMode::Dusk;
+};
+
+template <>
+struct ConfigEnumRange<Resampler> {
+    static constexpr auto min = Resampler::Bilinear;
+    static constexpr auto max = Resampler::Area;
 };
 
 template <>
@@ -131,6 +142,7 @@ struct UserSettings {
         ConfigVar<bool> enableFrameInterpolation;
         ConfigVar<int> internalResolutionScale;
         ConfigVar<int> shadowResolutionMultiplier;
+        ConfigVar<Resampler> resampler;
         ConfigVar<bool> enableDepthOfField;
         ConfigVar<bool> enableMapBackground;
         ConfigVar<bool> disableCutscenePillarboxing;

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -158,6 +158,7 @@ namespace dusk::config {
     template class ConfigImpl<dusk::DiscVerificationState>;
     template class ConfigImpl<dusk::GameLanguage>;
     template class ConfigImpl<dusk::GyroMode>;
+    template class ConfigImpl<dusk::Resampler>;
 }
 
 void dusk::config::Register(ConfigVarBase& configVar) {

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -69,6 +69,7 @@ UserSettings g_userSettings = {
         .enableFrameInterpolation {"game.enableFrameInterpolation", false},
         .internalResolutionScale {"game.internalResolutionScale", 0},
         .shadowResolutionMultiplier {"game.shadowResolutionMultiplier", 1},
+        .resampler {"game.resampler", Resampler::Bilinear},
         .enableDepthOfField {"game.enableDepthOfField", true},
         .enableMapBackground {"game.enableMapBackground", true},
         .disableCutscenePillarboxing {"game.disableCutscenePillarboxing", false},
@@ -232,6 +233,7 @@ void registerSettings() {
     Register(g_userSettings.game.disableWaterRefraction);
     Register(g_userSettings.game.enableTextureReplacements);
     Register(g_userSettings.game.internalResolutionScale);
+    Register(g_userSettings.game.resampler);
     Register(g_userSettings.game.shadowResolutionMultiplier);
     Register(g_userSettings.game.enableDepthOfField);
     Register(g_userSettings.game.enableMapBackground);

--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -3,6 +3,7 @@
 #include "Z2AudioLib/Z2SeMgr.h"
 #include "m_Do/m_Do_audio.h"
 
+#include <aurora/aurora.h>
 #include <dolphin/gx/GXAurora.h>
 #include <dolphin/vi.h>
 #include <fmt/format.h>
@@ -43,6 +44,8 @@ int get_value(GraphicsOption option) {
         return getSettings().game.internalResolutionScale.getValue();
     case GraphicsOption::ShadowResolution:
         return getSettings().game.shadowResolutionMultiplier.getValue();
+    case GraphicsOption::Resampler:
+        return static_cast<int>(getSettings().game.resampler.getValue());
     case GraphicsOption::BloomMode:
         return static_cast<int>(getSettings().game.bloomMode.getValue());
     case GraphicsOption::BloomMultiplier:
@@ -62,6 +65,22 @@ void set_value(GraphicsOption option, int value) {
     case GraphicsOption::ShadowResolution:
         getSettings().game.shadowResolutionMultiplier.setValue(value);
         break;
+    case GraphicsOption::Resampler: {
+        const auto sampler = static_cast<Resampler>(std::clamp(value,
+            static_cast<int>(Resampler::Bilinear),
+            static_cast<int>(Resampler::Area)));
+        getSettings().game.resampler.setValue(sampler);
+        switch (sampler) {
+        case Resampler::Area:
+            aurora_set_resampler(SAMPLER_AREA);
+            break;
+        case Resampler::Bilinear:
+        default:
+            aurora_set_resampler(SAMPLER_BILINEAR);
+            break;
+        }
+        break;
+    }
     case GraphicsOption::BloomMode:
         getSettings().game.bloomMode.setValue(static_cast<BloomMode>(std::clamp(
             value, static_cast<int>(BloomMode::Off), static_cast<int>(BloomMode::Dusk))));
@@ -177,6 +196,14 @@ Rml::String format_graphics_setting_value(GraphicsOption option, int value) {
     }
     case GraphicsOption::ShadowResolution:
         return fmt::format("{}×", value);
+    case GraphicsOption::Resampler:
+        switch (static_cast<Resampler>(value)) {
+        case Resampler::Bilinear:
+            return "Bilinear";
+        case Resampler::Area:
+            return "Area";
+        }
+        break;
     case GraphicsOption::BloomMode:
         switch (static_cast<BloomMode>(value)) {
         case BloomMode::Off:

--- a/src/dusk/ui/graphics_tuner.hpp
+++ b/src/dusk/ui/graphics_tuner.hpp
@@ -42,6 +42,7 @@ private:
 enum class GraphicsOption {
     InternalResolution,
     ShadowResolution,
+    Resampler,
     BloomMode,
     BloomMultiplier,
 };

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -351,6 +351,8 @@ const Rml::String kInternalResolutionHelpText =
 const Rml::String kShadowResolutionHelpText =
     "Configure the shadow-map resolution. Higher values improve shadow quality but increase GPU "
     "and memory usage.";
+const Rml::String kResamplerHelpText =
+    "Configure the sampling method used when scaling the internal resolution for final presentation.";
 const Rml::String kBloomHelpText =
     "Configure the post-processing bloom effect. Classic uses the original bloom pass; Dusklight uses "
     "a higher-quality bloom pass.";
@@ -773,6 +775,15 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .valueMin = 1,
                 .valueMax = 8,
                 .defaultValue = 1,
+            }, mPrelaunch);
+        graphics_tuner_control(*this, leftPane, rightPane, getSettings().game.resampler,
+            GraphicsTunerProps{
+                .option = GraphicsOption::Resampler,
+                .title = "Output Resampling",
+                .helpText = kResamplerHelpText,
+                .valueMin = static_cast<int>(Resampler::Bilinear),
+                .valueMax = static_cast<int>(Resampler::Area),
+                .defaultValue = static_cast<int>(Resampler::Bilinear),
             }, mPrelaunch);
 
         leftPane.add_section("Post-Processing");

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -584,6 +584,15 @@ int game_main(int argc, char* argv[]) {
         AuroraSetViewportPolicy(AURORA_VIEWPORT_STRETCH);
     }
     VISetFrameBufferScale(dusk::getSettings().game.internalResolutionScale.getValue());
+    switch (dusk::getSettings().game.resampler.getValue()) {
+    case dusk::Resampler::Area:
+        aurora_set_resampler(SAMPLER_AREA);
+        break;
+    case dusk::Resampler::Bilinear:
+    default:
+        aurora_set_resampler(SAMPLER_BILINEAR);
+        break;
+    }
 
     dusk::audio::SetMasterVolume(dusk::audio::MasterVolumeToLinear(dusk::getSettings().audio.masterVolume / 100.0f));
     dusk::audio::SetEnableReverb(dusk::getSettings().audio.enableReverb);


### PR DESCRIPTION
Requires https://github.com/encounter/aurora/pull/197.

Adds an Output Resampling option to the Video tab to allow choosing between the old Bilinear sampler and a new Area sampler. Area sampling produces a much cleaner, softer image when downscaling, and a significantly sharper image when upscaling. This can also serve as a halfway decent anti-aliasing substitute until we have a more proper implementation.

<details>
<summary>Bilinear at 8x IR (1440p presentation)</summary>
<img width="2560" height="1440" alt="Bilinear at 8x IR (1440p presentation)" src="https://github.com/user-attachments/assets/dda2ef19-1302-48d8-a125-ac62ab438ce4" />
</details>

<details>
<summary>Area at 8x IR (1440p presentation)</summary>
<img width="2560" height="1440" alt="Area at 8x IR (1440p presentation)" src="https://github.com/user-attachments/assets/4418d017-0ca6-4c31-a20d-925c668d8c54" />
</details>

<details>
<summary>Bilinear at 1x IR (1440p presentation)</summary>
<img width="2560" height="1440" alt="Bilinear at 1x IR (1440p presentation)" src="https://github.com/user-attachments/assets/390c643e-8051-4d32-a022-b02136e4c87a" />
</details>

<details>
<summary>Area at 1x IR (1440p presentation)</summary>
<img width="2560" height="1440" alt="Area at 1x IR (1440p presentation)" src="https://github.com/user-attachments/assets/ed553e46-3b63-4431-9cf3-899bccb04368" />
</details>