### PR TITLE
Fix enemy arrows loading too fast

### DIFF
--- a/src/d/actor/d_a_e_arrow.cpp
+++ b/src/d/actor/d_a_e_arrow.cpp
@@ -674,7 +674,29 @@ static int daE_ARROW_Create(fopAc_ac_c* i_this) {
     }
 
     int phase_state = dComIfG_resLoad(&a_this->mPhase, a_this->mResName);
+#if TARGET_PC
+    static int s_create_frames = 0;
+    static bool s_first_arrow = true;
+    static fpc_ProcID s_last_scene_id = 0;
+
+    s_create_frames++;
+    fpc_ProcID cur_scene_id = dStage_roomControl_c::getProcID();
+
+    if (cur_scene_id != s_last_scene_id) {
+        s_first_arrow = true;
+        s_last_scene_id = cur_scene_id;
+    }
+
+    if (phase_state == cPhs_COMPLEATE_e && s_first_arrow && s_create_frames < 4) {
+        return cPhs_INIT_e;
+    }
+#endif
     if (phase_state == cPhs_COMPLEATE_e) {
+#if TARGET_PC
+        s_create_frames = 0;
+        s_first_arrow = false;
+#endif
+
         a_this->mArrowType = fopAcM_GetParam(a_this) & 0xF;
         a_this->mFlags = fopAcM_GetParam(a_this) & 0xF0;
 


### PR DESCRIPTION
Delays the first enemy arrow creation by 3 frames after each room load to match GC behavior. On GC, the arrow's REL module takes 3 frames to load from disc on the first arrow in a room, while on PC it loads in a single frame. The target angle is set at creation time, so the missing delay makes the first arrow more accurate, causing speedrunners to get hit during the MDH rooftop section when they otherwise wouldn't