### PR TITLE
Fix limits of transform level in savefile editor

### DIFF
--- a/src/dusk/imgui/ImGuiSaveEditor.cpp
+++ b/src/dusk/imgui/ImGuiSaveEditor.cpp
@@ -713,7 +713,7 @@ namespace dusk {
                 transformLevel++;
             }
         }
-        if (ImGui::SliderInt("Transform Level", &transformLevel, 0, 3)) {
+        if (ImGui::SliderInt("Transform Level", &transformLevel, 0, 4)) {
             u8 newFlags = 0;
             for (int i = 0; i < transformLevel; i++) {
                 newFlags |= (1 << i);

--- a/src/dusk/ui/editor.cpp
+++ b/src/dusk/ui/editor.cpp
@@ -1501,14 +1501,14 @@ EditorWindow::EditorWindow() {
                 .getValue =
                     [] {
                         return std::popcount(static_cast<unsigned>(
-                            get_player_status_b()->mTransformLevelFlag & 0x7));
+                            get_player_status_b()->mTransformLevelFlag & 0xF));
                     },
                 .setValue =
                     [](int value) {
                         get_player_status_b()->mTransformLevelFlag =
                             static_cast<u8>((1u << value) - 1u);
                     },
-                .max = 3,
+                .max = 4,
             }),
             rightPane, {});
         leftPane.register_control(


### PR DESCRIPTION
Several users have had an issue trying to use the rmlui savefile editor to change their time; touching the transform level at any point after lakebed makes midna permanently disappear. Confirmed that transform level is set to 0xF after lakebed on Dolphin, so it should be settable in Dusklight too.