### PR TITLE
Extend wooden sign backdrop across ultrawide screens

### DIFF
--- a/src/d/d_msg_scrn_tree.cpp
+++ b/src/d/d_msg_scrn_tree.cpp
@@ -188,6 +188,14 @@ void dMsgScrnTree_c::exec() {
         fukiAlpha(1.0f);
     }
     mpPmP_c->scale(g_MsgObject_HIO_c.mBoxWoodScaleX, g_MsgObject_HIO_c.mBoxWoodScaleY);
+
+#if TARGET_PC
+    const f32 hudScale = mDoGph_gInf_c::hudAspectScaleUp;
+    if (hudScale > 1.0f) {
+        field_0xc4->getPanePtr()->setBasePosition(J2DBasePosition_4);
+        field_0xc4->getPanePtr()->scale(hudScale, 1.0f);
+    }
+#endif
 }
 
 void dMsgScrnTree_c::draw() {


### PR DESCRIPTION
This change improves the backdrop scaling of signposts on ultrawide monitors and bigger (> 16:9). Currently on an ultra wide it looks like this:

<img width="3432" height="1440" alt="image" src="https://github.com/user-attachments/assets/552ea472-77aa-4e8a-9978-614f4f93e900" />

With these changes, which are PC-specific, it will start looking like this:

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/f3f2a0ec-628c-4770-b333-5cbd0a5aa170" />



I also tested these changes with 16:9 and 4:3 and found no regressions.