### PR TITLE
Input Redesign

### DIFF
--- a/include/dusk/action_bindings.h
+++ b/include/dusk/action_bindings.h
@@ -7,14 +7,104 @@
 namespace dusk {
 
 enum class ActionBinds {
-    FIRST_PERSON_CAMERA,
-    CALL_MIDNA,
+    COUNT, /* Press Count */
+
+    /* Dusk Controls */
     OPEN_DUSKLIGHT_MENU,
     TURBO_SPEED_BUTTON,
-    COUNT,
+
+    MENU_UP,
+    MENU_LEFT,
+    MENU_DOWN,
+    MENU_RIGHT,
+    MENU_CONFIRM,
+    MENU_REJECT,
+
+    MENU_X, /* Analog that resolves to MENU_LEFT or MENU_RIGHT */
+    MENU_Y, /* Analog that resolves to MENU_UP or MENU_DOWN */
+
+    /* Button Presses */
+    SWORD_ATTACK, /* Attack with Sword */
+    ITEM_ACCESS_X, /* Access FIrst Quick Item slot */
+    ITEM_ACCESS_Y, /* Access Second Quick Item slot */
+    SHIELD_USE, /* For Shield attacks */
+
+    INTERACT, /* Talk or Examine */
+
+    ROLL, /* Roll on Ground */
+    MOVE_MODIFIER_TOGGLE, /* For Players using Digital Movement Input */
+
+    TARGET, /* Target to perform techs */
+
+    GRAB_HEAVY, /* Grab Blocks and chains to push or pull */
+    GRAB_LIGHT, /* Pickup lighter items (Boulder, Pots, Pets) */
+
+    CALL_MIDNA, /* Call on Midna, or any other available other companion like Hena during lure fishing */
+    INGAME_PAUSE,  /* Pause to the Game's Menu */
+    FIRST_PERSON_CAMERA, /* First Person Camera Toggle */
+
+    MAP_CYCLE_UP,   /* Analogous to the right D-pad press during free exploration */
+    MAP_CYCLE_DOWN, /* Analogous to The left D-pad press during free exploration */
+    PEEK_MAP,   /* Peek Map, or Peek out if in Map */
+    TOGGLE_MAP_SCREEN, /* Toggle HUD Map Screen */
+    HUD_VISIBILITY, /* Toggle the HUD Visibility */
+
+    ITEM_CYCLE_NEXT, /* Hold Down and press corresponding item access button to cycle to next item in wheel without opening it. (Default: Unbound) */
+    ITEM_CYCLE_PREV, /* Hold Down and press corresponding item access button to cycle to previous item in wheel without opening it. (Default: Unbound) */
+
+    /* Minimimal Button Bindings */
+    GRAB_ALL, /* Both GRAB_HEAVY and GRAB_LIGHT */
+
+    /* Classical Button Bindings */
+    BUTTON_A,
+    BUTTON_B,
+    BUTTON_X,
+    BUTTON_Y,
+    BUTTON_Z,
+    BUTTON_START,
+
+    DPAD_UP,
+    DPAD_LEFT,
+    DPAD_DOWN,
+    DPAD_RIGHT,
+
+    DIGITAL_L,
+    DIGITAL_R,
+
+    /* "Analog" Binds (Cursor Input, Analog Sticks, Analog triggers etc.) */
+    /* Movement input for Walking, Horseriding and Swimming */
+    MOVE_X, MOVE_Y,
+    /* Camera Movement during third person play */
+    CAM_X, CAM_Y,
+    /* Camera Movement during aiming/First Person view */
+    AIM_X, AIM_Y,
+    /* Item Wheel */
+    WHEEL_X, WHEEL_Y,
+
+    /* Minimal Analog Bindings */
+    /* Third Person, First Person and Wheel */
+    ALLCAM_X, ALLCAM_Y,
+
+    /* Classical Analog Bindings */
+    MAIN_STICK_X, MAIN_STICK_Y,
+    C_STICK_X, C_STICK_Y,
+    TRIGGER_L, TRIGGER_R,
+};
+
+enum class ActionBindContext {
+    DUSK, /* Used by Dusklight in menus */
+    VERB, /* A verb of the game */
+    CLASSICAL, /* Original Controller Mapping */
+};
+
+enum class ActionBindType {
+    BUTTON,
+    ANALOG,
 };
 
 struct ActionBindData {
+    ActionBindContext actionContext{};
+    ActionBindType actionType{};
     std::array<config::ActionBindConfigVar, 4>* configVars{};
     std::string actionName{};
 };
@@ -22,6 +112,7 @@ struct ActionBindData {
 struct ActionBindPressData {
     bool pressedCurFrame{false};
     bool pressedPrevFrame{false};
+    int bindCurAnalogData{0};
 };
 
 using ActionBindsMap = std::unordered_map<ActionBinds, ActionBindData>;

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -208,10 +208,69 @@ struct UserSettings {
 
     // Arrays of size 4 for 4 ports
     struct {
-        std::array<ActionBindConfigVar, 4> firstPersonCamera;
-        std::array<ActionBindConfigVar, 4> callMidna;
         std::array<ActionBindConfigVar, 4> openDusklightMenu;
         std::array<ActionBindConfigVar, 4> turboSpeedButton;
+        std::array<ActionBindConfigVar, 4> menuUp;
+        std::array<ActionBindConfigVar, 4> menuLeft;
+        std::array<ActionBindConfigVar, 4> menuDown;
+        std::array<ActionBindConfigVar, 4> menuRight;
+        std::array<ActionBindConfigVar, 4> menuConfirm;
+        std::array<ActionBindConfigVar, 4> menuReject;
+        std::array<ActionBindConfigVar, 4> menuX;
+        std::array<ActionBindConfigVar, 4> menuY;
+
+        std::array<ActionBindConfigVar, 4> swordAttack;
+        std::array<ActionBindConfigVar, 4> itemAccessX;
+        std::array<ActionBindConfigVar, 4> itemAccessY;
+        std::array<ActionBindConfigVar, 4> shieldUse;
+        std::array<ActionBindConfigVar, 4> interact;
+        std::array<ActionBindConfigVar, 4> roll;
+        std::array<ActionBindConfigVar, 4> moveModifierToggle;
+        std::array<ActionBindConfigVar, 4> target;
+        std::array<ActionBindConfigVar, 4> grabHeavy;
+        std::array<ActionBindConfigVar, 4> grabLight;
+        std::array<ActionBindConfigVar, 4> callMidna;
+        std::array<ActionBindConfigVar, 4> ingamePause;
+        std::array<ActionBindConfigVar, 4> firstPersonCamera;
+        std::array<ActionBindConfigVar, 4> mapCycleUp;
+        std::array<ActionBindConfigVar, 4> mapCycleDown;
+        std::array<ActionBindConfigVar, 4> peekMap;
+        std::array<ActionBindConfigVar, 4> toggleMapScreen;
+        std::array<ActionBindConfigVar, 4> hudVisibility;
+        std::array<ActionBindConfigVar, 4> itemCycleNext;
+        std::array<ActionBindConfigVar, 4> itemCyclePrev;
+        std::array<ActionBindConfigVar, 4> grabAll;
+
+        std::array<ActionBindConfigVar, 4> moveX;
+        std::array<ActionBindConfigVar, 4> moveY;
+        std::array<ActionBindConfigVar, 4> camX;
+        std::array<ActionBindConfigVar, 4> camY;
+        std::array<ActionBindConfigVar, 4> aimX;
+        std::array<ActionBindConfigVar, 4> aimY;
+        std::array<ActionBindConfigVar, 4> wheelX;
+        std::array<ActionBindConfigVar, 4> wheelY;
+        std::array<ActionBindConfigVar, 4> allcamX;
+        std::array<ActionBindConfigVar, 4> allcamY;
+
+        std::array<ActionBindConfigVar, 4> buttonA;
+        std::array<ActionBindConfigVar, 4> buttonB;
+        std::array<ActionBindConfigVar, 4> buttonX;
+        std::array<ActionBindConfigVar, 4> buttonY;
+        std::array<ActionBindConfigVar, 4> buttonZ;
+        std::array<ActionBindConfigVar, 4> buttonStart;
+        std::array<ActionBindConfigVar, 4> dpadUp;
+        std::array<ActionBindConfigVar, 4> dpadLeft;
+        std::array<ActionBindConfigVar, 4> dpadDown;
+        std::array<ActionBindConfigVar, 4> dpadRight;
+        std::array<ActionBindConfigVar, 4> digitalL;
+        std::array<ActionBindConfigVar, 4> digitalR;
+
+        std::array<ActionBindConfigVar, 4> mainStickX;
+        std::array<ActionBindConfigVar, 4> mainStickY;
+        std::array<ActionBindConfigVar, 4> cStickX;
+        std::array<ActionBindConfigVar, 4> cStickY;
+        std::array<ActionBindConfigVar, 4> triggerL;
+        std::array<ActionBindConfigVar, 4> triggerR;
     } actionBindings;
 };
 

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -10,10 +10,70 @@ static std::array<std::array<ActionBindPressData, static_cast<int>(ActionBinds::
 
 ActionBindsMap& getActionBinds() {
     static ActionBindsMap actionBinds = {
-        {ActionBinds::FIRST_PERSON_CAMERA, {&getSettings().actionBindings.firstPersonCamera, "First Person Camera"}},
-        {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna"}},
-        {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu"}},
-        {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button"}},
+        {ActionBinds::OPEN_DUSKLIGHT_MENU,  {ActionBindContext::DUSK,  ActionBindType::BUTTON,    &getSettings().actionBindings.openDusklightMenu,    "Open Dusklight Menu"}},
+        {ActionBinds::TURBO_SPEED_BUTTON,   {ActionBindContext::DUSK,  ActionBindType::BUTTON,    &getSettings().actionBindings.turboSpeedButton, "Turbo Speed Button"}},
+        {ActionBinds::MENU_UP,  {ActionBindContext::DUSK,  ActionBindType::BUTTON,    &getSettings().actionBindings.menuUp,   "Menu Up"}},
+        {ActionBinds::MENU_LEFT,    {ActionBindContext::DUSK,  ActionBindType::BUTTON,    &getSettings().actionBindings.menuLeft, "Menu Left"}},
+        {ActionBinds::MENU_DOWN,    {ActionBindContext::DUSK,  ActionBindType::BUTTON,    &getSettings().actionBindings.menuDown, "Menu Down"}},
+        {ActionBinds::MENU_RIGHT,   {ActionBindContext::DUSK,  ActionBindType::BUTTON,    &getSettings().actionBindings.menuRight,    "Menu Right"}},
+        {ActionBinds::MENU_CONFIRM, {ActionBindContext::DUSK,  ActionBindType::BUTTON,    &getSettings().actionBindings.menuConfirm,  "Confirm"}},
+        {ActionBinds::MENU_REJECT,  {ActionBindContext::DUSK,  ActionBindType::BUTTON,    &getSettings().actionBindings.menuReject,   "Reject"}},
+
+        {ActionBinds::MENU_X,   {ActionBindContext::DUSK,  ActionBindType::ANALOG,    &getSettings().actionBindings.menuX,    "Menu Left/Right"}},
+        {ActionBinds::MENU_Y,   {ActionBindContext::DUSK,  ActionBindType::ANALOG,    &getSettings().actionBindings.menuY,    "Menu Up/Down"}},
+
+        {ActionBinds::SWORD_ATTACK, {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.swordAttack,  "Use Sword"}},
+        {ActionBinds::ITEM_ACCESS_X,    {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.itemAccessX,  "Item Slot 2"}},
+        {ActionBinds::ITEM_ACCESS_Y,    {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.itemAccessY,  "Item Slot 1"}},
+        {ActionBinds::SHIELD_USE,   {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.shieldUse,    "Use Shield"}},
+        {ActionBinds::INTERACT, {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.interact, "Interact"}},
+        {ActionBinds::ROLL, {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.roll, "Roll"}},
+        {ActionBinds::MOVE_MODIFIER_TOGGLE, {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.moveModifierToggle,   "Run/Walk"}},
+        {ActionBinds::TARGET,   {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.target,   "Target"}},
+        {ActionBinds::GRAB_HEAVY,   {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.grabHeavy,    "Grab blocks and chains"}},
+        {ActionBinds::GRAB_LIGHT,   {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.grabLight,    "Pick up"}},
+        {ActionBinds::CALL_MIDNA,   {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.callMidna,    "Call Companion"}},
+        {ActionBinds::INGAME_PAUSE, {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.ingamePause,  "Character Menu"}},
+        {ActionBinds::FIRST_PERSON_CAMERA,  {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.firstPersonCamera,    "First Person Camera"}},
+        {ActionBinds::MAP_CYCLE_UP, {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.mapCycleUp,   "Map Cycle Up"}},
+        {ActionBinds::MAP_CYCLE_DOWN,   {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.mapCycleDown, "Map Cycle Down"}},
+        {ActionBinds::PEEK_MAP, {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.peekMap,  "Peek Map"}},
+        {ActionBinds::TOGGLE_MAP_SCREEN,    {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.toggleMapScreen,  "Toggle Map Screen"}},
+        {ActionBinds::HUD_VISIBILITY,   {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.hudVisibility,    "Toggle HUD Visibility"}},
+        {ActionBinds::ITEM_CYCLE_NEXT,  {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.itemCycleNext,    "Next Item"}},
+        {ActionBinds::ITEM_CYCLE_PREV,  {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.itemCyclePrev,    "Previous Item"}},
+        {ActionBinds::GRAB_ALL, {ActionBindContext::VERB,  ActionBindType::BUTTON,    &getSettings().actionBindings.grabAll,  "Grab and Pick up"}},
+
+        {ActionBinds::MOVE_X,   {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.moveX,    "Move Left/Right"}},
+        {ActionBinds::MOVE_Y,   {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.moveY,    "Move Forwards/Backwards"}},
+        {ActionBinds::CAM_X,    {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.camX, "Camera Left/Right (Third Person)"}},
+        {ActionBinds::CAM_Y,    {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.camY, "Camera Up/Down (Third Person)"}},
+        {ActionBinds::AIM_X,    {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.aimX, "Aim Left/Right"}},
+        {ActionBinds::AIM_Y,    {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.aimY, "Aim Up/Down"}},
+        {ActionBinds::WHEEL_X,  {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.wheelX,   "Wheel Left/Right"}},
+        {ActionBinds::WHEEL_Y,  {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.wheelY,   "Wheel Up/Down"}},
+        {ActionBinds::ALLCAM_X, {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.allcamX,  "Camera Left/Right"}},
+        {ActionBinds::ALLCAM_Y, {ActionBindContext::VERB,  ActionBindType::ANALOG,    &getSettings().actionBindings.allcamY,  "Camera Up/Down"}},
+
+        {ActionBinds::BUTTON_A, {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.buttonA,  "A"}},
+        {ActionBinds::BUTTON_B, {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.buttonB,  "B"}},
+        {ActionBinds::BUTTON_X, {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.buttonX,  "X"}},
+        {ActionBinds::BUTTON_Y, {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.buttonY,  "Y"}},
+        {ActionBinds::BUTTON_Z, {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.buttonZ,  "Z"}},
+        {ActionBinds::BUTTON_START, {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.buttonStart,  "START"}},
+        {ActionBinds::DPAD_UP,  {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.dpadUp,   "Dpad UP"}},
+        {ActionBinds::DPAD_LEFT,    {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.dpadLeft, "Dpad LEFT"}},
+        {ActionBinds::DPAD_DOWN,    {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.dpadDown, "Dpad DOWN"}},
+        {ActionBinds::DPAD_RIGHT,   {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.dpadRight,    "Dpad RIGHT"}},
+        {ActionBinds::DIGITAL_L,    {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.digitalL, "Digital L"}},
+        {ActionBinds::DIGITAL_R,    {ActionBindContext::CLASSICAL, ActionBindType::BUTTON,    &getSettings().actionBindings.digitalR, "Digital R"}},
+
+        {ActionBinds::MAIN_STICK_X, {ActionBindContext::CLASSICAL, ActionBindType::ANALOG,    &getSettings().actionBindings.mainStickX,   "Main Stick X"}},
+        {ActionBinds::MAIN_STICK_Y, {ActionBindContext::CLASSICAL, ActionBindType::ANALOG,    &getSettings().actionBindings.mainStickY,   "Main Stick Y"}},
+        {ActionBinds::C_STICK_X,    {ActionBindContext::CLASSICAL, ActionBindType::ANALOG,    &getSettings().actionBindings.cStickX,  "C-Stick X"}},
+        {ActionBinds::C_STICK_Y,    {ActionBindContext::CLASSICAL, ActionBindType::ANALOG,    &getSettings().actionBindings.cStickY,  "C-Stick Y"}},
+        {ActionBinds::TRIGGER_L,    {ActionBindContext::CLASSICAL, ActionBindType::ANALOG,    &getSettings().actionBindings.triggerL, "Analog L"}},
+        {ActionBinds::TRIGGER_R,    {ActionBindContext::CLASSICAL, ActionBindType::ANALOG,    &getSettings().actionBindings.triggerR, "Analog R"}},
     };
     return actionBinds;
 }
@@ -39,10 +99,12 @@ void updateActionBindings() {
         // Update current frame with whether action button is pressed
         for (auto& [action, boundAction] : getActionBinds()) {
             // If the action isn't bound, or if documents are visible and the action isn't
-            // opening the dusklight menu, don't update. Otherwise, we may accidentally
+            // a dusklight bound one, don't update. Otherwise, we may accidentally
             // perform actions while the dusklight menu is open.
+            // Also skip updating Analog bindings for now
             if (!isActionBound(action, port) ||
-                (ui::any_document_visible() && action != ActionBinds::OPEN_DUSKLIGHT_MENU)) {
+                (ui::any_document_visible() && getActionBinds()[action].actionContext != ActionBindContext::DUSK) ||
+                (getActionBinds()[action].actionType != ActionBindType::BUTTON)) {
                 continue;
             }
 

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -144,33 +144,83 @@ UserSettings g_userSettings = {
         .enableAdvancedSettings {"backend.enableAdvancedSettings", false},
     },
 
+#define ADD_FULL_ACTIONBINDCONFIGVAR(varname, bindingdefault)    .varname    {   \
+            ActionBindConfigVar{"actionBindings." #varname "_port0", bindingdefault},   \
+            ActionBindConfigVar{"actionBindings." #varname "_port1", bindingdefault},   \
+            ActionBindConfigVar{"actionBindings." #varname "_port2", bindingdefault},   \
+            ActionBindConfigVar{"actionBindings." #varname "_port3", bindingdefault},   \
+        }
+
     // Not sure if there's a better way to declare this
     .actionBindings = {
-        .firstPersonCamera {
-            ActionBindConfigVar{"actionBindings.firstPersonCamera_port0", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.firstPersonCamera_port1", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.firstPersonCamera_port2", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.firstPersonCamera_port3", PAD_NATIVE_BUTTON_INVALID},
-        },
-        .callMidna {
-            ActionBindConfigVar{"actionBindings.callMidna_port0", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.callMidna_port1", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.callMidna_port2", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.callMidna_port3", PAD_NATIVE_BUTTON_INVALID},
-        },
-        .openDusklightMenu {
-            ActionBindConfigVar{"actionBindings.openDusklightMenu_port0", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.openDusklightMenu_port1", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.openDusklightMenu_port2", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.openDusklightMenu_port3", PAD_NATIVE_BUTTON_INVALID},
-        },
-        .turboSpeedButton {
-            ActionBindConfigVar{"actionBindings.turboButton_port0", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.turboButton_port1", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.turboButton_port2", PAD_NATIVE_BUTTON_INVALID},
-            ActionBindConfigVar{"actionBindings.turboButton_port3", PAD_NATIVE_BUTTON_INVALID},
-        },
+        ADD_FULL_ACTIONBINDCONFIGVAR(openDusklightMenu, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(turboSpeedButton, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(menuUp, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(menuLeft, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(menuDown, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(menuRight, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(menuConfirm, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(menuReject, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(menuX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(menuY, PAD_NATIVE_BUTTON_INVALID),
+
+        ADD_FULL_ACTIONBINDCONFIGVAR(swordAttack, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(itemAccessX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(itemAccessY, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(shieldUse, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(interact, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(roll, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(moveModifierToggle, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(target, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(grabHeavy, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(grabLight, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(callMidna, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(ingamePause, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(firstPersonCamera, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(mapCycleUp, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(mapCycleDown, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(peekMap, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(toggleMapScreen, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(hudVisibility, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(itemCycleNext, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(itemCyclePrev, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(grabAll, PAD_NATIVE_BUTTON_INVALID),
+
+        // Will figure out analog input later
+        ADD_FULL_ACTIONBINDCONFIGVAR(moveX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(moveY, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(camX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(camY, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(aimX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(aimY, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(wheelX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(wheelY, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(allcamX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(allcamY, PAD_NATIVE_BUTTON_INVALID),
+
+        ADD_FULL_ACTIONBINDCONFIGVAR(buttonA, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(buttonB, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(buttonX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(buttonY, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(buttonZ, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(buttonStart, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(dpadUp, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(dpadLeft, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(dpadDown, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(dpadRight, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(digitalL, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(digitalR, PAD_NATIVE_BUTTON_INVALID),
+
+        ADD_FULL_ACTIONBINDCONFIGVAR(mainStickX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(mainStickY, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(cStickX, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(cStickY, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(triggerL, PAD_NATIVE_BUTTON_INVALID),
+        ADD_FULL_ACTIONBINDCONFIGVAR(triggerR, PAD_NATIVE_BUTTON_INVALID),
     }
+
+#undef ADD_FULL_ACTIONBINDCONFIGVAR
+
 };
 
 UserSettings& getSettings() {
@@ -292,22 +342,76 @@ void registerSettings() {
     Register(g_userSettings.backend.cardFileType);
     Register(g_userSettings.backend.enableAdvancedSettings);
 
-    Register(g_userSettings.actionBindings.firstPersonCamera[0]);
-    Register(g_userSettings.actionBindings.firstPersonCamera[1]);
-    Register(g_userSettings.actionBindings.firstPersonCamera[2]);
-    Register(g_userSettings.actionBindings.firstPersonCamera[3]);
-    Register(g_userSettings.actionBindings.callMidna[0]);
-    Register(g_userSettings.actionBindings.callMidna[1]);
-    Register(g_userSettings.actionBindings.callMidna[2]);
-    Register(g_userSettings.actionBindings.callMidna[3]);
-    Register(g_userSettings.actionBindings.openDusklightMenu[0]);
-    Register(g_userSettings.actionBindings.openDusklightMenu[1]);
-    Register(g_userSettings.actionBindings.openDusklightMenu[2]);
-    Register(g_userSettings.actionBindings.openDusklightMenu[3]);
-    Register(g_userSettings.actionBindings.turboSpeedButton[0]);
-    Register(g_userSettings.actionBindings.turboSpeedButton[1]);
-    Register(g_userSettings.actionBindings.turboSpeedButton[2]);
-    Register(g_userSettings.actionBindings.turboSpeedButton[3]);
+#define REGISTER_ACTION_BINDINGS(bindingname) Register(g_userSettings.actionBindings.bindingname[0]); \
+    Register(g_userSettings.actionBindings.bindingname[1]); \
+    Register(g_userSettings.actionBindings.bindingname[2]); \
+    Register(g_userSettings.actionBindings.bindingname[3]);
+
+    REGISTER_ACTION_BINDINGS(openDusklightMenu)
+    REGISTER_ACTION_BINDINGS(turboSpeedButton)
+    REGISTER_ACTION_BINDINGS(menuUp)
+    REGISTER_ACTION_BINDINGS(menuLeft)
+    REGISTER_ACTION_BINDINGS(menuDown)
+    REGISTER_ACTION_BINDINGS(menuRight)
+    REGISTER_ACTION_BINDINGS(menuConfirm)
+    REGISTER_ACTION_BINDINGS(menuReject)
+    REGISTER_ACTION_BINDINGS(menuX)
+    REGISTER_ACTION_BINDINGS(menuY)
+
+    REGISTER_ACTION_BINDINGS(swordAttack)
+    REGISTER_ACTION_BINDINGS(itemAccessX)
+    REGISTER_ACTION_BINDINGS(itemAccessY)
+    REGISTER_ACTION_BINDINGS(shieldUse)
+    REGISTER_ACTION_BINDINGS(interact)
+    REGISTER_ACTION_BINDINGS(roll)
+    REGISTER_ACTION_BINDINGS(moveModifierToggle)
+    REGISTER_ACTION_BINDINGS(target)
+    REGISTER_ACTION_BINDINGS(grabHeavy)
+    REGISTER_ACTION_BINDINGS(grabLight)
+    REGISTER_ACTION_BINDINGS(callMidna)
+    REGISTER_ACTION_BINDINGS(ingamePause)
+    REGISTER_ACTION_BINDINGS(firstPersonCamera)
+    REGISTER_ACTION_BINDINGS(mapCycleUp)
+    REGISTER_ACTION_BINDINGS(mapCycleDown)
+    REGISTER_ACTION_BINDINGS(peekMap)
+    REGISTER_ACTION_BINDINGS(toggleMapScreen)
+    REGISTER_ACTION_BINDINGS(hudVisibility)
+    REGISTER_ACTION_BINDINGS(itemCycleNext)
+    REGISTER_ACTION_BINDINGS(itemCyclePrev)
+    REGISTER_ACTION_BINDINGS(grabAll)
+
+    REGISTER_ACTION_BINDINGS(moveX)
+    REGISTER_ACTION_BINDINGS(moveY)
+    REGISTER_ACTION_BINDINGS(camX)
+    REGISTER_ACTION_BINDINGS(camY)
+    REGISTER_ACTION_BINDINGS(aimX)
+    REGISTER_ACTION_BINDINGS(aimY)
+    REGISTER_ACTION_BINDINGS(wheelX)
+    REGISTER_ACTION_BINDINGS(wheelY)
+    REGISTER_ACTION_BINDINGS(allcamX)
+    REGISTER_ACTION_BINDINGS(allcamY)
+
+    REGISTER_ACTION_BINDINGS(buttonA)
+    REGISTER_ACTION_BINDINGS(buttonB)
+    REGISTER_ACTION_BINDINGS(buttonX)
+    REGISTER_ACTION_BINDINGS(buttonY)
+    REGISTER_ACTION_BINDINGS(buttonZ)
+    REGISTER_ACTION_BINDINGS(buttonStart)
+    REGISTER_ACTION_BINDINGS(dpadUp)
+    REGISTER_ACTION_BINDINGS(dpadLeft)
+    REGISTER_ACTION_BINDINGS(dpadDown)
+    REGISTER_ACTION_BINDINGS(dpadRight)
+    REGISTER_ACTION_BINDINGS(digitalL)
+    REGISTER_ACTION_BINDINGS(digitalR)
+
+    REGISTER_ACTION_BINDINGS(mainStickX)
+    REGISTER_ACTION_BINDINGS(mainStickY)
+    REGISTER_ACTION_BINDINGS(cStickX)
+    REGISTER_ACTION_BINDINGS(cStickY)
+    REGISTER_ACTION_BINDINGS(triggerL)
+    REGISTER_ACTION_BINDINGS(triggerR)
+
+#undef REGISTER_ACTION_BINDINGS
 }
 
 // Transient settings

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -936,7 +936,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
             pane.add_section("Custom Action Bindings");
             pane.add_text("A key bound to any action here will REPLACE the default control for"
                           " that action. Only bind buttons here that aren't used anywhere else.");
-            for (auto& [configVars, actionName] : getActionBinds() | std::views::values) {
+            for (auto& [actionContext, actionType, configVars, actionName] : getActionBinds() | std::views::values) {
                 addActionBinding(&configVars->at(port), actionName);
             }
             break;
@@ -977,7 +977,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                 });
         };
 
-        for (auto& [configVars, actionName] : getActionBinds() | std::views::values) {
+        for (auto& [actionContext, actionType, configVars, actionName] : getActionBinds() | std::views::values) {
             addActionBinding(&configVars->at(port), actionName);
         }
         break;


### PR DESCRIPTION
Draft PR to overlook input redesign efforts if approved, since I didn't see any other ongoing work for this in other branches..

Plan:
1. Coalesce all inputs under action bindings. This includes the classical controller bindings, which should be preserved as an option with a toggle.
2. Port over the new control options to the RmlUI window under controller configuration. Make the classical controls a separate section there.
3. Track Analog inputs.
4. Track down all flags and button checks in actor code and replace them with these (with conditional macros, ofcourse).

If approved as the right direction to take this in, I'd like to ask @linkRace to bring the changes from #1512 on over to this branch.