### PR TITLE
Improve Collection/File Select screens at Widescreen/Ultrawide

### DIFF
--- a/include/d/d_file_select.h
+++ b/include/d/d_file_select.h
@@ -11,6 +11,40 @@
 
 class dFile_info_c;
 class J2DPicture;
+static bool cachedPanes = false;
+
+struct PaneCache {
+    u64 tag;
+    f32 origTransX;
+    f32 origTransY;
+    bool cached;
+};
+
+static PaneCache mSelDtPanes[] = {
+    {MULTI_CHAR('tate_n0'), 0.0f, false},
+    {MULTI_CHAR('tate_n1'), 0.0f, false},
+    {MULTI_CHAR('ken_n0'), 0.0f, false},
+    {MULTI_CHAR('ken_n1'), 0.0f, false},
+    {MULTI_CHAR('fuku_n0'), 0.0f, false},
+    {MULTI_CHAR('fuku_n1'), 0.0f, false},
+    {MULTI_CHAR('fuku_n2'), 0.0f, false},
+    {MULTI_CHAR('gray_n'), 0.0f, false},
+    {MULTI_CHAR('b_base'), 0.0f, false},
+    {MULTI_CHAR('b_base1'), 0.0f, false},
+};
+
+static PaneCache fileSelPanes[] = {
+    {MULTI_CHAR('w_uzu00'), 0.0f, false},
+    {MULTI_CHAR('w_uzu01'), 0.0f, false},
+    {MULTI_CHAR('w_uzu02'), 0.0f, false},
+    {MULTI_CHAR('w_uzu03'), 0.0f, false},
+    {MULTI_CHAR('w_uzu04'), 0.0f, false},
+    {MULTI_CHAR('w_uzu05'), 0.0f, false},
+    {MULTI_CHAR('w_uzu06'), 0.0f, false},
+    {MULTI_CHAR('w_uzu07'), 0.0f, false},
+    {MULTI_CHAR('w_uzu08'), 0.0f, false},
+    {MULTI_CHAR('w_uzu09'), 0.0f, false},
+};
 
 class dDlst_FileSel_c : public dDlst_base_c {
 public:

--- a/include/d/d_file_select.h
+++ b/include/d/d_file_select.h
@@ -11,6 +11,7 @@
 
 class dFile_info_c;
 class J2DPicture;
+#if TARGET_PC
 static bool cachedPanes = false;
 
 struct PaneCache {
@@ -45,7 +46,7 @@ static PaneCache fileSelPanes[] = {
     {MULTI_CHAR('w_uzu08'), 0.0f, false},
     {MULTI_CHAR('w_uzu09'), 0.0f, false},
 };
-
+#endif
 class dDlst_FileSel_c : public dDlst_base_c {
 public:
     void draw();

--- a/include/d/d_menu_collect.h
+++ b/include/d/d_menu_collect.h
@@ -15,6 +15,7 @@ class dMenu_Fishing_c;
 class dMenu_Skill_c;
 class dMenu_Insect_c;
 class dSelect_cursor_c;
+#if TARGET_PC
 static bool cachedPanes = false;
 
 struct PaneCache {
@@ -47,6 +48,7 @@ static PaneCache mpScreenPanes[] = {
     {MULTI_CHAR('f_t00'), 0.0f, false},
     {MULTI_CHAR('itemn_n'), 0.0f, false},
     {MULTI_CHAR('infotxtn'), 0.0f, false},
+    {MULTI_CHAR('sa_op_n'), 0.0f, false},
     {MULTI_CHAR('title_n'), 0.0f, false},
     {MULTI_CHAR('menu_n'), 0.0f, false},
     {MULTI_CHAR('w_er_n'), 0.0f, false},
@@ -55,6 +57,7 @@ static PaneCache mpScreenPanes[] = {
     {MULTI_CHAR('lavel_n'), 0.0f, false},
     {MULTI_CHAR('modelbgn'), 0.0f, false},
 };
+#endif
 
 class dMenu_Collect2D_c;
 class dMenu_Collect2DTop_c : public dDlst_base_c {

--- a/include/d/d_menu_collect.h
+++ b/include/d/d_menu_collect.h
@@ -15,6 +15,46 @@ class dMenu_Fishing_c;
 class dMenu_Skill_c;
 class dMenu_Insect_c;
 class dSelect_cursor_c;
+static bool cachedPanes = false;
+
+struct PaneCache {
+    u64 tag;
+    f32 origTransX;
+    f32 origTransY;
+    bool cached;
+};
+
+static PaneCache mpScreenPanes[] = {
+    {MULTI_CHAR('sa_tex_n'), 0.0f, false},
+    {MULTI_CHAR('op_tex_n'), 0.0f, false},
+    {MULTI_CHAR('heart_n'), 0.0f, false},
+    {MULTI_CHAR('wolf_n'), 0.0f, false},
+    {MULTI_CHAR('item_0_n'), 0.0f, false},
+    {MULTI_CHAR('item_1_n'), 0.0f, false},
+    {MULTI_CHAR('item_2_n'), 0.0f, false},
+    {MULTI_CHAR('fish_3_n'), 0.0f, false},
+    {MULTI_CHAR('lett_4_n'), 0.0f, false},
+    {MULTI_CHAR('maki_5_n'), 0.0f, false},
+    {MULTI_CHAR('fuku_n0'), 0.0f, false},
+    {MULTI_CHAR('fuku_n1'), 0.0f, false},
+    {MULTI_CHAR('fuku_n2'), 0.0f, false},
+    {MULTI_CHAR('tate_n0'), 0.0f, false},
+    {MULTI_CHAR('tate_n1'), 0.0f, false},
+    {MULTI_CHAR('ken_n0'), 0.0f, false},
+    {MULTI_CHAR('ken_n1'), 0.0f, false},
+    {MULTI_CHAR('kabu_6n'), 0.0f, false},
+    {MULTI_CHAR('t_t00'), 0.0f, false},
+    {MULTI_CHAR('f_t00'), 0.0f, false},
+    {MULTI_CHAR('itemn_n'), 0.0f, false},
+    {MULTI_CHAR('infotxtn'), 0.0f, false},
+    {MULTI_CHAR('title_n'), 0.0f, false},
+    {MULTI_CHAR('menu_n'), 0.0f, false},
+    {MULTI_CHAR('w_er_n'), 0.0f, false},
+    {MULTI_CHAR('center_n'), 0.0f, false},
+    {MULTI_CHAR('info_n'), 0.0f, false},
+    {MULTI_CHAR('lavel_n'), 0.0f, false},
+    {MULTI_CHAR('modelbgn'), 0.0f, false},
+};
 
 class dMenu_Collect2D_c;
 class dMenu_Collect2DTop_c : public dDlst_base_c {

--- a/include/d/d_select_cursor.h
+++ b/include/d/d_select_cursor.h
@@ -51,7 +51,7 @@ public:
     f32 getPositionX() const { return mPositionX; }
     f32 getPositionY() const { return mPositionY; }
 
-    void refreshAspectScale();
+    void refreshAspectScale(f32 param_0);
 #endif
 
     void onUpdateFlag() { mUpdateFlag = true; }

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -45,7 +45,7 @@ enum class FrameInterpMode : u8 {
     Unlimited = 2,
 };
 
-enum class CollectionScreenScaling : u8 {
+enum class MenuScaling : u8 {
     GameCube = 0,
     Wii = 1,
     Dusklight = 2,
@@ -89,9 +89,9 @@ struct ConfigEnumRange<FrameInterpMode> {
 };
 
 template <>
-struct ConfigEnumRange<CollectionScreenScaling> {
-    static constexpr auto min = CollectionScreenScaling::GameCube;
-    static constexpr auto max = CollectionScreenScaling::Dusklight;
+struct ConfigEnumRange<MenuScaling> {
+    static constexpr auto min = MenuScaling::GameCube;
+    static constexpr auto max = MenuScaling::Dusklight;
 };
 }  // namespace config
 
@@ -154,7 +154,7 @@ struct UserSettings {
         ConfigVar<bool> enableAchievementToasts;
         ConfigVar<bool> enableControllerToasts;
         ConfigVar<bool> enableDiscordPresence;
-        ConfigVar<CollectionScreenScaling> collectionScalingMode;
+        ConfigVar<MenuScaling> menuScalingMode;
 
         // Graphics
         ConfigVar<BloomMode> bloomMode;

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -45,6 +45,12 @@ enum class FrameInterpMode : u8 {
     Unlimited = 2,
 };
 
+enum class CollectionScreenScaling : u8 {
+    GameCube = 0,
+    Wii = 1,
+    Dusklight = 2,
+};
+
 namespace config {
 template <>
 struct ConfigEnumRange<BloomMode> {
@@ -80,6 +86,12 @@ template <>
 struct ConfigEnumRange<FrameInterpMode> {
     static constexpr auto min = FrameInterpMode::Off;
     static constexpr auto max = FrameInterpMode::Unlimited;
+};
+
+template <>
+struct ConfigEnumRange<CollectionScreenScaling> {
+    static constexpr auto min = CollectionScreenScaling::GameCube;
+    static constexpr auto max = CollectionScreenScaling::Dusklight;
 };
 }  // namespace config
 
@@ -142,6 +154,7 @@ struct UserSettings {
         ConfigVar<bool> enableAchievementToasts;
         ConfigVar<bool> enableControllerToasts;
         ConfigVar<bool> enableDiscordPresence;
+        ConfigVar<CollectionScreenScaling> collectionScalingMode;
 
         // Graphics
         ConfigVar<BloomMode> bloomMode;

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3787,7 +3787,7 @@ void dFile_select_c::fileSelectWide() {
         pane->translate(entry.origTransX, entry.origTransY);
     }
 
-    const bool wideScaling = dusk::getSettings().game.collectionScalingMode != dusk::CollectionScreenScaling::GameCube;
+    bool wideScaling = dusk::getSettings().game.collectionScalingMode != dusk::CollectionScreenScaling::GameCube;
     const f32 rootScale = wideScaling ? mDoGph_gInf_c::hudAspectScaleUp : 1.0f;
     const f32 childScale = wideScaling ? mDoGph_gInf_c::hudAspectScaleDown : 1.0f;
     const f32 rootTransX = wideScaling ? mDoGph_gInf_c::getSafeMinXF() : 0.0f;

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3789,13 +3789,51 @@ void dFile_select_c::fileSelectWide() {
     mCpSel.Scr->search(MULTI_CHAR('w_n_bk01'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
     mCpSel.Scr->search(MULTI_CHAR('w_n_bk02'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-    mSelDt.ScrDt->search(MULTI_CHAR('tate_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mSelDt.ScrDt->search(MULTI_CHAR('tate_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mSelDt.ScrDt->search(MULTI_CHAR('ken_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mSelDt.ScrDt->search(MULTI_CHAR('ken_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mSelDt.ScrDt->search(MULTI_CHAR('fuku_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mSelDt.ScrDt->search(MULTI_CHAR('fuku_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mSelDt.ScrDt->search(MULTI_CHAR('fuku_n2'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    // Equipment Icons/Slots
+    struct IconPaneCache {
+        u64 tag;
+        f32 origTransX;
+        bool cached;
+    };
+
+    static IconPaneCache s_Panes[] = {
+        {MULTI_CHAR('gray_n'), 0.0f, false},
+        {MULTI_CHAR('tate_n0'), 0.0f, false},
+        {MULTI_CHAR('tate_n1'), 0.0f, false},
+        {MULTI_CHAR('ken_n0'), 0.0f, false},
+        {MULTI_CHAR('ken_n1'), 0.0f, false},
+        {MULTI_CHAR('fuku_n0'), 0.0f, false},
+        {MULTI_CHAR('fuku_n1'), 0.0f, false},
+        {MULTI_CHAR('fuku_n2'), 0.0f, false},
+    };
+
+    constexpr f32 minAspect = 4.0f / 3.0f;
+    constexpr f32 maxAspect = 16.0f / 9.0 + 0.05f;
+    f32 screenAspect = mDoGph_gInf_c::getAspect();
+
+    // Pane holding Icons and slots escape the intended box at Ultrawide/Portrait due to non-linear
+    // stretching, so revert to default behavior
+    if (screenAspect >= minAspect && screenAspect <= maxAspect) { 
+        f32 gray_nScaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f);
+        f32 gray_nShiftFactor = mSelDt.ScrDt->search(MULTI_CHAR('gray_n'))->getTranslateX() * (gray_nScaleFactor - mDoGph_gInf_c::hudAspectScaleDown);
+
+        for (IconPaneCache& entry : s_Panes) {
+            J2DPane* pane = mSelDt.ScrDt->search(entry.tag);
+            if (!entry.cached) {
+                entry.origTransX = pane->getTranslateX(); // // Get pre-scale value
+                entry.cached = true;
+            }
+            pane->setBasePosition(J2DBasePosition_0);
+            pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f); // Scale Equipment Icons/Slots
+            if (entry.tag == MULTI_CHAR('gray_n')) { // Slots
+                pane->translate(entry.origTransX * gray_nScaleFactor, pane->getTranslateY());  // Move
+            }
+            else { // Shift Items
+                pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + gray_nShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());  // Move
+
+            }
+        }
+    }
 
     // Spirals
     fileSel.Scr->search(MULTI_CHAR('w_uzu00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3750,65 +3750,130 @@ bool dFile_select_c::yesnoWakuAlpahAnm(u8 param_1) {
 
 #if TARGET_PC
 void dFile_select_c::fileSelectWide() {
-    mYnSel.ScrYn->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
-    mYnSel.ScrYn->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
+    // Get pre-scale values for each pane
+    if (!cachedPanes) {
+        for (PaneCache& entry : mSelDtPanes) {
+            J2DPane* pane = mSelDt.ScrDt->search(entry.tag);
+            if (!entry.cached) {
+                entry.origTransX = pane->getTranslateX(); 
+                entry.origTransY = pane->getTranslateY();
+                entry.cached = true;
+            }
+        }
+        for (PaneCache& entry : fileSelPanes) {
+            J2DPane* pane = fileSel.Scr->search(entry.tag);
+            if (!entry.cached) {
+                entry.origTransX = pane->getTranslateX();
+                entry.origTransY = pane->getTranslateY(); 
+                entry.cached = true;
+            }
+        }
+        cachedPanes = true;
+    }
 
-    mYnSel.ScrYn->search(MULTI_CHAR('w_no_t'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mYnSel.ScrYn->search(MULTI_CHAR('f_no_t'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mYnSel.ScrYn->search(MULTI_CHAR('w_yes_t'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mYnSel.ScrYn->search(MULTI_CHAR('f_yes_t'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    // Reset all panes
+    mSelDt.ScrDt->scale(1.0f, 1.0f);
+    mSelDt.ScrDt->translate(0.0f, 0.0f);
+    for (PaneCache& entry : mSelDtPanes) {
+        J2DPane* pane = mSelDt.ScrDt->search(entry.tag);
+        pane->setBasePosition(J2DBasePosition_4);
+        pane->scale(1.0f, 1.0f);
+        pane->translate(entry.origTransX, entry.origTransY);
+    }
+    for (PaneCache& entry : fileSelPanes) {
+        J2DPane* pane = fileSel.Scr->search(entry.tag);
+        pane->setBasePosition(J2DBasePosition_4);
+        pane->scale(1.0f, 1.0f);
+        pane->translate(entry.origTransX, entry.origTransY);
+    }
 
-    m3mSel.Scr3m->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
-    m3mSel.Scr3m->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
+    const bool wideScaling = dusk::getSettings().game.collectionScalingMode != dusk::CollectionScreenScaling::GameCube;
+    const f32 rootScale = wideScaling ? mDoGph_gInf_c::hudAspectScaleUp : 1.0f;
+    const f32 childScale = wideScaling ? mDoGph_gInf_c::hudAspectScaleDown : 1.0f;
+    const f32 rootTransX = wideScaling ? mDoGph_gInf_c::getSafeMinXF() : 0.0f;
 
-    m3mSel.Scr3m->search(MULTI_CHAR('w_sta'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    m3mSel.Scr3m->search(MULTI_CHAR('f_sta'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    m3mSel.Scr3m->search(MULTI_CHAR('w_del'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    m3mSel.Scr3m->search(MULTI_CHAR('f_del'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    m3mSel.Scr3m->search(MULTI_CHAR('w_cop_t'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    m3mSel.Scr3m->search(MULTI_CHAR('f_cop_t'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    mYnSel.ScrYn->scale(rootScale, 1.0f);
+    mYnSel.ScrYn->translate(rootTransX, 0.0f);
 
-    fileSel.Scr->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
-    fileSel.Scr->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
+    mYnSel.ScrYn->search(MULTI_CHAR('w_no_t'))->scale(childScale, 1.0f);
+    mYnSel.ScrYn->search(MULTI_CHAR('f_no_t'))->scale(childScale, 1.0f);
+    mYnSel.ScrYn->search(MULTI_CHAR('w_yes_t'))->scale(childScale, 1.0f);
+    mYnSel.ScrYn->search(MULTI_CHAR('f_yes_t'))->scale(childScale, 1.0f);
 
-    fileSel.Scr->search(MULTI_CHAR('t_for'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('t_for1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    m3mSel.Scr3m->scale(rootScale, 1.0f);
+    m3mSel.Scr3m->translate(rootTransX, 0.0f);
 
-    fileSel.Scr->search(MULTI_CHAR('w_btn_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    m3mSel.Scr3m->search(MULTI_CHAR('w_sta'))->scale(childScale, 1.0f);
+    m3mSel.Scr3m->search(MULTI_CHAR('f_sta'))->scale(childScale, 1.0f);
+    m3mSel.Scr3m->search(MULTI_CHAR('w_del'))->scale(childScale, 1.0f);
+    m3mSel.Scr3m->search(MULTI_CHAR('f_del'))->scale(childScale, 1.0f);
+    m3mSel.Scr3m->search(MULTI_CHAR('w_cop_t'))->scale(childScale, 1.0f);
+    m3mSel.Scr3m->search(MULTI_CHAR('f_cop_t'))->scale(childScale, 1.0f);
 
-    fileSel.Scr->search(MULTI_CHAR('w_n_bk00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_n_bk01'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_n_bk02'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    fileSel.Scr->scale(rootScale, 1.0f);
+    fileSel.Scr->translate(rootTransX, 0.0f);
 
-    fileSel.Scr->search(MULTI_CHAR('w_dat_i0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_dat_i1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_dat_i2'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    fileSel.Scr->search(MULTI_CHAR('t_for'))->scale(childScale, 1.0f);
+    fileSel.Scr->search(MULTI_CHAR('t_for1'))->scale(childScale, 1.0f);
 
-    mCpSel.Scr->search(MULTI_CHAR('w_dat_i1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mCpSel.Scr->search(MULTI_CHAR('w_dat_i2'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mCpSel.Scr->search(MULTI_CHAR('w_n_bk01'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mCpSel.Scr->search(MULTI_CHAR('w_n_bk02'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    fileSel.Scr->search(MULTI_CHAR('w_btn_n'))->scale(childScale, 1.0f);
 
-    #if TARGET_PC
-        // Equipment Icons/Slots
-        struct IconPaneCache {
-            u64 tag;
-            f32 origTransX;
-            bool cached;
-        };
+    fileSel.Scr->search(MULTI_CHAR('w_n_bk00'))->scale(childScale, 1.0f);
+    fileSel.Scr->search(MULTI_CHAR('w_n_bk01'))->scale(childScale, 1.0f);
+    fileSel.Scr->search(MULTI_CHAR('w_n_bk02'))->scale(childScale, 1.0f);
 
-        static IconPaneCache s_Panes[] = {
-            {MULTI_CHAR('gray_n'), 0.0f, false},
-            {MULTI_CHAR('tate_n0'), 0.0f, false},
-            {MULTI_CHAR('tate_n1'), 0.0f, false},
-            {MULTI_CHAR('ken_n0'), 0.0f, false},
-            {MULTI_CHAR('ken_n1'), 0.0f, false},
-            {MULTI_CHAR('fuku_n0'), 0.0f, false},
-            {MULTI_CHAR('fuku_n1'), 0.0f, false},
-            {MULTI_CHAR('fuku_n2'), 0.0f, false},
-        };
+    fileSel.Scr->search(MULTI_CHAR('w_dat_i0'))->scale(childScale, 1.0f);
+    fileSel.Scr->search(MULTI_CHAR('w_dat_i1'))->scale(childScale, 1.0f);
+    fileSel.Scr->search(MULTI_CHAR('w_dat_i2'))->scale(childScale, 1.0f);
 
-        constexpr f32 minAspect = 4.0f / 3.0f;
+    mCpSel.Scr->search(MULTI_CHAR('w_dat_i1'))->scale(childScale, 1.0f);
+    mCpSel.Scr->search(MULTI_CHAR('w_dat_i2'))->scale(childScale, 1.0f);
+    mCpSel.Scr->search(MULTI_CHAR('w_n_bk01'))->scale(childScale, 1.0f);
+    mCpSel.Scr->search(MULTI_CHAR('w_n_bk02'))->scale(childScale, 1.0f);
+
+    switch (dusk::getSettings().game.collectionScalingMode) {
+    case (dusk::CollectionScreenScaling::GameCube):
+        // Selection Cursor
+        if (mSelIcon) {
+            mSelIcon->refreshAspectScale(1.0f);
+        }
+        if (mSelIcon2) {
+            mSelIcon2->refreshAspectScale(1.0f);
+        }
+        break;
+    case (dusk::CollectionScreenScaling::Wii):
+        // Icons
+        mSelDt.ScrDt->search(MULTI_CHAR('tate_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('tate_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('ken_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('ken_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('fuku_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('fuku_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('fuku_n2'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Spirals
+        fileSel.Scr->search(MULTI_CHAR('w_uzu00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu01'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu02'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu03'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu04'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu05'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu06'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu07'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu08'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu09'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Selection Cursor
+        if (mSelIcon) {
+            mSelIcon->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
+        }
+
+        if (mSelIcon2) {
+            mSelIcon2->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
+        }
+        break;
+    case (dusk::CollectionScreenScaling::Dusklight):
+        constexpr f32 minAspect = 4.0f / 2.94f;
         constexpr f32 wideAspect = 16.0f / 9.0f + 0.05f;
         constexpr f32 ultraAspect = 21.0f / 9.0f + 0.05f;
         const f32 screenAspect = mDoGph_gInf_c::getAspect();
@@ -3819,68 +3884,86 @@ void dFile_select_c::fileSelectWide() {
         const f32 wideShiftFactor = mSelDt.ScrDt->search(MULTI_CHAR('gray_n'))->getTranslateX() * (wideScaleFactor - mDoGph_gInf_c::hudAspectScaleDown);
         const f32 ultraShiftFactor = mSelDt.ScrDt->search(MULTI_CHAR('gray_n'))->getTranslateX() * (ultraScaleFactor - mDoGph_gInf_c::hudAspectScaleDown);
 
-        for (IconPaneCache& entry : s_Panes) {
+        for (PaneCache& entry : mSelDtPanes) {
+            const size_t index = &entry - mSelDtPanes;
             J2DPane* pane = mSelDt.ScrDt->search(entry.tag);
-            if (!entry.cached) {
-                entry.origTransX = pane->getTranslateX(); // Get pre-scale value
-                entry.cached = true;
-            }
             pane->setBasePosition(J2DBasePosition_0);
             pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
             if (screenAspect >= minAspect && screenAspect <= wideAspect) { // Handle widescreen
+                if (entry.tag == MULTI_CHAR('b_base')) { // Slots BG
+                    if (screenAspect > 1.75f) {
+                        pane->translate((entry.origTransX + 11.0f) * wideScaleFactor, pane->getTranslateY());
+                    } else { // Between 4:3 and 16:9
+                        pane->translate((entry.origTransX + 8.0f) * wideScaleFactor, pane->getTranslateY());
+                    }
+                }
+                if (entry.tag == MULTI_CHAR('b_base1')) { // Magic Armor Slot BG
+                    if (screenAspect > 1.75f) {
+                        pane->translate((entry.origTransX - 21.5f) * wideScaleFactor, pane->getTranslateY());
+                    } else { // Between 4:3 and 16:9
+                        pane->translate((entry.origTransX - 12.0f) * wideScaleFactor, pane->getTranslateY());
+                    }
+                }
                 if (entry.tag == MULTI_CHAR('gray_n')) { // Slots
                     pane->translate(entry.origTransX * wideScaleFactor, pane->getTranslateY());
-                } else { // Icons
+                }
+                if (index <= 6) { // Icons
                     pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + wideShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
                 }
-            } else if (screenAspect >= minAspect && screenAspect <= ultraAspect) { // Handle ultrawide
+            } else if (screenAspect >= minAspect && screenAspect >= wideAspect && screenAspect <= ultraAspect) // Handle ultrawide
+            { 
+                if (entry.tag == MULTI_CHAR('b_base')) { // Slots BG
+                    pane->translate((entry.origTransX + 18.0f) * ultraScaleFactor, pane->getTranslateY());
+                }
+                if (entry.tag == MULTI_CHAR('b_base1')) { // Magic Armor Slot BG
+                    pane->translate((entry.origTransX - 40.0f) * ultraScaleFactor, pane->getTranslateY());
+                }
                 if (entry.tag == MULTI_CHAR('gray_n')) { // Slots
                     pane->translate(entry.origTransX * ultraScaleFactor, pane->getTranslateY());
-                } else { // Icons
+                }
+                if (index <= 6) { // Icons
                     pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + ultraShiftFactor - 57.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
                 }
-            }
-            else { // 4:3/default behavior
+            } else { // 4:3/default behavior
                 pane->setBasePosition(J2DBasePosition_4);
                 pane->translate(entry.origTransX, pane->getTranslateY());
-                if (entry.tag == MULTI_CHAR('gray_n')) {
-                    pane->scale(1.0f, 1.0f); // Slots
-                } else { // Icons
+                if (entry.tag == MULTI_CHAR('gray_n')) { // Slots
+                    pane->scale(1.0f, 1.0f);
+                }
+                if (entry.tag == MULTI_CHAR('b_base')) { // Slots BG
+                    pane->scale(1.0f, 1.0f);
+                }
+                if (entry.tag == MULTI_CHAR('b_base1')) { // Magic Armor Slot BG
+                    pane->scale(1.0f, 1.0f);
+                }
+                if (index <= 6) { // Icons
                     pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
                 }
             }
         }
-    #else
-        mSelDt.ScrDt->search(MULTI_CHAR('tate_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-        mSelDt.ScrDt->search(MULTI_CHAR('tate_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-        mSelDt.ScrDt->search(MULTI_CHAR('ken_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-        mSelDt.ScrDt->search(MULTI_CHAR('ken_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-        mSelDt.ScrDt->search(MULTI_CHAR('fuku_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-        mSelDt.ScrDt->search(MULTI_CHAR('fuku_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-        mSelDt.ScrDt->search(MULTI_CHAR('fuku_n2'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    #endif
 
-    // Spirals
-    fileSel.Scr->search(MULTI_CHAR('w_uzu00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_uzu01'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_uzu02'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_uzu03'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_uzu04'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_uzu05'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_uzu06'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_uzu07'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_uzu08'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    fileSel.Scr->search(MULTI_CHAR('w_uzu09'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        // Selection Cursor
+        if (mSelIcon) {
+            mSelIcon->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
+        }
 
-    #if TARGET_PC
-    if (mSelIcon) {
-        mSelIcon->refreshAspectScale();
+        if (mSelIcon2) {
+            mSelIcon2->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
+        }
+
+        // Spirals
+        fileSel.Scr->search(MULTI_CHAR('w_uzu00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu01'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu02'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu03'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu04'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu05'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu06'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu07'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu08'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        fileSel.Scr->search(MULTI_CHAR('w_uzu09'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        break;
     }
-    
-    if (mSelIcon2) {
-        mSelIcon2->refreshAspectScale();
-    }
-    #endif
 }
 #endif
 

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3825,21 +3825,19 @@ void dFile_select_c::fileSelectWide() {
                 entry.origTransX = pane->getTranslateX(); // Get pre-scale value
                 entry.cached = true;
             }
+            pane->setBasePosition(J2DBasePosition_0);
+            pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
             if (screenAspect >= minAspect && screenAspect <= wideAspect) { // Handle widescreen
-                pane->setBasePosition(J2DBasePosition_0);
-                pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
                 if (entry.tag == MULTI_CHAR('gray_n')) { // Slots
                     pane->translate(entry.origTransX * wideScaleFactor, pane->getTranslateY());
                 } else { // Icons
                     pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + wideShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
                 }
             } else if (screenAspect >= minAspect && screenAspect <= ultraAspect) { // Handle ultrawide
-                pane->setBasePosition(J2DBasePosition_0);
-                pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
                 if (entry.tag == MULTI_CHAR('gray_n')) { // Slots
                     pane->translate(entry.origTransX * ultraScaleFactor, pane->getTranslateY());
                 } else { // Icons
-                    pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + ultraShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
+                    pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + ultraShiftFactor - 57.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
                 }
             }
             else { // 4:3/default behavior

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3808,29 +3808,35 @@ void dFile_select_c::fileSelectWide() {
     };
 
     constexpr f32 minAspect = 4.0f / 3.0f;
-    constexpr f32 maxAspect = 16.0f / 9.0 + 0.05f;
-    f32 screenAspect = mDoGph_gInf_c::getAspect();
+    constexpr f32 maxAspect = 16.0f / 9.0f + 0.05f;
+    const f32 screenAspect = mDoGph_gInf_c::getAspect();
+    const f32 gray_nScaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f);
+    const f32 gray_nShiftFactor = mSelDt.ScrDt->search(MULTI_CHAR('gray_n'))->getTranslateX() * (gray_nScaleFactor - mDoGph_gInf_c::hudAspectScaleDown);
 
-    // Pane holding Icons and slots escape the intended box at Ultrawide/Portrait due to non-linear
-    // stretching, so revert to default behavior
-    if (screenAspect >= minAspect && screenAspect <= maxAspect) { 
-        f32 gray_nScaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f);
-        f32 gray_nShiftFactor = mSelDt.ScrDt->search(MULTI_CHAR('gray_n'))->getTranslateX() * (gray_nScaleFactor - mDoGph_gInf_c::hudAspectScaleDown);
-
-        for (IconPaneCache& entry : s_Panes) {
-            J2DPane* pane = mSelDt.ScrDt->search(entry.tag);
-            if (!entry.cached) {
-                entry.origTransX = pane->getTranslateX(); // // Get pre-scale value
-                entry.cached = true;
-            }
+    for (IconPaneCache& entry : s_Panes) {
+        J2DPane* pane = mSelDt.ScrDt->search(entry.tag);
+        if (!entry.cached) {
+            entry.origTransX = pane->getTranslateX(); // Get pre-scale value
+            entry.cached = true;
+        }
+        // Pane holding icons and slots escape the intended box at Ultrawide/Portrait due to
+        // non-linear stretching, so revert to default behavior
+        if (screenAspect >= minAspect && screenAspect <= maxAspect) {
             pane->setBasePosition(J2DBasePosition_0);
-            pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f); // Scale Equipment Icons/Slots
-            if (entry.tag == MULTI_CHAR('gray_n')) { // Slots
-                pane->translate(entry.origTransX * gray_nScaleFactor, pane->getTranslateY());  // Move
+            pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+            if (entry.tag == MULTI_CHAR('gray_n')) {
+                pane->translate(entry.origTransX * gray_nScaleFactor, pane->getTranslateY());
+            } else {
+                pane->translate(
+                    mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + gray_nShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
             }
-            else { // Shift Items
-                pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + gray_nShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());  // Move
-
+        } else { // Default behavior
+            pane->setBasePosition(J2DBasePosition_4);
+            pane->translate(entry.origTransX, pane->getTranslateY());
+            if (entry.tag == MULTI_CHAR('gray_n')) {
+                pane->scale(1.0f, 1.0f);
+            } else {
+                pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
             }
         }
     }

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3787,7 +3787,7 @@ void dFile_select_c::fileSelectWide() {
         pane->translate(entry.origTransX, entry.origTransY);
     }
 
-    bool wideScaling = dusk::getSettings().game.collectionScalingMode != dusk::CollectionScreenScaling::GameCube;
+    bool wideScaling = dusk::getSettings().game.collectionScalingMode.getValue() != dusk::CollectionScreenScaling::GameCube;
     const f32 rootScale = wideScaling ? mDoGph_gInf_c::hudAspectScaleUp : 1.0f;
     const f32 childScale = wideScaling ? mDoGph_gInf_c::hudAspectScaleDown : 1.0f;
     const f32 rootTransX = wideScaling ? mDoGph_gInf_c::getSafeMinXF() : 0.0f;

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3787,7 +3787,7 @@ void dFile_select_c::fileSelectWide() {
         pane->translate(entry.origTransX, entry.origTransY);
     }
 
-    bool wideScaling = dusk::getSettings().game.collectionScalingMode.getValue() != dusk::CollectionScreenScaling::GameCube;
+    bool wideScaling = dusk::getSettings().game.menuScalingMode.getValue() != dusk::MenuScaling::GameCube;
     const f32 rootScale = wideScaling ? mDoGph_gInf_c::hudAspectScaleUp : 1.0f;
     const f32 childScale = wideScaling ? mDoGph_gInf_c::hudAspectScaleDown : 1.0f;
     const f32 rootTransX = wideScaling ? mDoGph_gInf_c::getSafeMinXF() : 0.0f;
@@ -3831,8 +3831,8 @@ void dFile_select_c::fileSelectWide() {
     mCpSel.Scr->search(MULTI_CHAR('w_n_bk01'))->scale(childScale, 1.0f);
     mCpSel.Scr->search(MULTI_CHAR('w_n_bk02'))->scale(childScale, 1.0f);
 
-    switch (dusk::getSettings().game.collectionScalingMode) {
-    case (dusk::CollectionScreenScaling::GameCube):
+    switch (dusk::getSettings().game.menuScalingMode) {
+    case (dusk::MenuScaling::GameCube):
         // Selection Cursor
         if (mSelIcon) {
             mSelIcon->refreshAspectScale(1.0f);
@@ -3841,7 +3841,7 @@ void dFile_select_c::fileSelectWide() {
             mSelIcon2->refreshAspectScale(1.0f);
         }
         break;
-    case (dusk::CollectionScreenScaling::Wii):
+    case (dusk::MenuScaling::Wii):
         // Icons
         mSelDt.ScrDt->search(MULTI_CHAR('tate_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
         mSelDt.ScrDt->search(MULTI_CHAR('tate_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
@@ -3872,7 +3872,7 @@ void dFile_select_c::fileSelectWide() {
             mSelIcon2->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
         }
         break;
-    case (dusk::CollectionScreenScaling::Dusklight):
+    case (dusk::MenuScaling::Dusklight):
         constexpr f32 minAspect = 4.0f / 2.94f;
         constexpr f32 wideAspect = 16.0f / 9.0f + 0.05f;
         constexpr f32 ultraAspect = 21.0f / 9.0f + 0.05f;

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3922,7 +3922,7 @@ void dFile_select_c::fileSelectWide() {
                     pane->translate(entry.origTransX * ultraScaleFactor, pane->getTranslateY());
                 }
                 if (index <= 6) { // Icons
-                    pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + ultraShiftFactor - 57.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
+                    pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + ultraShiftFactor - 62.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
                 }
             } else { // 4:3/default behavior
                 pane->setBasePosition(J2DBasePosition_4);

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -3789,57 +3789,78 @@ void dFile_select_c::fileSelectWide() {
     mCpSel.Scr->search(MULTI_CHAR('w_n_bk01'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
     mCpSel.Scr->search(MULTI_CHAR('w_n_bk02'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-    // Equipment Icons/Slots
-    struct IconPaneCache {
-        u64 tag;
-        f32 origTransX;
-        bool cached;
-    };
+    #if TARGET_PC
+        // Equipment Icons/Slots
+        struct IconPaneCache {
+            u64 tag;
+            f32 origTransX;
+            bool cached;
+        };
 
-    static IconPaneCache s_Panes[] = {
-        {MULTI_CHAR('gray_n'), 0.0f, false},
-        {MULTI_CHAR('tate_n0'), 0.0f, false},
-        {MULTI_CHAR('tate_n1'), 0.0f, false},
-        {MULTI_CHAR('ken_n0'), 0.0f, false},
-        {MULTI_CHAR('ken_n1'), 0.0f, false},
-        {MULTI_CHAR('fuku_n0'), 0.0f, false},
-        {MULTI_CHAR('fuku_n1'), 0.0f, false},
-        {MULTI_CHAR('fuku_n2'), 0.0f, false},
-    };
+        static IconPaneCache s_Panes[] = {
+            {MULTI_CHAR('gray_n'), 0.0f, false},
+            {MULTI_CHAR('tate_n0'), 0.0f, false},
+            {MULTI_CHAR('tate_n1'), 0.0f, false},
+            {MULTI_CHAR('ken_n0'), 0.0f, false},
+            {MULTI_CHAR('ken_n1'), 0.0f, false},
+            {MULTI_CHAR('fuku_n0'), 0.0f, false},
+            {MULTI_CHAR('fuku_n1'), 0.0f, false},
+            {MULTI_CHAR('fuku_n2'), 0.0f, false},
+        };
 
-    constexpr f32 minAspect = 4.0f / 3.0f;
-    constexpr f32 maxAspect = 16.0f / 9.0f + 0.05f;
-    const f32 screenAspect = mDoGph_gInf_c::getAspect();
-    const f32 gray_nScaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f);
-    const f32 gray_nShiftFactor = mSelDt.ScrDt->search(MULTI_CHAR('gray_n'))->getTranslateX() * (gray_nScaleFactor - mDoGph_gInf_c::hudAspectScaleDown);
+        constexpr f32 minAspect = 4.0f / 3.0f;
+        constexpr f32 wideAspect = 16.0f / 9.0f + 0.05f;
+        constexpr f32 ultraAspect = 21.0f / 9.0f + 0.05f;
+        const f32 screenAspect = mDoGph_gInf_c::getAspect();
 
-    for (IconPaneCache& entry : s_Panes) {
-        J2DPane* pane = mSelDt.ScrDt->search(entry.tag);
-        if (!entry.cached) {
-            entry.origTransX = pane->getTranslateX(); // Get pre-scale value
-            entry.cached = true;
-        }
-        // Pane holding icons and slots escape the intended box at Ultrawide/Portrait due to
-        // non-linear stretching, so revert to default behavior
-        if (screenAspect >= minAspect && screenAspect <= maxAspect) {
-            pane->setBasePosition(J2DBasePosition_0);
-            pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-            if (entry.tag == MULTI_CHAR('gray_n')) {
-                pane->translate(entry.origTransX * gray_nScaleFactor, pane->getTranslateY());
-            } else {
-                pane->translate(
-                    mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + gray_nShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
+        const f32 wideScaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f);
+        const f32 ultraScaleFactor = 1.0f + 0.115f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f);
+
+        const f32 wideShiftFactor = mSelDt.ScrDt->search(MULTI_CHAR('gray_n'))->getTranslateX() * (wideScaleFactor - mDoGph_gInf_c::hudAspectScaleDown);
+        const f32 ultraShiftFactor = mSelDt.ScrDt->search(MULTI_CHAR('gray_n'))->getTranslateX() * (ultraScaleFactor - mDoGph_gInf_c::hudAspectScaleDown);
+
+        for (IconPaneCache& entry : s_Panes) {
+            J2DPane* pane = mSelDt.ScrDt->search(entry.tag);
+            if (!entry.cached) {
+                entry.origTransX = pane->getTranslateX(); // Get pre-scale value
+                entry.cached = true;
             }
-        } else { // Default behavior
-            pane->setBasePosition(J2DBasePosition_4);
-            pane->translate(entry.origTransX, pane->getTranslateY());
-            if (entry.tag == MULTI_CHAR('gray_n')) {
-                pane->scale(1.0f, 1.0f);
-            } else {
+            if (screenAspect >= minAspect && screenAspect <= wideAspect) { // Handle widescreen
+                pane->setBasePosition(J2DBasePosition_0);
                 pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+                if (entry.tag == MULTI_CHAR('gray_n')) { // Slots
+                    pane->translate(entry.origTransX * wideScaleFactor, pane->getTranslateY());
+                } else { // Icons
+                    pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + wideShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
+                }
+            } else if (screenAspect >= minAspect && screenAspect <= ultraAspect) { // Handle ultrawide
+                pane->setBasePosition(J2DBasePosition_0);
+                pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+                if (entry.tag == MULTI_CHAR('gray_n')) { // Slots
+                    pane->translate(entry.origTransX * ultraScaleFactor, pane->getTranslateY());
+                } else { // Icons
+                    pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + ultraShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
+                }
+            }
+            else { // 4:3/default behavior
+                pane->setBasePosition(J2DBasePosition_4);
+                pane->translate(entry.origTransX, pane->getTranslateY());
+                if (entry.tag == MULTI_CHAR('gray_n')) {
+                    pane->scale(1.0f, 1.0f); // Slots
+                } else { // Icons
+                    pane->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+                }
             }
         }
-    }
+    #else
+        mSelDt.ScrDt->search(MULTI_CHAR('tate_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('tate_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('ken_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('ken_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('fuku_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('fuku_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mSelDt.ScrDt->search(MULTI_CHAR('fuku_n2'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    #endif
 
     // Spirals
     fileSel.Scr->search(MULTI_CHAR('w_uzu00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);

--- a/src/d/d_menu_collect.cpp
+++ b/src/d/d_menu_collect.cpp
@@ -97,43 +97,52 @@ dMenu_Collect2D_c::~dMenu_Collect2D_c() {
 
 #if TARGET_PC
 void dMenu_Collect2D_c::menuCollectWide() {
-    // Main Canvas
-    mpScreen->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
-    mpScreen->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
+    // Get pre-scale values for each pane
+    if (!cachedPanes) {
+        for (PaneCache& entry : mpScreenPanes) {
+            J2DPane* pane = mpScreen->search(entry.tag);
+            if (!entry.cached) {
+                entry.origTransX = pane->getTranslateX();
+                entry.origTransY = pane->getTranslateY();
+                entry.cached = true;
+            }
+        }
+        cachedPanes = true;
+    }
 
-    // "Save" Text
-    mpScreen->search(MULTI_CHAR('sa_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    // Reset all panes
+    mpScreen->scale(1.0f, 1.0f);
+    mpScreen->translate(0.0f, 0.0f);
+    for (PaneCache& entry : mpScreenPanes) {
+        J2DPane* pane = mpScreen->search(entry.tag);
+        pane->scale(1.0f, 1.0f);
+        pane->translate(entry.origTransX, entry.origTransY);
+    }
 
-    // "Options" Text
-    mpScreen->search(MULTI_CHAR('op_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    // Reset button overlay
+    mpScreenIcon->translate(0.0f, 0.0f);
 
-    #if TARGET_PC
-        // "Collection" Title Bar
-        mpScreen->search(MULTI_CHAR('title_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    switch (dusk::getSettings().game.collectionScalingMode) {
+    case dusk::CollectionScreenScaling::GameCube:
+        // Selection Cursor
+        if (mpDrawCursor) {
+            mpDrawCursor->refreshAspectScale(1.0f);
+        }
+        break;
+    case dusk::CollectionScreenScaling::Wii:
+        // Main Canvas
+        mpScreen->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
+        mpScreen->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
 
-        // Main Central Elements
-        mpScreen->search(MULTI_CHAR('menu_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-        mpScreen->search(MULTI_CHAR('w_er_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-        mpScreen->search(MULTI_CHAR('center_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        // Button Overlay
+        mpScreenIcon->translate(-mDoGph_gInf_c::getSafeMinXF(), 0.0f);
 
-        const f32 leftShift = 48.0f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f); // Shifting certain items left to keep center (> 4:3 only)
+        // "Save" Text
+        mpScreen->search(MULTI_CHAR('sa_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-        J2DPane* info_n = mpScreen->search(MULTI_CHAR('info_n'));
-        static f32 infoTransX_orig = info_n->getTranslateX();
-        info_n->translate(infoTransX_orig - leftShift, info_n->getTranslateY());
+        // "Options" Text
+        mpScreen->search(MULTI_CHAR('op_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-        J2DPane* lavel_n = mpScreen->search(MULTI_CHAR('lavel_n'));
-        static f32 lavelTransX_orig = lavel_n->getTranslateX();
-        lavel_n->translate(lavelTransX_orig - leftShift, lavel_n->getTranslateY());
-
-        J2DPane* modelbgn = mpScreen->search(MULTI_CHAR('modelbgn'));
-        static f32 modelbgnTransX_orig = modelbgn->getTranslateX(); // Get pre-scale value
-        modelbgn->setBasePosition(J2DBasePosition_0);
-        modelbgn->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-        f32 modelbgn_scaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleDown - 1.0f);
-        modelbgn->translate(modelbgnTransX_orig * modelbgn_scaleFactor, modelbgn->getTranslateY());
-
-    #else
         // Pieces of Heart
         mpScreen->search(MULTI_CHAR('heart_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
@@ -192,12 +201,56 @@ void dMenu_Collect2D_c::menuCollectWide() {
         // Item Description Text
         mpScreen->search(MULTI_CHAR('infotxtn'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-        #if TARGET_PC
-            if (mpDrawCursor) {
-                mpDrawCursor->refreshAspectScale();
-            }
-        #endif
-    #endif
+        // Selection Cursor
+        if (mpDrawCursor) {
+            mpDrawCursor->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
+        }
+        break;
+    case dusk::CollectionScreenScaling::Dusklight:
+        // Main Canvas
+        mpScreen->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
+        mpScreen->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
+
+        // "Save" Text
+        mpScreen->search(MULTI_CHAR('sa_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // "Options" Text
+        mpScreen->search(MULTI_CHAR('op_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // "Collection" Title Bar
+        mpScreen->search(MULTI_CHAR('title_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Main Central Elements
+        mpScreen->search(MULTI_CHAR('menu_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mpScreen->search(MULTI_CHAR('w_er_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mpScreen->search(MULTI_CHAR('center_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        const f32 leftShift = 48.0f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f);  // Shifting certain items left to keep center (> 4:3 only)
+
+        // Item Name/Description Text
+        J2DPane* info_n = mpScreen->search(MULTI_CHAR('info_n'));
+        static f32 infoTransX_orig = info_n->getTranslateX();
+        info_n->translate(infoTransX_orig - leftShift, info_n->getTranslateY());
+
+        // Designs
+        J2DPane* lavel_n = mpScreen->search(MULTI_CHAR('lavel_n'));
+        static f32 lavelTransX_orig = lavel_n->getTranslateX();
+        lavel_n->translate(lavelTransX_orig - leftShift, lavel_n->getTranslateY());
+
+        // Fused Shadow/Mirror Background
+        J2DPane* modelbgn = mpScreen->search(MULTI_CHAR('modelbgn'));
+        static f32 modelbgnTransX_orig = modelbgn->getTranslateX();  // Get pre-scale value
+        modelbgn->setBasePosition(J2DBasePosition_0);
+        modelbgn->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.3f);
+        f32 modelbgn_scaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleDown - 1.0f);
+        modelbgn->translate((modelbgnTransX_orig - 12.0f) * modelbgn_scaleFactor, modelbgn->getTranslateY());
+
+        // Selection Cursor
+        if (mpDrawCursor) {
+            mpDrawCursor->refreshAspectScale(1.0f);
+        }
+        break;
+    }
 }
 #endif
 

--- a/src/d/d_menu_collect.cpp
+++ b/src/d/d_menu_collect.cpp
@@ -116,23 +116,21 @@ void dMenu_Collect2D_c::menuCollectWide() {
     mpScreen->search(MULTI_CHAR('center_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
     // Item Name/Description
-    f32 leftShift = 48.0f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f);  // Shifting certain items left to keep center (> 4:3 only)
+    f32 leftShift = 48.0f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f); // Shifting certain items left to keep center (> 4:3 only)
     J2DPane* info_n = mpScreen->search(MULTI_CHAR('info_n'));
     static f32 infoTransX_orig = info_n->getTranslateX();
-    info_n->translate(infoTransX_orig - leftShift, info_n->getTranslateY()); // Move
+    info_n->translate(infoTransX_orig - leftShift, info_n->getTranslateY());
 
-    // Designs
     J2DPane* lavel_n = mpScreen->search(MULTI_CHAR('lavel_n'));
     static f32 lavelTransX_orig = lavel_n->getTranslateX();
-    lavel_n->translate(lavelTransX_orig - leftShift, lavel_n->getTranslateY()); // Move
+    lavel_n->translate(lavelTransX_orig - leftShift, lavel_n->getTranslateY());
 
-    // Fused Shadow/Mirror Background
     J2DPane* modelbgn = mpScreen->search(MULTI_CHAR('modelbgn'));
     static f32 modelbgnTransX_orig = modelbgn->getTranslateX(); // Get pre-scale value
     modelbgn->setBasePosition(J2DBasePosition_0);
     modelbgn->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
     f32 modelbgn_scaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleDown - 1.0f);
-    modelbgn->translate(modelbgnTransX_orig * modelbgn_scaleFactor, modelbgn->getTranslateY());  // Move
+    modelbgn->translate(modelbgnTransX_orig * modelbgn_scaleFactor, modelbgn->getTranslateY());
 
     // Stretches the selection cursor to the aspect ratio, but this menu works at any aspect so this is un-needed? Looks bad on Ultrawide
     // #if TARGET_PC

--- a/src/d/d_menu_collect.cpp
+++ b/src/d/d_menu_collect.cpp
@@ -122,14 +122,14 @@ void dMenu_Collect2D_c::menuCollectWide() {
     // Reset button overlay
     mpScreenIcon->translate(0.0f, 0.0f);
 
-    switch (dusk::getSettings().game.collectionScalingMode) {
-    case dusk::CollectionScreenScaling::GameCube:
+    switch (dusk::getSettings().game.menuScalingMode) {
+    case dusk::MenuScaling::GameCube:
         // Selection Cursor
         if (mpDrawCursor) {
             mpDrawCursor->refreshAspectScale(1.0f);
         }
         break;
-    case dusk::CollectionScreenScaling::Wii:
+    case dusk::MenuScaling::Wii:
         // Main Canvas
         mpScreen->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
         mpScreen->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
@@ -206,16 +206,13 @@ void dMenu_Collect2D_c::menuCollectWide() {
             mpDrawCursor->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
         }
         break;
-    case dusk::CollectionScreenScaling::Dusklight:
+    case dusk::MenuScaling::Dusklight:
         // Main Canvas
         mpScreen->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
         mpScreen->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
 
-        // "Save" Text
-        mpScreen->search(MULTI_CHAR('sa_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-        // "Options" Text
-        mpScreen->search(MULTI_CHAR('op_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        // Save/Options Buttons
+        mpScreen->search(MULTI_CHAR('sa_op_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
         // "Collection" Title Bar
         mpScreen->search(MULTI_CHAR('title_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);

--- a/src/d/d_menu_collect.cpp
+++ b/src/d/d_menu_collect.cpp
@@ -101,43 +101,103 @@ void dMenu_Collect2D_c::menuCollectWide() {
     mpScreen->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
     mpScreen->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
 
-    // "Collection" Title Bar
-    mpScreen->search(MULTI_CHAR('title_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
     // "Save" Text
     mpScreen->search(MULTI_CHAR('sa_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
     // "Options" Text
     mpScreen->search(MULTI_CHAR('op_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-    // Main Central Elements
-    mpScreen->search(MULTI_CHAR('menu_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mpScreen->search(MULTI_CHAR('w_er_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mpScreen->search(MULTI_CHAR('center_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    #if TARGET_PC
+        // "Collection" Title Bar
+        mpScreen->search(MULTI_CHAR('title_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-    // Item Name/Description
-    f32 leftShift = 48.0f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f); // Shifting certain items left to keep center (> 4:3 only)
-    J2DPane* info_n = mpScreen->search(MULTI_CHAR('info_n'));
-    static f32 infoTransX_orig = info_n->getTranslateX();
-    info_n->translate(infoTransX_orig - leftShift, info_n->getTranslateY());
+        // Main Central Elements
+        mpScreen->search(MULTI_CHAR('menu_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mpScreen->search(MULTI_CHAR('w_er_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mpScreen->search(MULTI_CHAR('center_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-    J2DPane* lavel_n = mpScreen->search(MULTI_CHAR('lavel_n'));
-    static f32 lavelTransX_orig = lavel_n->getTranslateX();
-    lavel_n->translate(lavelTransX_orig - leftShift, lavel_n->getTranslateY());
+        const f32 leftShift = 48.0f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f); // Shifting certain items left to keep center (> 4:3 only)
 
-    J2DPane* modelbgn = mpScreen->search(MULTI_CHAR('modelbgn'));
-    static f32 modelbgnTransX_orig = modelbgn->getTranslateX(); // Get pre-scale value
-    modelbgn->setBasePosition(J2DBasePosition_0);
-    modelbgn->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    f32 modelbgn_scaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleDown - 1.0f);
-    modelbgn->translate(modelbgnTransX_orig * modelbgn_scaleFactor, modelbgn->getTranslateY());
+        J2DPane* info_n = mpScreen->search(MULTI_CHAR('info_n'));
+        static f32 infoTransX_orig = info_n->getTranslateX();
+        info_n->translate(infoTransX_orig - leftShift, info_n->getTranslateY());
 
-    // Stretches the selection cursor to the aspect ratio, but this menu works at any aspect so this is un-needed? Looks bad on Ultrawide
-    // #if TARGET_PC
-    // if (mpDrawCursor) {
-    //     mpDrawCursor->refreshAspectScale();
-    // }
-    // #endif
+        J2DPane* lavel_n = mpScreen->search(MULTI_CHAR('lavel_n'));
+        static f32 lavelTransX_orig = lavel_n->getTranslateX();
+        lavel_n->translate(lavelTransX_orig - leftShift, lavel_n->getTranslateY());
+
+        J2DPane* modelbgn = mpScreen->search(MULTI_CHAR('modelbgn'));
+        static f32 modelbgnTransX_orig = modelbgn->getTranslateX(); // Get pre-scale value
+        modelbgn->setBasePosition(J2DBasePosition_0);
+        modelbgn->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        f32 modelbgn_scaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleDown - 1.0f);
+        modelbgn->translate(modelbgnTransX_orig * modelbgn_scaleFactor, modelbgn->getTranslateY());
+
+    #else
+        // Pieces of Heart
+        mpScreen->search(MULTI_CHAR('heart_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Scents
+        mpScreen->search(MULTI_CHAR('wolf_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Quiver
+        mpScreen->search(MULTI_CHAR('item_0_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Wallet
+        mpScreen->search(MULTI_CHAR('item_1_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Poes
+        mpScreen->search(MULTI_CHAR('item_2_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Fish Bestiary
+        mpScreen->search(MULTI_CHAR('fish_3_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Letters
+        mpScreen->search(MULTI_CHAR('lett_4_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Hidden Skills
+        mpScreen->search(MULTI_CHAR('maki_5_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Green Tunic
+        mpScreen->search(MULTI_CHAR('fuku_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Zora Armor
+        mpScreen->search(MULTI_CHAR('fuku_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Magic Armor
+        mpScreen->search(MULTI_CHAR('fuku_n2'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Ordon Shield
+        mpScreen->search(MULTI_CHAR('tate_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Hylian Shield
+        mpScreen->search(MULTI_CHAR('tate_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Ordon Sword
+        mpScreen->search(MULTI_CHAR('ken_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Master Sword
+        mpScreen->search(MULTI_CHAR('ken_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Bugs
+        mpScreen->search(MULTI_CHAR('kabu_6n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // "Collection" Text
+        mpScreen->search(MULTI_CHAR('t_t00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mpScreen->search(MULTI_CHAR('f_t00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Item Name Text
+        mpScreen->search(MULTI_CHAR('itemn_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        // Item Description Text
+        mpScreen->search(MULTI_CHAR('infotxtn'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+
+        #if TARGET_PC
+            if (mpDrawCursor) {
+                mpDrawCursor->refreshAspectScale();
+            }
+        #endif
+    #endif
 }
 #endif
 

--- a/src/d/d_menu_collect.cpp
+++ b/src/d/d_menu_collect.cpp
@@ -101,57 +101,8 @@ void dMenu_Collect2D_c::menuCollectWide() {
     mpScreen->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
     mpScreen->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);
 
-    // Pieces of Heart
-    mpScreen->search(MULTI_CHAR('heart_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Scents
-    mpScreen->search(MULTI_CHAR('wolf_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Quiver
-    mpScreen->search(MULTI_CHAR('item_0_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Wallet
-    mpScreen->search(MULTI_CHAR('item_1_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Poes
-    mpScreen->search(MULTI_CHAR('item_2_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Fish Bestiary
-    mpScreen->search(MULTI_CHAR('fish_3_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Letters
-    mpScreen->search(MULTI_CHAR('lett_4_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Hidden Skills
-    mpScreen->search(MULTI_CHAR('maki_5_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Green Tunic
-    mpScreen->search(MULTI_CHAR('fuku_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Zora Armor
-    mpScreen->search(MULTI_CHAR('fuku_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Magic Armor
-    mpScreen->search(MULTI_CHAR('fuku_n2'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Ordon Shield
-    mpScreen->search(MULTI_CHAR('tate_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Hylian Shield
-    mpScreen->search(MULTI_CHAR('tate_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Ordon Sword
-    mpScreen->search(MULTI_CHAR('ken_n0'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Master Sword
-    mpScreen->search(MULTI_CHAR('ken_n1'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // Bugs
-    mpScreen->search(MULTI_CHAR('kabu_6n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-
-    // "Collection" Text
-    mpScreen->search(MULTI_CHAR('t_t00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mpScreen->search(MULTI_CHAR('f_t00'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    // "Collection" Title Bar
+    mpScreen->search(MULTI_CHAR('title_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
     // "Save" Text
     mpScreen->search(MULTI_CHAR('sa_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
@@ -159,17 +110,36 @@ void dMenu_Collect2D_c::menuCollectWide() {
     // "Options" Text
     mpScreen->search(MULTI_CHAR('op_tex_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-    // Item Name Text
-    mpScreen->search(MULTI_CHAR('itemn_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    // Main Central Elements
+    mpScreen->search(MULTI_CHAR('menu_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    mpScreen->search(MULTI_CHAR('w_er_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    mpScreen->search(MULTI_CHAR('center_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
 
-    // Item Description Text
-    mpScreen->search(MULTI_CHAR('infotxtn'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    // Item Name/Description
+    f32 leftShift = 48.0f * (mDoGph_gInf_c::hudAspectScaleUp - 1.0f);  // Shifting certain items left to keep center (> 4:3 only)
+    J2DPane* info_n = mpScreen->search(MULTI_CHAR('info_n'));
+    static f32 infoTransX_orig = info_n->getTranslateX();
+    info_n->translate(infoTransX_orig - leftShift, info_n->getTranslateY()); // Move
 
-    #if TARGET_PC
-    if (mpDrawCursor) {
-        mpDrawCursor->refreshAspectScale();
-    }
-    #endif
+    // Designs
+    J2DPane* lavel_n = mpScreen->search(MULTI_CHAR('lavel_n'));
+    static f32 lavelTransX_orig = lavel_n->getTranslateX();
+    lavel_n->translate(lavelTransX_orig - leftShift, lavel_n->getTranslateY()); // Move
+
+    // Fused Shadow/Mirror Background
+    J2DPane* modelbgn = mpScreen->search(MULTI_CHAR('modelbgn'));
+    static f32 modelbgnTransX_orig = modelbgn->getTranslateX(); // Get pre-scale value
+    modelbgn->setBasePosition(J2DBasePosition_0);
+    modelbgn->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    f32 modelbgn_scaleFactor = 1.0f + 0.16f * (mDoGph_gInf_c::hudAspectScaleDown - 1.0f);
+    modelbgn->translate(modelbgnTransX_orig * modelbgn_scaleFactor, modelbgn->getTranslateY());  // Move
+
+    // Stretches the selection cursor to the aspect ratio, but this menu works at any aspect so this is un-needed? Looks bad on Ultrawide
+    // #if TARGET_PC
+    // if (mpDrawCursor) {
+    //     mpDrawCursor->refreshAspectScale();
+    // }
+    // #endif
 }
 #endif
 

--- a/src/d/d_menu_save.cpp
+++ b/src/d/d_menu_save.cpp
@@ -2817,7 +2817,7 @@ void dMenu_save_c::menuSaveWide() {
     
     #if TARGET_PC
     if (mSelIcon) {
-        mSelIcon->refreshAspectScale();
+        mSelIcon->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
     }
     #endif
 }

--- a/src/d/d_name.cpp
+++ b/src/d/d_name.cpp
@@ -1430,10 +1430,10 @@ void dName_c::selectCursorPosSet(int row) {
 
 #if TARGET_PC
 void dName_c::nameWide() {
-    //Resize Select Icon
+    // Resize Select Icon
     #if TARGET_PC
     if (mSelIcon) {
-        mSelIcon->refreshAspectScale();
+        mSelIcon->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
     }
     #endif
 

--- a/src/d/d_select_cursor.cpp
+++ b/src/d/d_select_cursor.cpp
@@ -577,7 +577,7 @@ void dSelect_cursor_c::moveCenter(J2DPane* i_pane, f32 i_x, f32 i_y) {
 }
 
 #ifdef TARGET_PC
-void dSelect_cursor_c::refreshAspectScale() {
-    mParam1 = mBaseParam1 * mDoGph_gInf_c::hudAspectScaleUp;
+void dSelect_cursor_c::refreshAspectScale(f32 param_0) {
+    mParam1 = mBaseParam1 * param_0;
 }
 #endif

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -176,6 +176,7 @@ namespace dusk::config {
     template class ConfigImpl<dusk::GameLanguage>;
     template class ConfigImpl<dusk::GyroMode>;
     template class ConfigImpl<dusk::FrameInterpMode>;
+    template class ConfigImpl<dusk::CollectionScreenScaling>;
     template class ConfigImpl<dusk::Resampler>;
 }
 

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -176,7 +176,7 @@ namespace dusk::config {
     template class ConfigImpl<dusk::GameLanguage>;
     template class ConfigImpl<dusk::GyroMode>;
     template class ConfigImpl<dusk::FrameInterpMode>;
-    template class ConfigImpl<dusk::CollectionScreenScaling>;
+    template class ConfigImpl<dusk::MenuScaling>;
     template class ConfigImpl<dusk::Resampler>;
 }
 

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -54,6 +54,7 @@ UserSettings g_userSettings = {
         .enableAchievementToasts {"game.enableAchievementToasts", true},
         .enableControllerToasts {"game.enableControllerToasts", true},
         .enableDiscordPresence {"game.enableDiscordPresence", true},
+        .collectionScalingMode {"game.collectionScalingMode", CollectionScreenScaling::Wii},
 
         // Graphics
         .bloomMode {"game.bloomMode", BloomMode::Dusk},
@@ -247,6 +248,7 @@ void registerSettings() {
     Register(g_userSettings.game.liveSplitEnabled);
     Register(g_userSettings.game.showSpeedrunRTATimer);
     Register(g_userSettings.game.recordingMode);
+    Register(g_userSettings.game.collectionScalingMode);
     Register(g_userSettings.game.removeQuestMapMarkers);
     Register(g_userSettings.game.showInputViewer);
     Register(g_userSettings.game.showInputViewerGyro);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -54,7 +54,7 @@ UserSettings g_userSettings = {
         .enableAchievementToasts {"game.enableAchievementToasts", true},
         .enableControllerToasts {"game.enableControllerToasts", true},
         .enableDiscordPresence {"game.enableDiscordPresence", true},
-        .collectionScalingMode {"game.collectionScalingMode", CollectionScreenScaling::Wii},
+        .menuScalingMode {"game.menuScalingMode", MenuScaling::Wii},
 
         // Graphics
         .bloomMode {"game.bloomMode", BloomMode::Dusk},
@@ -248,7 +248,7 @@ void registerSettings() {
     Register(g_userSettings.game.liveSplitEnabled);
     Register(g_userSettings.game.showSpeedrunRTATimer);
     Register(g_userSettings.game.recordingMode);
-    Register(g_userSettings.game.collectionScalingMode);
+    Register(g_userSettings.game.menuScalingMode);
     Register(g_userSettings.game.removeQuestMapMarkers);
     Register(g_userSettings.game.showInputViewer);
     Register(g_userSettings.game.showInputViewerGyro);

--- a/src/dusk/ui/preset.cpp
+++ b/src/dusk/ui/preset.cpp
@@ -19,7 +19,7 @@ void applyPresetClassic() {
     s.game.internalResolutionScale.setValue(1);
     s.game.shadowResolutionMultiplier.setValue(1);
     s.game.hideTvSettingsScreen.setValue(false);
-    s.game.collectionScalingMode.setValue(CollectionScreenScaling::GameCube);
+    s.game.menuScalingMode.setValue(MenuScaling::GameCube);
     AuroraSetViewportPolicy(AURORA_VIEWPORT_FIT);
 }
 
@@ -48,7 +48,7 @@ void applyPresetDusk() {
     s.game.shadowResolutionMultiplier.setValue(4);
     s.game.enableGyroAim.setValue(true);
     s.game.autoSave.setValue(true);
-    s.game.collectionScalingMode.setValue(CollectionScreenScaling::Dusklight);
+    s.game.menuScalingMode.setValue(MenuScaling::Dusklight);
 }
 
 }  // namespace

--- a/src/dusk/ui/preset.cpp
+++ b/src/dusk/ui/preset.cpp
@@ -19,6 +19,7 @@ void applyPresetClassic() {
     s.game.internalResolutionScale.setValue(1);
     s.game.shadowResolutionMultiplier.setValue(1);
     s.game.hideTvSettingsScreen.setValue(false);
+    s.game.collectionScalingMode.setValue(CollectionScreenScaling::GameCube);
     AuroraSetViewportPolicy(AURORA_VIEWPORT_FIT);
 }
 
@@ -47,6 +48,7 @@ void applyPresetDusk() {
     s.game.shadowResolutionMultiplier.setValue(4);
     s.game.enableGyroAim.setValue(true);
     s.game.autoSave.setValue(true);
+    s.game.collectionScalingMode.setValue(CollectionScreenScaling::Dusklight);
 }
 
 }  // namespace

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -70,7 +70,7 @@ constexpr std::array kGyroInputModeLabels = {
     "Mouse",
 };
 
-constexpr std::array kCollectionMenuModeLabels = {
+constexpr std::array kMenuScalingModeLabels = {
     "GameCube",
     "Wii",
     "Dusklight",
@@ -1424,45 +1424,46 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .helpText = "Show gyro sensor values in the input viewer.",
                 .isDisabled = [] { return !getSettings().game.showInputViewer; },
             });
-
+        #if TARGET_PC
         leftPane.add_section("Game");
         leftPane.register_control(
             leftPane.add_select_button({
-                .key = "Collection Menu Scaling",
+                .key = "Menu Scaling Mode",
                 .getValue =
                     [] {
-                        return kCollectionMenuModeLabels[static_cast<u8>(
-                            getSettings().game.collectionScalingMode.getValue())];
+                        return kMenuScalingModeLabels[static_cast<u8>(
+                            getSettings().game.menuScalingMode.getValue())];
                     },
                 .isModified =
                     [] {
-                        const auto& mode = getSettings().game.collectionScalingMode;
+                        const auto& mode = getSettings().game.menuScalingMode;
                         return mode.getValue() != mode.getDefaultValue();
                     },
             }),
             rightPane, [](Pane& pane) {
-                for (int i = 0; i < static_cast<int>(kCollectionMenuModeLabels.size()); ++i) {
+                for (int i = 0; i < static_cast<int>(kMenuScalingModeLabels.size()); ++i) {
                     pane
                         .add_button({
-                            .text = kCollectionMenuModeLabels[i],
+                            .text = kMenuScalingModeLabels[i],
                             .isSelected =
                                 [i] {
-                                    return getSettings().game.collectionScalingMode.getValue() ==
-                                           static_cast<CollectionScreenScaling>(i);
+                                    return getSettings().game.menuScalingMode.getValue() ==
+                                           static_cast<MenuScaling>(i);
                                     ;
                                 },
                         })
                         .on_pressed([i] {
                             mDoAud_seStartMenu(kSoundItemChange);
-                            getSettings().game.collectionScalingMode.setValue(
-                                static_cast<CollectionScreenScaling>(i));
+                            getSettings().game.menuScalingMode.setValue(
+                                static_cast<MenuScaling>(i));
                             ;
                             config::Save();
                         });
                 }
-                pane.add_rml("<br/>Changes how the Collection menu scales to your aspect ratio. "
-                             "Also affects the collection on the file select screen.");
+                pane.add_rml("<br/>Changes how the Collection and File Select menus scale to your "
+                             "aspect ratio.");
             });
+        #endif
         config_bool_select(leftPane, rightPane, getSettings().game.hideTvSettingsScreen,
             {
                 .key = "Skip TV Settings Screen",

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1424,7 +1424,6 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .helpText = "Show gyro sensor values in the input viewer.",
                 .isDisabled = [] { return !getSettings().game.showInputViewer; },
             });
-        #if TARGET_PC
         leftPane.add_section("Game");
         leftPane.register_control(
             leftPane.add_select_button({
@@ -1463,7 +1462,6 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 pane.add_rml("<br/>Changes how the Collection and File Select menus scale to your "
                              "aspect ratio.");
             });
-        #endif
         config_bool_select(leftPane, rightPane, getSettings().game.hideTvSettingsScreen,
             {
                 .key = "Skip TV Settings Screen",

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -70,6 +70,12 @@ constexpr std::array kGyroInputModeLabels = {
     "Mouse",
 };
 
+constexpr std::array kCollectionMenuModeLabels = {
+    "GameCube",
+    "Wii",
+    "Dusklight",
+};
+
 bool try_parse_backend(std::string_view backend, AuroraBackend& outBackend) {
     if (backend == "auto") {
         outBackend = BACKEND_AUTO;
@@ -1420,6 +1426,43 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             });
 
         leftPane.add_section("Game");
+        leftPane.register_control(
+            leftPane.add_select_button({
+                .key = "Collection Menu Scaling",
+                .getValue =
+                    [] {
+                        return kCollectionMenuModeLabels[static_cast<u8>(
+                            getSettings().game.collectionScalingMode.getValue())];
+                    },
+                .isModified =
+                    [] {
+                        const auto& mode = getSettings().game.collectionScalingMode;
+                        return mode.getValue() != mode.getDefaultValue();
+                    },
+            }),
+            rightPane, [](Pane& pane) {
+                for (int i = 0; i < static_cast<int>(kCollectionMenuModeLabels.size()); ++i) {
+                    pane
+                        .add_button({
+                            .text = kCollectionMenuModeLabels[i],
+                            .isSelected =
+                                [i] {
+                                    return getSettings().game.collectionScalingMode.getValue() ==
+                                           static_cast<CollectionScreenScaling>(i);
+                                    ;
+                                },
+                        })
+                        .on_pressed([i] {
+                            mDoAud_seStartMenu(kSoundItemChange);
+                            getSettings().game.collectionScalingMode.setValue(
+                                static_cast<CollectionScreenScaling>(i));
+                            ;
+                            config::Save();
+                        });
+                }
+                pane.add_rml("<br/>Changes how the Collection menu scales to your aspect ratio. "
+                             "Also affects the collection on the file select screen.");
+            });
         config_bool_select(leftPane, rightPane, getSettings().game.hideTvSettingsScreen,
             {
                 .key = "Skip TV Settings Screen",


### PR DESCRIPTION
The default behavior for these menus stretches the whole menu to fit your aspect ratio, as the Wii version does. Nothing particularly bothered me except the equipment slots in these menus. At 16:9 the stretch applied to them is okay, but 21:9 they just look a bit weird:


<img width="2560" height="1080" alt="defaultultracollect" src="https://github.com/user-attachments/assets/d5d3925b-6672-4fea-acdb-cd3fdad0c6d1" />
<img width="2560" height="1080" alt="ultradefault" src="https://github.com/user-attachments/assets/c64c016e-ebd5-4c60-8ccf-4795c3c88fdb" />


The File Select screen unfortunately stretches non-linearly, ~~or something along those lines. I couldn't figure out a way to consistently keep all the icons in the right spot above the background pane, so I just kept the default behaviour on that screen above 16:9/16:10.~~ However, most other ~~(non-ultrawide)~~ aspect ratios should work with these changes.


### **Before (Collection)**
<img width="1950" height="1440" alt="defaultcollect" src="https://github.com/user-attachments/assets/4e520322-6bf6-4196-af0d-940633710a1d" />
<img width="2560" height="1440" alt="defaultwidecollect" src="https://github.com/user-attachments/assets/7b3a65c3-d6d0-4767-9b30-41bf5f91407e" />


### **Before (File Select)**
<img width="1950" height="1440" alt="default" src="https://github.com/user-attachments/assets/65cbc764-776a-4ccf-b7a8-b0c6fa4b780d" />
<img width="2560" height="1440" alt="widedefault" src="https://github.com/user-attachments/assets/64ba094e-58e2-4cb3-8836-50d8f9451a9d" />


### **After (Collection)**
<img width="2560" height="1440" alt="widecollect" src="https://github.com/user-attachments/assets/4988afe7-0c08-4b44-bff8-55956aa50bee" />
<img width="2560" height="1080" alt="ultracollect" src="https://github.com/user-attachments/assets/b397d7e7-5525-4eaa-8bd5-59d9768d6501" />



### **After (File Select)**
<img width="2560" height="1440" alt="wide" src="https://github.com/user-attachments/assets/c7f4bfb7-a11a-43e4-a03d-e7be1da1c1bc" />
<img width="2560" height="1080" alt="ultra" src="https://github.com/user-attachments/assets/e6f45c65-83d3-4c80-9266-f60af4569353" />


~~Could maybe be made into a toggle like Stretch Collection screen or something, since the stretching *is* the intended Wii behavior, but I just modified the default behavior in my fork.~~ ✅