### PR TITLE
Tag operator new overloads with noexcept

### DIFF
--- a/libs/JSystem/include/JSystem/JAudio2/JASHeapCtrl.h
+++ b/libs/JSystem/include/JSystem/JAudio2/JASHeapCtrl.h
@@ -287,28 +287,28 @@ template <typename T>
 class JASPoolAllocObject {
 public:
 #if TARGET_PC
-    static void* operator new(size_t n, JKRHeapToken) {
+    static void* operator new(size_t n, JKRHeapToken) IF_DUSK(noexcept) {
         return operator new(n);
     }
 #endif
 
-    static void* operator new(size_t n) {
+    static void* operator new(size_t n) IF_DUSK(noexcept) {
 #if PLATFORM_GCN
         JASMemPool<T>& memPool_ = getMemPool_();
 #endif
         return memPool_.alloc(n);
     }
-    static void* operator new(size_t n, void* ptr) {
+    static void* operator new(size_t n, void* ptr) IF_DUSK(noexcept) {
         return ptr;
     }
 
 #if TARGET_PC
-    static void operator delete(void* ptr, size_t n, JKRHeapToken) {
+    static void operator delete(void* ptr, size_t n, JKRHeapToken) IF_DUSK(noexcept) {
         operator delete(ptr, n);
     }
 #endif
 
-    static void operator delete(void* ptr, size_t n) {
+    static void operator delete(void* ptr, size_t n) IF_DUSK(noexcept) {
 #if PLATFORM_GCN
         JASMemPool<T>& memPool_ = getMemPool_();
 #endif

--- a/libs/JSystem/include/JSystem/JAudio2/JASHeapCtrl.h
+++ b/libs/JSystem/include/JSystem/JAudio2/JASHeapCtrl.h
@@ -402,28 +402,28 @@ template <typename T>
 class JASPoolAllocObject_MultiThreaded {
 public:
 #if TARGET_PC
-    static void* operator new(size_t n, JKRHeapToken) {
+    static void* operator new(size_t n, JKRHeapToken) IF_DUSK(noexcept) {
         return operator new(n);
     }
 #endif
 
-    static void* operator new(size_t n) {
+    static void* operator new(size_t n) IF_DUSK(noexcept) {
 #if PLATFORM_GCN
         JASMemPool_MultiThreaded<T>& memPool_ = getMemPool();
 #endif
         return memPool_.alloc(n);
     }
-    static void* operator new(size_t n, void* ptr) {
+    static void* operator new(size_t n, void* ptr) IF_DUSK(noexcept) {
         return ptr;
     }
 
 #if TARGET_PC
-    static void operator delete(void* ptr, size_t n, JKRHeapToken) {
+    static void operator delete(void* ptr, size_t n, JKRHeapToken) IF_DUSK(noexcept) {
         return operator delete(ptr, n);
     }
 #endif
 
-    static void operator delete(void* ptr, size_t n) {
+    static void operator delete(void* ptr, size_t n) IF_DUSK(noexcept) {
 #if PLATFORM_GCN
         JASMemPool_MultiThreaded<T>& memPool_ = getMemPool();
 #endif

--- a/libs/JSystem/include/JSystem/JKernel/JKRHeap.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRHeap.h
@@ -237,11 +237,11 @@ enum class JKRHeapToken {
     Dummy
 };
 
-inline void* operator new(size_t, JKRHeapToken, void* where) {
+inline void* operator new(size_t, JKRHeapToken, void* where) noexcept {
     return where;
 }
 
-inline void* operator new[](size_t, JKRHeapToken, void* where) {
+inline void* operator new[](size_t, JKRHeapToken, void* where) noexcept {
     return where;
 }
 
@@ -264,21 +264,21 @@ inline void* operator new[](size_t, JKRHeapToken, void* where) {
 #define JKR_HEAP_TOKEN_PARAM
 #endif
 
-void* operator new(size_t size JKR_HEAP_TOKEN_PARAM);
-void* operator new(size_t size JKR_HEAP_TOKEN_PARAM, int alignment);
-void* operator new(size_t size JKR_HEAP_TOKEN_PARAM, JKRHeap* heap, int alignment);
+void* operator new(size_t size JKR_HEAP_TOKEN_PARAM) IF_DUSK(noexcept);
+void* operator new(size_t size JKR_HEAP_TOKEN_PARAM, int alignment) IF_DUSK(noexcept);
+void* operator new(size_t size JKR_HEAP_TOKEN_PARAM, JKRHeap* heap, int alignment) IF_DUSK(noexcept);
 
 // On PC, these new[] overloads are only used to catch usages of JKR_NEW with [].
-void* operator new[](size_t size JKR_HEAP_TOKEN_PARAM);
-void* operator new[](size_t size JKR_HEAP_TOKEN_PARAM, int alignment);
-void* operator new[](size_t size JKR_HEAP_TOKEN_PARAM, JKRHeap* heap, int alignment);
+void* operator new[](size_t size JKR_HEAP_TOKEN_PARAM) IF_DUSK(noexcept);
+void* operator new[](size_t size JKR_HEAP_TOKEN_PARAM, int alignment) IF_DUSK(noexcept);
+void* operator new[](size_t size JKR_HEAP_TOKEN_PARAM, JKRHeap* heap, int alignment) IF_DUSK(noexcept);
 
-void operator delete(void* ptr JKR_HEAP_TOKEN_PARAM);
-void operator delete[](void* ptr JKR_HEAP_TOKEN_PARAM);
+void operator delete(void* ptr JKR_HEAP_TOKEN_PARAM) IF_DUSK(noexcept);
+void operator delete[](void* ptr JKR_HEAP_TOKEN_PARAM) IF_DUSK(noexcept);
 
 #if TARGET_PC
 template<typename T>
-void jkrDelete(T* ptr) {
+void jkrDelete(T* ptr) IF_DUSK(noexcept) {
     if (ptr == nullptr) {
         return;
     }
@@ -298,7 +298,7 @@ void jkrDelete(T* ptr) {
 }
 
 template<>
-inline void jkrDelete(void* ptr) {
+inline void jkrDelete(void* ptr) IF_DUSK(noexcept) {
     if (ptr == nullptr) {
         return;
     }
@@ -322,7 +322,7 @@ constexpr bool newArgsHasCustomAlignment() {
 }
 
 template<typename T, typename... Args>
-T* jkrNewArray(size_t count, std::in_place_type_t<T>, Args&&... args) {
+T* jkrNewArray(size_t count, std::in_place_type_t<T>, Args&&... args) IF_DUSK(noexcept) {
     size_t allocSize = count * sizeof(T);
     if constexpr (!std::is_trivially_destructible<T>()) {
         static_assert(
@@ -333,6 +333,10 @@ T* jkrNewArray(size_t count, std::in_place_type_t<T>, Args&&... args) {
     }
 
     void* ptr = operator new(allocSize, JKRHeapToken::Dummy, args...);
+    if (!ptr) {
+        return nullptr;
+    }
+
     T* dataPtr;
     if constexpr (!std::is_trivially_destructible<T>()) {
         auto length = static_cast<size_t*>(ptr);
@@ -352,7 +356,7 @@ T* jkrNewArray(size_t count, std::in_place_type_t<T>, Args&&... args) {
 }
 
 template<typename T>
-void jkrDeleteArray(T* pointer) {
+void jkrDeleteArray(T* pointer) IF_DUSK(noexcept) {
     if (pointer == nullptr) {
         return;
     }
@@ -372,7 +376,7 @@ void jkrDeleteArray(T* pointer) {
 }
 
 template<>
-inline void jkrDeleteArray(void* pointer) {
+inline void jkrDeleteArray(void* pointer) IF_DUSK(noexcept) {
     if (pointer == nullptr) {
         return;
     }

--- a/libs/JSystem/src/JKernel/JKRHeap.cpp
+++ b/libs/JSystem/src/JKernel/JKRHeap.cpp
@@ -559,7 +559,7 @@ void* operator new(size_t size) {
     return JKRHeap::alloc(size, 4, NULL);
 }
 #else
-void* operator new(size_t size JKR_HEAP_TOKEN_PARAM) {
+void* operator new(size_t size JKR_HEAP_TOKEN_PARAM) noexcept {
     if (sCurrentHeap == NULL) {
         return fallback_alloc(size, 0, false);
     }
@@ -576,7 +576,7 @@ void* operator new(size_t size, int alignment) {
     return JKRHeap::alloc(size, alignment, NULL);
 }
 #else
-void* operator new(size_t size JKR_HEAP_TOKEN_PARAM, int alignment) {
+void* operator new(size_t size JKR_HEAP_TOKEN_PARAM, int alignment) noexcept {
     void* mem = JKRHeap::alloc(size, alignment, nullptr);
     if (mem == nullptr) {
         return fallback_alloc(size, abs(alignment), true);
@@ -585,7 +585,7 @@ void* operator new(size_t size JKR_HEAP_TOKEN_PARAM, int alignment) {
 }
 #endif
 
-void* operator new(size_t size JKR_HEAP_TOKEN_PARAM, JKRHeap* heap, int alignment) {
+void* operator new(size_t size JKR_HEAP_TOKEN_PARAM, JKRHeap* heap, int alignment) IF_DUSK(noexcept) {
     void* mem = JKRHeap::alloc(size, alignment, heap);
 #if TARGET_PC
     if (mem == nullptr) {
@@ -600,7 +600,7 @@ void* operator new[](size_t size) {
     return JKRHeap::alloc(size, 4, NULL);
 }
 #else
-void* operator new[](size_t JKR_HEAP_TOKEN_PARAM) {
+void* operator new[](size_t JKR_HEAP_TOKEN_PARAM) IF_DUSK(noexcept) {
     OSPanic(__FILE__, __LINE__, "Allocation should go through JKR_NEW_ARRAY instead");
 }
 #endif
@@ -610,12 +610,12 @@ void* operator new[](size_t size, int alignment) {
     return JKRHeap::alloc(size, alignment, NULL);
 }
 #else
-void* operator new[](size_t JKR_HEAP_TOKEN_PARAM, int) {
+void* operator new[](size_t JKR_HEAP_TOKEN_PARAM, int) IF_DUSK(noexcept) {
     OSPanic(__FILE__, __LINE__, "Allocation should go through JKR_NEW_ARRAY instead");
 }
 #endif
 
-void* operator new[](size_t JKR_HEAP_TOKEN_PARAM, JKRHeap*, int) {
+void* operator new[](size_t JKR_HEAP_TOKEN_PARAM, JKRHeap*, int) IF_DUSK(noexcept) {
     OSPanic(__FILE__, __LINE__, "Allocation should go through JKR_NEW_ARRAY instead");
 }
 
@@ -624,7 +624,7 @@ void operator delete(void* ptr) {
     JKRHeap::free(ptr, NULL);
 }
 #else
-void operator delete(void* ptr JKR_HEAP_TOKEN_PARAM) {
+void operator delete(void* ptr JKR_HEAP_TOKEN_PARAM) IF_DUSK(noexcept) {
     if (ptr == NULL)
         return;
     JKRHeap* heap = JKRHeap::findFromRoot(ptr);
@@ -645,7 +645,7 @@ void operator delete[](void* ptr) {
     JKRHeap::free(ptr, NULL);
 }
 #else
-void operator delete[](void* ptr JKR_HEAP_TOKEN_PARAM) {
+void operator delete[](void* ptr JKR_HEAP_TOKEN_PARAM) IF_DUSK(noexcept) {
     if (ptr == NULL)
         return;
     JKRHeap* heap = JKRHeap::findFromRoot(ptr);


### PR DESCRIPTION
According to the C++ standard, regular operator new must always return a valid pointer, and allocation failure should throw an exception.

The original game did not use exceptions, and instead had its operator new return null on alloc failure.

Clang and GCC seem to be enforcing the standard here, and this is causing crashes on non-Windows platforms like https://sentry.twilitrealm.dev/organizations/twilitrealm/issues/952/, where a JAISe allocation failure (custom pooled operator new overload) crashes the game when it should be handled gracefully. MSVC seems to not make use of this opportunity, meaning the code works as intended.

Tagging the operators with noexcept seems to satisfy GCC and Clang, but I admit cppreference is very light on details here. [Godbolt link](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIM6SuADJ4DJgAcj4ARpjE/gBspAAOqAqETgwe3r7%2ByanpAiFhkSwxcWaJdpgOGUIETMQEWT5%2BAVU1AnUNBEUR0bEJtvWNzTltwz2hfaUDFQCUtqhexMjsHOYAzKHI3lgA1CYbbsgKBOhYVIfYJhoAgje3jD57O0wKCnsAUgDSAEoAEpgmEkACqoADWjAOAHYrHc9gi9gARHwsACeDxM0KRhzh9zup2IXgcewAYqhUFEGjC8Yi9gA3VB4dAAKj2qCSsSYRGIezCAHcIGkAF6YAD6BD5pC%2Bf0BwLBkIY0sZzLZ/IQsUwcwOGzxDzp5MpDQgc1xmOxZruDxV6D2txNltuNr2Fgdusxd0NVOIbJBmFOEBtbKY2qxtMRaAYpz2TC8RD2xH9XloksOSL5mH5ewgPwBQNBEMYIBAKJY6OlIbJFO9br18MReCo2cTCmTBFDsP1dMR9tN7vrCKx6cwtCUNK73ZdtYnMJxVoHCcwBGWDEXrZTjqHHAWtE4AFZeH4OFpSKhOG5rNY9golitMAczBseKQCJptwtwSANhsAHSSACckjQvEGxmP%2B8RcNC0IbP%2B%2BicJIh5vqenC8AoIAaC%2Bb4LHAsAwIgKCoCwSR0LE5CUGgREkXEwBcBBfB0AQsRoRAURIVEoQNGinDPuxzDEGiADyUTaNUr7cLwFFsIIAkMLQXHHrwWBRF4wBuGIo7cYpmAsIYwDiAppD4ImNT0v6SGYKo1Rxmsz6hIxu4GbQeBRMQnEeFgSEEMQeAsJppCmcQUSpJgSLabpTlGFhfAGMACgAGp4JmAmckez78IIIhiOwUgyIIigqOoBm6Fw%2Bi6Sgl6WPozloZACwco4AhoRwAC0AkbLwqABd5WA1SatgjqJGQuAw7ieC0ejBFMJRlHoKRpA1mRjTkJVzQUDC9NNAwle0C1dCMS1%2BNtA0dAwe2TMU/RxNtEyjIdQzdBtl0SAsN7LKsz1wRwB6kEeJ5nhweyqAAHPEzXxJIezAMgyB7LRP5cNmuCECQD5PnMvBiVocwfl%2Be4/uBAFcGYZhAxo0IaJBiQOQhpC%2BXuGG/R1KG2OhmEKdheEQEgFHEfQZAUBAPNUSgBhGMTXAYTQKZMZQrEGbxnF%2BQr/FCSJDh%2BZJjAEDJclIUpKlqbQGniYZYVGPpJ5GYNplNSeFlWYxfl2SOSFOS5bkYGsJ5eT5fkBUFSihTp5uhKA7PRUwsUJUlKV%2BelwiiOIOXx/lahIboGylZFpiWNYVVRL1dVJAtTWte1p5dcyZm1f19gLcNo3ZHdk0XTMV15PNGS3bN%2BQLY9bd6DttQ3Qdg/HbtEz9zN13dN3M%2BNFPW0vbe71cDu%2B6IQZ/2AyDYMQ68Rh7MT8M/hoiP4DyqNrxjWELBqTBYHEfXU7wdMM0h/2oazmPvqQn4bJIeGe4gbQkkHuICe5oR7jMJIaQDly6M2QhwG%2B4ccJQE5tzQivNSICyFnzEA9JkBJCSGKekXB/xigMIxU4YpVDg3otLYgzE5YnmVvJHiHEVbCVEhrQiUltayXkpbTAylVLqSas%2BLAwc9Je0UngYyjgbbmUssgayTtBAu0cs5Vy/F3KyJfN5XyJt/bBSDuFUOUUqAxXiolfkyUiwm3jplJO0gU5KDTkVXIotjAVRsG7Qup5i4ZDQgAegEgETqsRurVz6kPZwEBXBz0CCNRe7dVoLSSekjIqSx512HrPUeR08mdEnlNJ688miFPugvMpA816LDetldeX1N5/U4IDcGewWAKEIQychP4qH%2BklBAJGl9NjXzZljHGoEfwAPBv%2BImJMyYUyBp9Gmb8fof2ZmhDCP8ObwC5gRSifMyKCywcLA%2BwBxaSwYjLFibFOHsN4Gw1WPCTaa2koIvWIiDbiL8lI8K%2BirYmTMgZe2qjHYm2dg5E8bsdFoj0Z5QxftYgBxCmbPSFjw5WMjjYmODi0qyGcdlVxshU6FRPLoOBZUc5WEqv4%2BARcS6cDLnsZqVAGCoGahZVYQTGodUrj1RltdBrxMSVUlu0xp4dzWpk3u2TanSriadEeTdcmipVQ9RVW1qmVLVRUnJ9TXp3g%2Bg5b6iDt7A1Bp0y5R8zAnzPiMi%2BKNxno0mb/e%2Bj9KDNPWSAemmyt7bO/rfP%2BX57VzMJsTUm5MuCrPga0pmyD3XY0%2BmYBNSCUFTP8kxIakggA%3D%3D%3D)