### PR TITLE
three heart challenge fix

### DIFF
--- a/src/dusk/achievements.cpp
+++ b/src/dusk/achievements.cpp
@@ -392,7 +392,7 @@ std::vector<AchievementSystem::Entry> AchievementSystem::makeEntries() {
                 false, 0, 0, false
             },
             [](Achievement& a, json&) {
-                if (daNpcF_chkEvtBit(0x1F9) && dComIfGs_getMaxLife() <= 15) {
+                if (daNpcF_chkEvtBit(0x1F9) && dComIfGs_getMaxLife() <= 19) {
                     a.progress = 1;
                 }
             },


### PR DESCRIPTION
checking for 19 health gives you 4 heart pieces and 3 heart containers, which does not affect gameplay