### PR TITLE
Fix interpolation for Shadow Beast & Twilight Vermin hair

### DIFF
--- a/src/d/actor/d_a_e_s1.cpp
+++ b/src/d/actor/d_a_e_s1.cpp
@@ -117,6 +117,13 @@ static void daE_S1_interp_callback(bool isSimFrame, void* pUserWork) {
             dst[i] = p0 + (p1 - p0) * alpha;
         }
     }
+    GXColor line_color;
+    line_color.r = JREG_S(0) + 5;
+    line_color.g = JREG_S(1) + 10;
+    line_color.b = JREG_S(2) + 10;
+    line_color.a = 0xFF;
+
+    i_this->mLineMat.update(16, line_color, &i_this->tevStr);
 }
 #endif
 

--- a/src/d/actor/d_a_e_yg.cpp
+++ b/src/d/actor/d_a_e_yg.cpp
@@ -139,6 +139,7 @@ static BOOL pl_check(e_yg_class* i_this, f32 i_dist) {
 #if TARGET_PC
 static void daE_YG_interp_callback(bool isSimFrame, void* pUserWork) {
     e_yg_class* i_this = (e_yg_class*)pUserWork;
+    fopAc_ac_c* actor = (fopAc_ac_c*)&i_this->actor;
     if (!i_this->mTentacleInterpPrevValid || !i_this->mTentacleInterpCurrValid) {
         return;
     }
@@ -152,6 +153,13 @@ static void daE_YG_interp_callback(bool isSimFrame, void* pUserWork) {
             dst[i] = p0 + (p1 - p0) * alpha;
         }
     }
+    GXColor color;
+    color.r = JREG_S(0) + 20;
+    color.g = JREG_S(1) + 20;
+    color.b = JREG_S(2) + 20;
+    color.a = 0xFF;
+
+    i_this->mLineMat.update(10, color, &actor->tevStr);
 }
 #endif
 


### PR DESCRIPTION
There was an important bit of these two actors' draw code missing from their interp callbacks, which made the previous interp fix not actually work. This fixes that and closes https://github.com/TwilitRealm/dusklight/issues/1566.