### PR TITLE
Preview texture replacements without the menu obstructing the view 

### DIFF
--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -4,6 +4,7 @@
 #include "m_Do/m_Do_audio.h"
 
 #include <aurora/aurora.h>
+#include <aurora/gfx.h>
 #include <dolphin/gx/GXAurora.h>
 #include <dolphin/vi.h>
 #include <fmt/format.h>
@@ -54,6 +55,8 @@ int get_value(GraphicsOption option) {
             100);
     case GraphicsOption::DepthOfFieldMode:
         return static_cast<int>(getSettings().game.depthOfFieldMode.getValue());
+    case GraphicsOption::TextureReplacements:
+        return getSettings().game.enableTextureReplacements.getValue();
     }
     return 0;
 }
@@ -93,6 +96,10 @@ void set_value(GraphicsOption option, int value) {
         break;
     case GraphicsOption::BloomMultiplier:
         getSettings().game.bloomMultiplier.setValue(std::clamp(value, 0, 100) / 100.0f);
+        break;
+    case GraphicsOption::TextureReplacements:
+        getSettings().game.enableTextureReplacements.setValue(static_cast<bool>(value));
+        aurora_set_texture_replacements_enabled(static_cast<bool>(value));
         break;
     }
 }
@@ -231,6 +238,8 @@ Rml::String format_graphics_setting_value(GraphicsOption option, int value) {
         break;
     case GraphicsOption::BloomMultiplier:
         return fmt::format("{}%", value);
+    case GraphicsOption::TextureReplacements:
+        return static_cast<bool>(value) ? "On" : "Off";
     }
     return "";
 }

--- a/src/dusk/ui/graphics_tuner.hpp
+++ b/src/dusk/ui/graphics_tuner.hpp
@@ -46,6 +46,7 @@ enum class GraphicsOption {
     BloomMode,
     BloomMultiplier,
     DepthOfFieldMode,
+    TextureReplacements,
 };
 
 Rml::String format_graphics_setting_value(GraphicsOption option, int value);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -13,7 +13,6 @@
 #include "dusk/imgui/ImGuiEngine.hpp"
 #include "dusk/io.hpp"
 #include "dusk/livesplit.h"
-#include "dusk/main.h"
 #include "dusk/discord_presence.hpp"
 #include "graphics_tuner.hpp"
 #include "m_Do/m_Do_main.h"

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -859,12 +859,17 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             mPrelaunch);
 
         leftPane.add_section("Rendering");
-        config_bool_select(leftPane, rightPane, getSettings().game.enableTextureReplacements,
-            {
-                .key = "Use Texture Pack",
-                .helpText = "Enable installed texture replacements.",
-                .onChange = [](bool value) { aurora_set_texture_replacements_enabled(value); },
-            });
+        graphics_tuner_control(*this, leftPane, rightPane,
+            getSettings().game.enableTextureReplacements,
+            GraphicsTunerProps{
+                .option = GraphicsOption::TextureReplacements,
+                .title = "Enable Texture Replacements",
+                .helpText = kTextureReplacementHelpText,
+                .valueMin = static_cast<int>(false),
+                .valueMax = static_cast<int>(true),
+                .defaultValue = static_cast<int>(false),
+            },
+            mPrelaunch);
         leftPane.register_control(
             leftPane.add_select_button({
                 .key = "Unlock Framerate",

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -376,6 +376,8 @@ const Rml::String kDepthOfFieldHelpText =
 const Rml::String kUnlockFramerateHelpText =
     "<br/>Uses inter-frame interpolation to enable higher frame rates.<br/><br/>May introduce minor "
     "visual artifacts or animation glitches.";
+const Rml::String kTextureReplacementHelpText =
+    "Enable installed texture replacements.";
 
 int float_setting_percent(ConfigVar<float>& var) {
     return static_cast<int>(var.getValue() * 100.0f + 0.5f);


### PR DESCRIPTION
This changes texture replacement toggle from config_bool_select to graphics_tuner_control.
Allows users to view the texture pack being used without the menu hiding it.

| ON | OFF |
| --- | --- |
| <img width="600" alt="Screenshot 2026-05-18 at 18 22 10" src="https://github.com/user-attachments/assets/26d224e8-9020-43f9-88eb-815b321642f8" /> |  <img width="600" alt="Screenshot 2026-05-18 at 18 21 59" src="https://github.com/user-attachments/assets/58d64c2a-4ac1-4ad6-a608-d4ae699b04d5" /> |