### PR TITLE
[WIP][Feature] PS5 Dualsense Native Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Dusklight is a reverse-engineered reimplementation of Twilight Princess.
 
 It aims to be as accurate as possible to the original while also providing new options, enhancements, and tools to customize your experience.
 
+# Features
+
+- **PS5 DualSense Controller Enhancements (Native):**
+  - **Adaptive Triggers (L2 / R2):** Heavy mechanical pull tension during Iron Boots walking, tactical resistance on Left Trigger during target lock (Z-targeting), and dynamic string pull tension during archery/slingshot (Right Trigger) with realistic snap release.
+  - **Dynamic Health LED Lightbar:** Gamepad LEDs pulse breathing red when health drops to 2 hearts ($dComIfGs\_getLife() \le 8$) or lower, matching tunic colors and targeting reticles under normal conditions.
+  - **Settings Toggle & Compatibility Fallback:** Toggleable at will via the *Input* Settings menu; automatically disables and falls back to standard trigger behaviors if using a non-PS5 gamepad.
+
 # Setup
 
 > [!IMPORTANT]

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -142,6 +142,7 @@ struct UserSettings {
         ConfigVar<bool> enableAchievementToasts;
         ConfigVar<bool> enableControllerToasts;
         ConfigVar<bool> enableDiscordPresence;
+        ConfigVar<bool> enableDualSenseTriggers;
 
         // Graphics
         ConfigVar<BloomMode> bloomMode;

--- a/src/dusk/gamepad_color.cpp
+++ b/src/dusk/gamepad_color.cpp
@@ -3,6 +3,8 @@
 #include <d/d_com_inf_game.h>
 #include <d/actor/d_a_player.h>
 #include <d/actor/d_a_alink.h>
+#include <dolphin/pad.h>
+#include <dusk/settings.h>
 #include <dusk/gamepad_color.h>
 
 cXyz currentGamepadColor = {0, 0, 0};
@@ -14,8 +16,38 @@ float lerpSpeed = 0.0f;
 const cXyz duskColor = {50, 50, -50};
 const cXyz noColor = {0, 0, 0};
 
+static u8 s_lastLeftMode = 0xFF;
+static u8 s_lastLeftParam0 = 0xFF;
+static u8 s_lastLeftParam1 = 0xFF;
+static u8 s_lastLeftParam2 = 0xFF;
+
+static u8 s_lastRightMode = 0xFF;
+static u8 s_lastRightParam0 = 0xFF;
+static u8 s_lastRightParam1 = 0xFF;
+static u8 s_lastRightParam2 = 0xFF;
+
+void updateLeftTrigger(u8 mode, u8 p0, u8 p1, u8 p2) {
+    if (mode != s_lastLeftMode || p0 != s_lastLeftParam0 || p1 != s_lastLeftParam1 || p2 != s_lastLeftParam2) {
+        PADSetTriggerEffect(PAD_CHAN0, 0, mode, p0, p1, p2);
+        s_lastLeftMode = mode;
+        s_lastLeftParam0 = p0;
+        s_lastLeftParam1 = p1;
+        s_lastLeftParam2 = p2;
+    }
+}
+
+void updateRightTrigger(u8 mode, u8 p0, u8 p1, u8 p2) {
+    if (mode != s_lastRightMode || p0 != s_lastRightParam0 || p1 != s_lastRightParam1 || p2 != s_lastRightParam2) {
+        PADSetTriggerEffect(PAD_CHAN0, 1, mode, p0, p1, p2);
+        s_lastRightMode = mode;
+        s_lastRightParam0 = p0;
+        s_lastRightParam1 = p1;
+        s_lastRightParam2 = p2;
+    }
+}
+
 cXyz LerpColor(cXyz a, cXyz b, float t) {
-    return {std::lerp(a.x, b.x, t), std::lerp(a.y, b.y, t), std::lerp(a.z, b.z, t)};
+    return {a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t};
 }
 
 void FadeLED(cXyz newColor, float speed) {
@@ -35,15 +67,27 @@ void SetGamepadAdditionalColor(cXyz addColor) {
 }
 
 void handleGamepadColor() {
+    static u32 s_pulseFrame = 0;
+    s_pulseFrame++;
+
     bool setColor = false;
 
-    fopAc_ac_c* zhint = dComIfGp_att_getZHint();
-    if (zhint != NULL) {
-        FadeLED({50, 50, 175}, 2.0f);
+    // Pulse red when health is 2 hearts or less (each heart is 4 quarter-hearts)
+    if (dComIfGs_getLife() > 0 && dComIfGs_getLife() <= 8) {
+        float wave = (std::sin(s_pulseFrame * 0.12f) + 1.0f) * 0.5f; // 0.0 to 1.0
+        float redVal = 60.0f + wave * 195.0f;
+        FadeLED({redVal, 0.0f, 0.0f}, 10.0f);
         setColor = true;
     }
 
-    daPy_py_c* player = daPy_getPlayerActorClass();
+    if (!setColor) {
+        fopAc_ac_c* zhint = dComIfGp_att_getZHint();
+        if (zhint != nullptr) {
+            FadeLED({50, 50, 175}, 2.0f);
+            setColor = true;
+        }
+    }
+
     daAlink_c* link = daAlink_getAlinkActorClass();
 
     if (link != nullptr && !setColor) {
@@ -80,6 +124,46 @@ void handleGamepadColor() {
         SetGamepadAdditionalColor(duskColor);
     } else {
         SetGamepadAdditionalColor(noColor);
+    }
+
+    // --- PS5 DualSense Adaptive Triggers Integration ---
+    if (dusk::getSettings().game.enableDualSenseTriggers.getValue() && PADGetControllerType(PAD_CHAN0) == PAD_TYPE_PS5) {
+        if (link != nullptr) {
+            // 1. Check for Heavy/Iron Boots first (overrides targeting/archery triggers)
+            if (link->checkEquipHeavyBoots()) {
+                updateLeftTrigger(0x01, 0, 220, 0);  // Heavy resistance L2
+                updateRightTrigger(0x01, 0, 220, 0); // Heavy resistance R2
+            } else {
+                // 2. Left Trigger (L2) - Z-Targeting
+                fopAc_ac_c* zhint = dComIfGp_att_getZHint();
+                if (zhint != nullptr) {
+                    updateLeftTrigger(0x01, 10, 150, 0); // Tactile targeting stiffness
+                } else {
+                    updateLeftTrigger(0x00, 0, 0, 0); // Normal trigger
+                }
+
+                // 3. Right Trigger (R2) - Archery (Bow & Slingshot)
+                if (link->checkBowAnime()) {
+                    if (link->checkBowChargeWaitAnime()) {
+                        updateRightTrigger(0x01, 5, 210, 0); // Heavy draw tension
+                    } else if (link->checkBowReadyAnime()) {
+                        updateRightTrigger(0x01, 20, 120, 0); // Standard draw tension
+                    } else {
+                        updateRightTrigger(0x00, 0, 0, 0); // Arrow shot (immediate release)
+                    }
+                } else {
+                    updateRightTrigger(0x00, 0, 0, 0); // Normal trigger
+                }
+            }
+        } else {
+            // Menus / loading screen safety fallback
+            updateLeftTrigger(0x00, 0, 0, 0);
+            updateRightTrigger(0x00, 0, 0, 0);
+        }
+    } else {
+        // Disabled in settings or active controller is not a DualSense: clear triggers to normal
+        updateLeftTrigger(0x00, 0, 0, 0);
+        updateRightTrigger(0x00, 0, 0, 0);
     }
 
     f32 finalRed = finalGamepadColor.x + additionalGamepadColor.x;

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -54,6 +54,7 @@ UserSettings g_userSettings = {
         .enableAchievementToasts {"game.enableAchievementToasts", true},
         .enableControllerToasts {"game.enableControllerToasts", true},
         .enableDiscordPresence {"game.enableDiscordPresence", true},
+        .enableDualSenseTriggers {"game.enableDualSenseTriggers", true},
 
         // Graphics
         .bloomMode {"game.bloomMode", BloomMode::Dusk},
@@ -219,6 +220,7 @@ void registerSettings() {
     Register(g_userSettings.game.minimalHUD);
     Register(g_userSettings.game.pauseOnFocusLost);
     Register(g_userSettings.game.enableDiscordPresence);
+    Register(g_userSettings.game.enableDualSenseTriggers);
     Register(g_userSettings.game.bloomMode);
     Register(g_userSettings.game.bloomMultiplier);
     Register(g_userSettings.game.disableWaterRefraction);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -920,6 +920,8 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .helpText = "Allow inputs even when the game window is not focused.",
                 .onChange = [](bool value) { aurora_set_background_input(value); },
             });
+        addOption("DualSense Adaptive Triggers", getSettings().game.enableDualSenseTriggers,
+            "Enables dynamic haptic feedback and resistance for the PS5 DualSense controller triggers during gameplay (e.g. Z-Targeting, Archery tension, and Iron Boots weight).");
 
         leftPane.add_section("Camera");
         addOption("Free Camera", getSettings().game.freeCamera,


### PR DESCRIPTION
# Add native PS5 DualSense controller support

Closes #1192

This PR adds native PlayStation 5 DualSense controller support to the game. It implements context-aware adaptive triggers (L2/R2), health-based LED breathing behavior, a settings menu toggle, and safe fallback logic for non-DualSense gamepads.

### Summary of Changes

#### 1. Adaptive Triggers (L2/R2)
Triggers update dynamically based on Link's current state:
*   **Z-Targeting:** Left trigger (L2) stiffens slightly to provide a tactile lock-on threshold.
*   **Archery (Bow & Slingshot):** Right trigger (R2) has moderate tension on pull-back, increasing to heavy tension when fully drawn, and snaps back to zero resistance immediately upon releasing the shot.
*   **Iron Boots:** Applies high persistent resistance to both triggers to simulate heavy boots.

#### 2. Gamepad LED Breathing Effect
*   At full or normal health, gamepad LEDs match the tunic or targeting color as normal.
*   When health drops to 2 hearts or fewer, the LED pulses breathing red using a sine wave.

#### 3. Settings Menu & Compatibility Fallback
*   Added a toggle option **"DualSense Adaptive Triggers"** under **Input** settings in the ImGui/RmlUI menu.
*   Added controller-type checking so trigger effects are skipped when using Xbox, Switch Pro, or generic gamepads.
*   Added state caching so SDL trigger effect packets are only sent when states change, preventing Bluetooth packet saturation and input latency.
*   Automatically resets triggers back to default calibration mode if the setting is turned off or if the gamepad is swapped.

### Implementation Details
*   **`extern/aurora` (Submodule):** 
    *   Declared `PADSetTriggerEffect(u32 port, u32 trigger, u8 mode, u8 param0, u8 param1, u8 param2)` in `include/dolphin/pad.h`.
    *   Implemented the HID output report packed structure `DS5EffectsState_t` (47 bytes) and sent gamepad effects via `SDL_SendGamepadEffect` in `pad.cpp` when a PS5 controller is detected.
*   **`src/dusk`:**
    *   `gamepad_color.cpp`: Added real-time actor state checking and caching loop inside gamepad update.
    *   `settings.h` / `settings.cpp`: Added and registered the `enableDualSenseTriggers` config variable.
    *   `ui/settings.cpp`: Added the toggle option to the Input menu page.

### Verification Steps
1. Build with `cmake --preset windows-msvc-relwithdebinfo` and `cmake --build --preset windows-msvc-relwithdebinfo`.
2. Launch game and plug in a DualSense pad. Ensure trigger tension responds correctly to Z-targeting, drawing a bow, and wearing Iron Boots.
3. Switch controllers or toggle the option off in settings, and ensure the triggers immediately soften back to normal.
