### PR TITLE
Make bloom resolution independent and change blending method

### DIFF
--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1535,7 +1535,11 @@ void mDoGph_gInf_c::bloom_c::draw2() {
 
         // Successively downsample and apply blurs.
         static int divStart = 2;
-        static int divNum = 6; // inclusive
+
+        int divNum = 6; // inclusive
+        while (divNum < MaxDivNum - 1 && divRects[divNum].h > 8) {
+            divNum++;
+        }
 
         // The original mBlureRatio is multiplied into each sample, of which there are 8 samples originally.
         // This is applied over two passes, the second one with an alpha of 25%; however, the clipping that this introduces is a bit integral to the look,

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1511,18 +1511,6 @@ void mDoGph_gInf_c::bloom_c::draw2() {
 
         // Setup blur filter TEV.
         GXSetNumTexGens(8);
-
-        u32 texMtxID = GX_TEXMTX0;
-        int angle = 0;
-        for (int texCoord = (int)GX_TEXCOORD0; texCoord < (int)GX_MAX_TEXCOORD; texCoord++) {
-            GXSetTexCoordGen((GXTexCoordID)texCoord, GX_TG_MTX2x4, GX_TG_TEX0, texMtxID);
-            mDoMtx_stack_c::transS((blurScale * cM_scos(angle)) * getInvScale(),
-                                   blurScale * cM_ssin(angle), 0.0f);
-            GXLoadTexMtxImm(mDoMtx_stack_c::get(), texMtxID, GX_MTX2x4);
-            texMtxID += 3;
-            angle += 0x2000;
-        }
-
         GXSetNumTevStages(8);
         for (int stage = 0; stage < 8; stage++) {
             GXTevStageID tevStage = (GXTevStageID)stage;
@@ -1552,6 +1540,19 @@ void mDoGph_gInf_c::bloom_c::draw2() {
         GXSetTevColorS10(GX_TEVREG1, {0, 0, 0, s16(brightnessPerPass / 8)});
 
         for (int i = divStart; i < divNum; i++) {
+            f32 texelRadius = 1.5f;
+            f32 blurU = texelRadius / (f32)divRects[i].w;
+            f32 blurV = texelRadius / (f32)divRects[i].h;
+
+            u32 texMtxID = GX_TEXMTX0;
+            int angle = 0;
+            for (int texCoord = (int)GX_TEXCOORD0; texCoord < (int)GX_MAX_TEXCOORD; texCoord++) {
+                GXSetTexCoordGen((GXTexCoordID)texCoord, GX_TG_MTX2x4, GX_TG_TEX0, texMtxID);
+                mDoMtx_stack_c::transS(blurU * cM_scos(angle), blurV * cM_ssin(angle), 0.0f);
+                GXLoadTexMtxImm(mDoMtx_stack_c::get(), texMtxID, GX_MTX2x4);
+                texMtxID += 3;
+                angle += 0x2000;
+            }
             // Apply blur filter.
             divQuad(i);
 

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1527,15 +1527,27 @@ void mDoGph_gInf_c::bloom_c::draw2() {
             divNum++;
         }
 
+        // Originally mBlureSize would be used to set the sample spread. But since this is a blur pyramid,
+        // changing the sample spread introduces artifacts. Fortunately, we compute multiple levels of blur
+        // anyway through the downsampling and upsampling process. We can convert the spread to change
+        // the blend weight of later (wider blur) layers in the pyramid, producing the same effect
+        // but with some nice high-resolution hot spots.
+        // However, to match the original bloom intensity, we must also lower the brightness of the bloom
+        // as the bloom gets wider, otherwise the bloom becomes too bright.
+        float sizeFactor = std::clamp(static_cast<float>(mBlureSize) / 255.0f, 0.0f, 1.0f);
+        float ratioFactor = std::clamp(static_cast<float>(mBlureRatio) / 255.0f, 0.0f, 1.0f);
+        float densityFalloff = 1.0f / (1.0f + (sizeFactor * 1.5f));
+
         // The original mBlureRatio is multiplied into each sample, of which there are 8 samples originally.
         // This is applied over two passes, the second one with an alpha of 25%; however, the clipping that this introduces is a bit integral to the look,
         // so we do the same thing, letting it clip.
         float userMult = dusk::getSettings().game.bloomMultiplier.getValue();
-        float brightnessF32 = (mBlureRatio * userMult * 16.0f / 255.0f);
+        float brightnessF32 = (mBlureRatio * userMult * densityFalloff * 16.0f / 255.0f);
 
         // Distribute the brightness through the total number of passes.
         f32 totalNumPasses = (divNum - divStart + 1);
         float brightnessPerPass = 255.0f * powf(brightnessF32, 1.0f / totalNumPasses);
+        brightnessPerPass *= 1.0f + (static_cast<float>(mPoint) / 255.0f);
         GXSetTevColorS10(GX_TEVREG1, {0, 0, 0, s16(brightnessPerPass / 8)});
 
         for (int i = divStart; i < divNum; i++) {
@@ -1577,7 +1589,7 @@ void mDoGph_gInf_c::bloom_c::draw2() {
         // Normalize the per-pass decay so that after N passes, the total weight matches the baseline.
         int N = divNum - divStart;
         if (N <= 0) N = 1;
-        float D = std::clamp((f32)mBlureSize / 128.0f, 0.01f, 0.99f);
+        float D = 0.33f + ratioFactor * sizeFactor * 0.66f;
         float perPassDecay = powf(D, 4.0f / (f32)N);
         float alpha = std::clamp(255.0f * perPassDecay, 0.0f, 255.0f);
 

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -1199,7 +1199,7 @@ static void trimming(view_class* param_0, view_port_class* param_1) {
         #if TARGET_PC
         f32 sc_top = param_1->scissor.y_orig;
         f32 sc_bottom = sc_top + param_1->scissor.height;
-        
+
         f32 sc_left = 0.0f;
         f32 sc_right = param_1->width;
 
@@ -1379,7 +1379,7 @@ void mDoGph_gInf_c::bloom_c::draw2() {
     GXSetVtxAttrFmt(GX_VTXFMT0, GX_VA_TEX0, GX_TEX_ST, GX_S8, 0);
 
     // Set up viewports for our pyramid.
-    enum { MaxDivNum = 10 };
+    enum { MaxDivNum = 14 };
     enum {
         Pass0,
         FinalPass,
@@ -1507,8 +1507,6 @@ void mDoGph_gInf_c::bloom_c::draw2() {
         GXTexObj* texPass0 = divCopyTex(Pass0, 2);
         GXLoadTexObj(texPass0, GX_TEXMAP0);
 
-        f32 blurScale = mBlureSize * ((448.0f / height) / 6400.0f);
-
         // Setup blur filter TEV.
         GXSetNumTexGens(8);
         GXSetNumTevStages(8);
@@ -1532,7 +1530,8 @@ void mDoGph_gInf_c::bloom_c::draw2() {
         // The original mBlureRatio is multiplied into each sample, of which there are 8 samples originally.
         // This is applied over two passes, the second one with an alpha of 25%; however, the clipping that this introduces is a bit integral to the look,
         // so we do the same thing, letting it clip.
-        float brightnessF32 = (mBlureRatio * 16 / 255.0f);
+        float userMult = dusk::getSettings().game.bloomMultiplier.getValue();
+        float brightnessF32 = (mBlureRatio * userMult * 16.0f / 255.0f);
 
         // Distribute the brightness through the total number of passes.
         f32 totalNumPasses = (divNum - divStart + 1);
@@ -1572,8 +1571,17 @@ void mDoGph_gInf_c::bloom_c::draw2() {
         GXSetTevColorS10(GX_TEVREG1, {0, 0, 0, s16(255)});
         GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY);
         GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_ONE, GX_LO_OR);
+
+        // N is the actual number of upsample passes happening at the current resolution
+        // D is the total decay factor we want over a baseline of 4 passes (1x resolution).
+        // Normalize the per-pass decay so that after N passes, the total weight matches the baseline.
+        int N = divNum - divStart;
+        if (N <= 0) N = 1;
+        float D = std::clamp((f32)mBlureSize / 128.0f, 0.01f, 0.99f);
+        float perPassDecay = powf(D, 4.0f / (f32)N);
+        float alpha = std::clamp(255.0f * perPassDecay, 0.0f, 255.0f);
+
         for (int i = divNum; i > divStart; i--) {
-            float alpha = 255.0f * powf(0.25f * dusk::getSettings().game.bloomMultiplier.getValue(), 1.0f / (i - divStart + 1));
             GXSetTevColorS10(GX_TEVREG0, {0, 0, 0, s16(alpha)});
 
             divCopySrc(i);


### PR DESCRIPTION
Hi! I've been bothered by the default bloom so I made some changes. I understand some of these changes are subjective. However, I think the main issue I'm trying to address is objectively good. 

Currently, Dusklight's bloom looks different as the user increases the internal resolution, losing much of its range and becoming visually smaller as the internal resolution increases. After some testing, I also found that the blurring had some minor issues with shimmering, which would become visible in areas where there were bright bloomy objects. 

With these patches, bloom is mostly consistent between different resolutions. It looks closer to the vanilla bloom without any shimmering.

| 1x Res | 12x Res|
| --- | --- |
| <img width="3840" height="2160" alt="Screenshot_20260518_224903" src="https://github.com/user-attachments/assets/4ae06394-52b4-4046-85d7-9dbbf0c2bfc7" /> | <img width="3840" height="2160" alt="Screenshot_20260518_224900" src="https://github.com/user-attachments/assets/aed962f6-9efe-4224-8608-495c442d2f16" /> |

Key changes:
1. Changes how the blur texcoords were calculated so they would take the texture size into account. Previously, they weren't, so the blur wasn't propagating to lower levels of the pyramid correctly. As the pyramid is now blurred as it reaches the lower levels, the upscaling no longer has visible aliasing artifacts. 
2. Locked the size of the per-pass blur. Since this is a blur pyramid, scaling the sample offset will lead to artifacts from oversampling as the underlying pixels don't fit the sample region. Instead, we reinterpret the blur size as a decay factor that adjusts the contribution of each later (wider) blur pass. The overall intensity is then scaled by the other bloom parameters to make it look close to the classic bloom. 
4. The maximum number of blur passes has been increased to 14, and the number of blur passes used scales based on the render resolution. This might be bad for performance, and maybe the initial buffer size should be clamped. But that requires better resampling on the input, which is difficult to write in a fixed function environment. 

These changes are pretty flexible, so I'm hoping they can be adopted even if they need some tweaking to satisfy everyone. Please let me know your thoughts!

| New | Classic |
| --- | --- |
|<img width="3840" height="2160" alt="Screenshot_20260518_233647" src="https://github.com/user-attachments/assets/c405956e-a9f8-46ea-8e41-a7577abdfe22" /> | <img width="3840" height="2160" alt="Screenshot_20260518_233645" src="https://github.com/user-attachments/assets/da8a2555-f2b9-40a8-9057-29c6c721405d" /> |
| <img width="3840" height="2160" alt="Screenshot_20260518_234220" src="https://github.com/user-attachments/assets/bbbe946a-2eea-4faf-8c15-8b80a1263163" /> | <img width="3840" height="2160" alt="Screenshot_20260518_234222" src="https://github.com/user-attachments/assets/85a54564-fc67-4bca-9dd6-72c6406c29ff" /> |
| <img width="3840" height="2160" alt="Screenshot_20260518_234250" src="https://github.com/user-attachments/assets/6a74f4c9-4dac-4ddf-8c72-9a6ef77ca7f1" /> | <img width="3840" height="2160" alt="Screenshot_20260518_234252" src="https://github.com/user-attachments/assets/438d4c7d-6121-4e34-9a68-0ec8008676eb" /> |
| <img width="3840" height="2160" alt="Screenshot_20260518_234333" src="https://github.com/user-attachments/assets/bed08411-02a0-4b59-a8c8-902454f36dd9" /> | <img width="3840" height="2160" alt="Screenshot_20260518_234335" src="https://github.com/user-attachments/assets/d66f38b5-6a55-467f-b819-8a881cad2f6b" /> | 
| <img width="3840" height="2160" alt="Screenshot_20260518_234450" src="https://github.com/user-attachments/assets/5c774a85-73d4-47af-b712-28ce18dd6342" /> | <img width="3840" height="2160" alt="Screenshot_20260518_234452" src="https://github.com/user-attachments/assets/988138d1-dc1b-436f-ba12-3a31591cab82" /> |