### PR TITLE
Feat: Added Touch Controls for both iOS and Android 

### DIFF
--- a/files.cmake
+++ b/files.cmake
@@ -1416,6 +1416,7 @@ set(DUSK_FILES
         include/dusk/config.hpp
         include/dusk/dvd_asset.hpp
         include/dusk/scope_guard.hpp
+        include/dusk/touch_controls.h
         src/dusk/dvd_asset.cpp
         src/d/actor/d_a_alink_dusk.cpp
         src/dusk/asserts.cpp
@@ -1440,6 +1441,7 @@ set(DUSK_FILES
         src/dusk/settings.cpp
         src/dusk/speedrun.cpp
         src/dusk/stubs.cpp
+        src/dusk/touch_controls.cpp
         src/dusk/update_check.cpp
         src/dusk/update_check.hpp
         #src/dusk/m_Do_ext_dusk.cpp

--- a/include/dusk/touch_controls.h
+++ b/include/dusk/touch_controls.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <dolphin/pad.h>
+
+union SDL_Event;
+
+namespace dusk::touch_controls {
+
+void handle_event(const SDL_Event& event) noexcept;
+void apply_pad_state(PADStatus& status, u32 port = PAD_CHAN0) noexcept;
+void apply_post_clamp_stick_state(PADStatus& status, u32 port = PAD_CHAN0) noexcept;
+void draw() noexcept;
+void reset() noexcept;
+bool enabled_for_port(u32 port) noexcept;
+void set_enabled_for_port(u32 port, bool enabled) noexcept;
+int stick_sensitivity_percent() noexcept;
+void set_stick_sensitivity_percent(int value) noexcept;
+const char* controller_name() noexcept;
+
+}  // namespace dusk::touch_controls

--- a/libs/JSystem/src/JUtility/JUTGamePad.cpp
+++ b/libs/JSystem/src/JUtility/JUTGamePad.cpp
@@ -6,6 +6,7 @@
 
 #if TARGET_PC
 #include "dusk/action_bindings.h"
+#include "dusk/touch_controls.h"
 #endif
 
 u32 JUTGamePad::CRumble::sChannelMask[4] = {
@@ -91,6 +92,10 @@ u32 JUTGamePad::read() {
     sRumbleSupported = PADRead(mPadStatus);
 #if TARGET_PC
    dusk::updateActionBindings();
+
+    for (u32 port = PAD_CHAN0; port < PAD_CHANMAX; ++port) {
+        dusk::touch_controls::apply_pad_state(mPadStatus[port], port);
+    }
 #endif
 
     switch (sClampMode) {
@@ -101,6 +106,12 @@ u32 JUTGamePad::read() {
         PADClampCircle(mPadStatus);
         break;
     }
+
+#if TARGET_PC
+    for (u32 port = PAD_CHAN0; port < PAD_CHANMAX; ++port) {
+        dusk::touch_controls::apply_post_clamp_stick_state(mPadStatus[port], port);
+    }
+#endif
 
     u32 bittest;
     u32 reset_mask = 0;

--- a/src/dusk/gyro.cpp
+++ b/src/dusk/gyro.cpp
@@ -1,10 +1,21 @@
 #include "dusk/gyro.h"
 #include "dusk/ui/ui.hpp"
+#include "dusk/touch_controls.h"
 #include "d/actor/d_a_alink.h"
 
 #include <aurora/lib/window.hpp>
+#include <SDL3/SDL_init.h>
 #include <SDL3/SDL_mouse.h>
+#include <SDL3/SDL_video.h>
 #include <cmath>
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+#if defined(TARGET_OS_IOS) && TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+#include <SDL3/SDL_sensor.h>
+#endif
 
 namespace dusk::gyro {
 namespace {
@@ -37,6 +48,130 @@ float s_roll_rad              = 0.0f;
 s32   s_rollgoal_ax           = 0;
 s32   s_rollgoal_az           = 0;
 
+#if defined(TARGET_OS_IOS) && TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+bool        s_device_sensors_scanned = false;
+SDL_Sensor* s_device_gyro            = nullptr;
+SDL_Sensor* s_device_accel           = nullptr;
+
+void close_device_sensors() {
+    if (s_device_gyro != nullptr) {
+        SDL_CloseSensor(s_device_gyro);
+        s_device_gyro = nullptr;
+    }
+    if (s_device_accel != nullptr) {
+        SDL_CloseSensor(s_device_accel);
+        s_device_accel = nullptr;
+    }
+    s_device_sensors_scanned = false;
+}
+
+SDL_Sensor* open_device_sensor(SDL_SensorType type) {
+    int count = 0;
+    SDL_SensorID* sensors = SDL_GetSensors(&count);
+    if (sensors == nullptr) {
+        return nullptr;
+    }
+
+    SDL_Sensor* selected = nullptr;
+    for (int i = 0; i < count; ++i) {
+        SDL_Sensor* sensor = SDL_OpenSensor(sensors[i]);
+        if (sensor == nullptr) {
+            continue;
+        }
+        if (SDL_GetSensorType(sensor) == type) {
+            selected = sensor;
+            break;
+        }
+        SDL_CloseSensor(sensor);
+    }
+
+    SDL_free(sensors);
+    return selected;
+}
+
+bool ensure_device_sensors() {
+    if (!dusk::touch_controls::enabled_for_port(PAD_CHAN0)) {
+        close_device_sensors();
+        return false;
+    }
+
+    if (!s_device_sensors_scanned) {
+        s_device_sensors_scanned = true;
+        if (!SDL_InitSubSystem(SDL_INIT_SENSOR)) {
+            return false;
+        }
+        s_device_gyro = open_device_sensor(SDL_SENSOR_GYRO);
+        s_device_accel = open_device_sensor(SDL_SENSOR_ACCEL);
+    }
+
+    return s_device_gyro != nullptr;
+}
+
+SDL_DisplayOrientation current_display_orientation() {
+    SDL_Window* window = aurora::window::get_sdl_window();
+    if (window == nullptr) {
+        return SDL_ORIENTATION_UNKNOWN;
+    }
+
+    const SDL_DisplayID display_id = SDL_GetDisplayForWindow(window);
+    if (display_id == 0) {
+        return SDL_ORIENTATION_UNKNOWN;
+    }
+
+    return SDL_GetCurrentDisplayOrientation(display_id);
+}
+
+void remap_ios_sensor_axes(float values[3]) {
+    const float x = values[0];
+    const float y = values[1];
+
+    switch (current_display_orientation()) {
+    case SDL_ORIENTATION_LANDSCAPE:
+        values[0] = -y;
+        values[1] = x;
+        break;
+    case SDL_ORIENTATION_LANDSCAPE_FLIPPED:
+        values[0] = y;
+        values[1] = -x;
+        break;
+    case SDL_ORIENTATION_PORTRAIT_FLIPPED:
+        values[0] = -x;
+        values[1] = -y;
+        break;
+    case SDL_ORIENTATION_PORTRAIT:
+    case SDL_ORIENTATION_UNKNOWN:
+    default:
+        break;
+    }
+}
+
+bool read_device_sensor(SDL_Sensor* sensor, float data[3]) {
+    if (sensor == nullptr) {
+        return false;
+    }
+
+    if (!SDL_GetSensorData(sensor, data, 3)) {
+        return false;
+    }
+
+    remap_ios_sensor_axes(data);
+    return true;
+}
+
+bool read_device_gyro(float gyro[3]) {
+    if (!ensure_device_sensors()) {
+        return false;
+    }
+
+    SDL_UpdateSensors();
+    return read_device_sensor(s_device_gyro, gyro);
+}
+
+bool read_device_accel(float accel[3]) {
+    return read_device_sensor(s_device_accel, accel);
+}
+#endif
+
 void reset_filter_state() {
     s_smooth_gx = s_smooth_gy = s_smooth_gz = 0.0f;
     s_gravity_y = s_gravity_z = 0.0f;
@@ -64,6 +199,9 @@ void disable_pad_sensors() {
         PADSetSensorEnabled(PAD_CHAN0, PAD_SENSOR_ACCEL, FALSE);
         s_accel_enabled = false;
     }
+#if defined(TARGET_OS_IOS) && TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+    close_device_sensors();
+#endif
 }
 }  // namespace
 
@@ -151,7 +289,21 @@ void read(float dt) {
         return;
     }
 
-    if (!s_sensor_enabled) {
+    f32 gyro[3] = {};
+    bool has_gyro = false;
+    bool has_accel = false;
+    bool using_device_gyro = false;
+    f32 accel[3] = {};
+
+#if defined(TARGET_OS_IOS) && TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+    if (read_device_gyro(gyro)) {
+        has_gyro = true;
+        using_device_gyro = true;
+        has_accel = read_device_accel(accel);
+    }
+#endif
+
+    if (!has_gyro && !s_sensor_enabled) {
         if (!PADHasSensor(PAD_CHAN0, PAD_SENSOR_GYRO)) {
             return;
         }
@@ -161,16 +313,20 @@ void read(float dt) {
         s_sensor_enabled = true;
     }
 
-    if (!s_accel_enabled && PADHasSensor(PAD_CHAN0, PAD_SENSOR_ACCEL) &&
+    if (!has_gyro && !s_accel_enabled && PADHasSensor(PAD_CHAN0, PAD_SENSOR_ACCEL) &&
         PADSetSensorEnabled(PAD_CHAN0, PAD_SENSOR_ACCEL, TRUE))
     {
         // We only need accel for the gravity-aware yaw/roll mix.
         s_accel_enabled = true;
     }
 
-    f32 gyro[3];
-    if (!PADGetSensorData(PAD_CHAN0, PAD_SENSOR_GYRO, gyro, 3)) {
+    if (!has_gyro && !PADGetSensorData(PAD_CHAN0, PAD_SENSOR_GYRO, gyro, 3)) {
         return;
+    }
+    has_gyro = true;
+
+    if (!has_accel && !using_device_gyro && s_accel_enabled) {
+        has_accel = PADGetSensorData(PAD_CHAN0, PAD_SENSOR_ACCEL, accel, 3);
     }
 
     const float smooth_alpha = kGyroEmaAlphaMax + getSettings().game.gyroSmoothing * (kGyroEmaAlphaMin - kGyroEmaAlphaMax);
@@ -188,38 +344,35 @@ void read(float dt) {
     s_roll_rad  = roll_rate * dt * getSettings().game.gyroSensitivityX; // GYRO NOTE: Exposing Z sensitivity seems unusual, so I'm just using X
 
     float horizontal_rate = yaw_rate;
-    if (aim_active && s_accel_enabled) {
-        f32 accel[3];
-        if (PADGetSensorData(PAD_CHAN0, PAD_SENSOR_ACCEL, accel, 3)) {
+    if (aim_active && has_accel) {
+        if (!s_have_gravity_baseline) {
+            s_gravity_y = accel[1];
+            s_gravity_z = accel[2];
+        } else {
+            s_gravity_y += kGravityEmaAlpha * (accel[1] - s_gravity_y);
+            s_gravity_z += kGravityEmaAlpha * (accel[2] - s_gravity_z);
+        }
+
+        // Compare the current gravity projection against the gravity vector from
+        // aim start so the user's resting hold angle becomes the neutral baseline.
+        const float gravity_yz_len = std::sqrt((s_gravity_y * s_gravity_y) + (s_gravity_z * s_gravity_z));
+        if (gravity_yz_len >= kMinGravityProjection) {
+            const float current_gravity_y = s_gravity_y / gravity_yz_len;
+            const float current_gravity_z = s_gravity_z / gravity_yz_len;
+
             if (!s_have_gravity_baseline) {
-                s_gravity_y = accel[1];
-                s_gravity_z = accel[2];
-            } else {
-                s_gravity_y += kGravityEmaAlpha * (accel[1] - s_gravity_y);
-                s_gravity_z += kGravityEmaAlpha * (accel[2] - s_gravity_z);
+                s_baseline_gravity_y = current_gravity_y;
+                s_baseline_gravity_z = current_gravity_z;
+                s_have_gravity_baseline = true;
             }
 
-            // Compare the current gravity projection against the gravity vector from
-            // aim start so the user's resting hold angle becomes the neutral baseline.
-            const float gravity_yz_len = std::sqrt((s_gravity_y * s_gravity_y) + (s_gravity_z * s_gravity_z));
-            if (gravity_yz_len >= kMinGravityProjection) {
-                const float current_gravity_y = s_gravity_y / gravity_yz_len;
-                const float current_gravity_z = s_gravity_z / gravity_yz_len;
-
-                if (!s_have_gravity_baseline) {
-                    s_baseline_gravity_y = current_gravity_y;
-                    s_baseline_gravity_z = current_gravity_z;
-                    s_have_gravity_baseline = true;
-                }
-
-                const float yaw_weight =
-                    (s_baseline_gravity_y * current_gravity_y) + (s_baseline_gravity_z * current_gravity_z);
-                const float roll_weight =
-                    (s_baseline_gravity_y * current_gravity_z) - (s_baseline_gravity_z * current_gravity_y);
-                const float roll_mix = std::fabs(roll_weight);
-                const float roll_boost = 1.0f + (roll_mix * (kRollAimBoostMax - 1.0f));
-                horizontal_rate = (yaw_rate * yaw_weight) + (roll_rate * roll_weight * roll_boost);
-            }
+            const float yaw_weight =
+                (s_baseline_gravity_y * current_gravity_y) + (s_baseline_gravity_z * current_gravity_z);
+            const float roll_weight =
+                (s_baseline_gravity_y * current_gravity_z) - (s_baseline_gravity_z * current_gravity_y);
+            const float roll_mix = std::fabs(roll_weight);
+            const float roll_boost = 1.0f + (roll_mix * (kRollAimBoostMax - 1.0f));
+            horizontal_rate = (yaw_rate * yaw_weight) + (roll_rate * roll_weight * roll_boost);
         }
     }
 

--- a/src/dusk/touch_controls.cpp
+++ b/src/dusk/touch_controls.cpp
@@ -1,0 +1,613 @@
+#include "dusk/touch_controls.h"
+
+#include <SDL3/SDL_events.h>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <system_error>
+
+#include "dusk/imgui/ImGuiEngine.hpp"
+#include "dusk/io.hpp"
+#include "dusk/main.h"
+#include "dusk/ui/ui.hpp"
+#include "imgui.h"
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+namespace dusk::touch_controls {
+namespace {
+
+constexpr float kStickRadius = 74.0f;
+constexpr float kButtonRadius = 34.0f;
+constexpr float kSmallButtonRadius = 25.0f;
+constexpr float kShoulderWidth = 118.0f;
+constexpr float kShoulderHeight = 44.0f;
+constexpr float kDeadZone = 0.12f;
+constexpr float kRunSnapThreshold = 0.16f;
+constexpr float kAlphaIdle = 0.34f;
+constexpr float kAlphaActive = 0.66f;
+constexpr int kDefaultStickSensitivityPercent = 500;
+constexpr int kMinStickSensitivityPercent = 50;
+constexpr int kMaxStickSensitivityPercent = 2000;
+constexpr std::uint32_t kSettingsMagic = 0x54434831;  // TCH1
+constexpr std::uint32_t kSettingsVersion = 1;
+constexpr auto kSettingsFileName = "touch_controls.dat";
+
+enum class Control {
+    None,
+    MainStick,
+    CStick,
+    DPad,
+    A,
+    B,
+    X,
+    Y,
+    L,
+    R,
+    Z,
+    Start,
+};
+
+struct FingerState {
+    SDL_FingerID id = 0;
+    Control control = Control::None;
+    ImVec2 start{};
+    ImVec2 current{};
+    bool active = false;
+};
+
+struct Layout {
+    ImVec2 display{};
+    float scale = 1.0f;
+    ImVec2 mainStick{};
+    ImVec2 cStick{};
+    ImVec2 dpad{};
+    ImVec2 a{};
+    ImVec2 b{};
+    ImVec2 x{};
+    ImVec2 y{};
+    ImVec2 lMin{};
+    ImVec2 lMax{};
+    ImVec2 rMin{};
+    ImVec2 rMax{};
+    ImVec2 z{};
+    ImVec2 start{};
+};
+
+std::array<FingerState, 10> sFingers;
+std::array<bool, PAD_MAX_CONTROLLERS> sEnabledPorts{};
+bool sSettingsLoaded = false;
+int sStickSensitivityPercent = kDefaultStickSensitivityPercent;
+
+bool defaults_enable_touch_controls() noexcept {
+#if defined(__APPLE__) && TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+    return true;
+#else
+    return false;
+#endif
+}
+
+void apply_default_settings() noexcept {
+    sEnabledPorts.fill(false);
+    sEnabledPorts[PAD_CHAN0] = defaults_enable_touch_controls();
+    sStickSensitivityPercent = kDefaultStickSensitivityPercent;
+}
+
+float scaled(float value, const Layout& layout) noexcept {
+    return value * layout.scale;
+}
+
+float distance(ImVec2 a, ImVec2 b) noexcept {
+    const float dx = a.x - b.x;
+    const float dy = a.y - b.y;
+    return std::sqrt(dx * dx + dy * dy);
+}
+
+ImVec2 clamp_vector(ImVec2 value, float radius) noexcept {
+    const float length = std::sqrt(value.x * value.x + value.y * value.y);
+    if (length <= radius || length <= 0.0f) {
+        return value;
+    }
+    const float scale = radius / length;
+    return ImVec2(value.x * scale, value.y * scale);
+}
+
+std::filesystem::path settings_path() {
+    if (dusk::ConfigPath.empty()) {
+        return {};
+    }
+    return dusk::ConfigPath / kSettingsFileName;
+}
+
+void save_settings() noexcept;
+
+void load_settings() noexcept {
+    if (sSettingsLoaded) {
+        return;
+    }
+
+    sSettingsLoaded = true;
+    apply_default_settings();
+
+    const auto path = settings_path();
+    std::error_code ec;
+    if (path.empty() || !std::filesystem::exists(path, ec)) {
+        if (defaults_enable_touch_controls()) {
+            save_settings();
+        }
+        return;
+    }
+
+    try {
+        auto bytes = dusk::io::FileStream::ReadAllBytes(path);
+        if (bytes.size() < 8) {
+            return;
+        }
+
+        const auto read_u32 = [&bytes](std::size_t offset) {
+            return static_cast<std::uint32_t>(bytes[offset]) |
+                   (static_cast<std::uint32_t>(bytes[offset + 1]) << 8) |
+                   (static_cast<std::uint32_t>(bytes[offset + 2]) << 16) |
+                   (static_cast<std::uint32_t>(bytes[offset + 3]) << 24);
+        };
+
+        if (read_u32(0) != kSettingsMagic || read_u32(4) != kSettingsVersion) {
+            return;
+        }
+
+        for (std::size_t i = 0; i < sEnabledPorts.size(); ++i) {
+            const std::size_t offset = 8 + i;
+            sEnabledPorts[i] = offset < bytes.size() && bytes[offset] != 0;
+        }
+        if (bytes.size() >= 14) {
+            const int sensitivity = static_cast<int>(bytes[12]) |
+                                    (static_cast<int>(bytes[13]) << 8);
+            sStickSensitivityPercent = std::clamp(
+                sensitivity, kMinStickSensitivityPercent, kMaxStickSensitivityPercent);
+        }
+    } catch (...) {
+        apply_default_settings();
+        if (defaults_enable_touch_controls()) {
+            save_settings();
+        }
+    }
+}
+
+void save_settings() noexcept {
+    const auto path = settings_path();
+    if (path.empty()) {
+        return;
+    }
+
+    try {
+        std::error_code ec;
+        std::filesystem::create_directories(path.parent_path(), ec);
+        std::array<std::uint8_t, 14> bytes{};
+        const auto write_u32 = [&bytes](std::size_t offset, std::uint32_t value) {
+            bytes[offset] = static_cast<std::uint8_t>(value & 0xff);
+            bytes[offset + 1] = static_cast<std::uint8_t>((value >> 8) & 0xff);
+            bytes[offset + 2] = static_cast<std::uint8_t>((value >> 16) & 0xff);
+            bytes[offset + 3] = static_cast<std::uint8_t>((value >> 24) & 0xff);
+        };
+        write_u32(0, kSettingsMagic);
+        write_u32(4, kSettingsVersion);
+        for (std::size_t i = 0; i < sEnabledPorts.size(); ++i) {
+            bytes[8 + i] = sEnabledPorts[i] ? 1 : 0;
+        }
+        const auto sensitivity = static_cast<std::uint16_t>(std::clamp(
+            sStickSensitivityPercent, kMinStickSensitivityPercent, kMaxStickSensitivityPercent));
+        bytes[12] = static_cast<std::uint8_t>(sensitivity & 0xff);
+        bytes[13] = static_cast<std::uint8_t>((sensitivity >> 8) & 0xff);
+        auto stream = dusk::io::FileStream::Create(path);
+        stream.Write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    } catch (...) {
+    }
+}
+
+Layout make_layout() noexcept {
+    if (ImGui::GetCurrentContext() == nullptr) {
+        return {};
+    }
+
+    const ImGuiIO& io = ImGui::GetIO();
+    Layout layout{};
+    layout.display = io.DisplaySize;
+    layout.scale = std::clamp(std::min(layout.display.x / 844.0f, layout.display.y / 390.0f), 0.72f, 1.35f);
+
+    const float safeBottom = ImGui::GetStyle().DisplaySafeAreaPadding.y;
+    const float bottom = layout.display.y - std::max(safeBottom, scaled(26.0f, layout));
+    const float left = scaled(112.0f, layout);
+    const float right = layout.display.x - scaled(118.0f, layout);
+
+    layout.mainStick = ImVec2(left, bottom - scaled(82.0f, layout));
+    layout.dpad = ImVec2(left + scaled(150.0f, layout), bottom - scaled(62.0f, layout));
+    layout.cStick = ImVec2(right - scaled(170.0f, layout), bottom - scaled(58.0f, layout));
+
+    layout.a = ImVec2(right, bottom - scaled(108.0f, layout));
+    layout.b = ImVec2(right - scaled(78.0f, layout), bottom - scaled(60.0f, layout));
+    layout.x = ImVec2(right + scaled(74.0f, layout), bottom - scaled(108.0f, layout));
+    layout.y = ImVec2(right - scaled(6.0f, layout), bottom - scaled(182.0f, layout));
+
+    layout.lMin = ImVec2(scaled(18.0f, layout), scaled(18.0f, layout));
+    layout.lMax = ImVec2(layout.lMin.x + scaled(kShoulderWidth, layout), layout.lMin.y + scaled(kShoulderHeight, layout));
+    layout.rMax = ImVec2(layout.display.x - scaled(18.0f, layout), scaled(18.0f, layout) + scaled(kShoulderHeight, layout));
+    layout.rMin = ImVec2(layout.rMax.x - scaled(kShoulderWidth, layout), scaled(18.0f, layout));
+    layout.z = ImVec2(layout.display.x - scaled(204.0f, layout), scaled(41.0f, layout));
+    layout.start = ImVec2(layout.display.x * 0.5f, bottom - scaled(30.0f, layout));
+    return layout;
+}
+
+ImVec2 event_position(const SDL_TouchFingerEvent& event) noexcept {
+    const ImVec2 display = ImGui::GetIO().DisplaySize;
+    return ImVec2(event.x * display.x, event.y * display.y);
+}
+
+bool in_rect(ImVec2 pos, ImVec2 min, ImVec2 max) noexcept {
+    return pos.x >= min.x && pos.x <= max.x && pos.y >= min.y && pos.y <= max.y;
+}
+
+Control hit_test(ImVec2 pos, const Layout& layout) noexcept {
+    if (in_rect(pos, layout.lMin, layout.lMax)) {
+        return Control::L;
+    }
+    if (in_rect(pos, layout.rMin, layout.rMax)) {
+        return Control::R;
+    }
+    if (distance(pos, layout.z) <= scaled(kSmallButtonRadius, layout)) {
+        return Control::Z;
+    }
+    if (distance(pos, layout.start) <= scaled(kSmallButtonRadius, layout)) {
+        return Control::Start;
+    }
+    if (distance(pos, layout.mainStick) <= scaled(kStickRadius * 1.25f, layout)) {
+        return Control::MainStick;
+    }
+    if (distance(pos, layout.cStick) <= scaled(kStickRadius, layout)) {
+        return Control::CStick;
+    }
+    if (distance(pos, layout.dpad) <= scaled(56.0f, layout)) {
+        return Control::DPad;
+    }
+    if (distance(pos, layout.a) <= scaled(kButtonRadius * 1.25f, layout)) {
+        return Control::A;
+    }
+    if (distance(pos, layout.b) <= scaled(kButtonRadius, layout)) {
+        return Control::B;
+    }
+    if (distance(pos, layout.x) <= scaled(kButtonRadius, layout)) {
+        return Control::X;
+    }
+    if (distance(pos, layout.y) <= scaled(kButtonRadius, layout)) {
+        return Control::Y;
+    }
+    return Control::None;
+}
+
+FingerState* find_finger(SDL_FingerID id) noexcept {
+    for (auto& finger : sFingers) {
+        if (finger.active && finger.id == id) {
+            return &finger;
+        }
+    }
+    return nullptr;
+}
+
+FingerState* free_finger() noexcept {
+    for (auto& finger : sFingers) {
+        if (!finger.active) {
+            return &finger;
+        }
+    }
+    return nullptr;
+}
+
+bool control_held(Control control) noexcept {
+    return std::any_of(sFingers.begin(), sFingers.end(), [control](const FingerState& finger) {
+        return finger.active && finger.control == control;
+    });
+}
+
+ImVec2 stick_value(Control control, const Layout& layout) noexcept {
+    for (const auto& finger : sFingers) {
+        if (!finger.active || finger.control != control) {
+            continue;
+        }
+
+        const ImVec2 layoutCenter = control == Control::MainStick ? layout.mainStick : layout.cStick;
+        const ImVec2 center = finger.start;
+        const float sensitivityScale = 100.0f / static_cast<float>(stick_sensitivity_percent());
+        const float fullTiltRadius = scaled(kStickRadius * std::clamp(sensitivityScale, 0.05f, 1.20f), layout);
+        ImVec2 value = clamp_vector(ImVec2(finger.current.x - center.x, finger.current.y - center.y),
+            fullTiltRadius);
+        value.x /= fullTiltRadius;
+        value.y /= fullTiltRadius;
+        if (std::sqrt(value.x * value.x + value.y * value.y) < kDeadZone) {
+            return ImVec2(0.0f, 0.0f);
+        }
+        if (distance(finger.start, layoutCenter) <= scaled(kStickRadius * 0.35f, layout) &&
+            distance(finger.current, layoutCenter) > scaled(kStickRadius * 0.35f, layout))
+        {
+            value = clamp_vector(ImVec2(finger.current.x - layoutCenter.x, finger.current.y - layoutCenter.y),
+                fullTiltRadius);
+            value.x /= fullTiltRadius;
+            value.y /= fullTiltRadius;
+        }
+        const float magnitude = std::sqrt(value.x * value.x + value.y * value.y);
+        if (control == Control::MainStick && magnitude >= kRunSnapThreshold) {
+            value.x /= magnitude;
+            value.y /= magnitude;
+        }
+        return value;
+    }
+    return ImVec2(0.0f, 0.0f);
+}
+
+ImVec2 dpad_value(const Layout& layout) noexcept {
+    for (const auto& finger : sFingers) {
+        if (!finger.active || finger.control != Control::DPad) {
+            continue;
+        }
+
+        ImVec2 value = ImVec2(finger.current.x - layout.dpad.x, finger.current.y - layout.dpad.y);
+        const float absX = std::abs(value.x);
+        const float absY = std::abs(value.y);
+        if (std::max(absX, absY) < scaled(14.0f, layout)) {
+            return ImVec2(0.0f, 0.0f);
+        }
+        if (absX > absY) {
+            return ImVec2(value.x > 0.0f ? 1.0f : -1.0f, 0.0f);
+        }
+        return ImVec2(0.0f, value.y > 0.0f ? 1.0f : -1.0f);
+    }
+    return ImVec2(0.0f, 0.0f);
+}
+
+s8 axis_to_pad(float value) noexcept {
+    return static_cast<s8>(std::clamp(std::lround(value * 127.0f), -127l, 127l));
+}
+
+s8 axis_to_post_clamp_pad(float value, long max) noexcept {
+    return static_cast<s8>(std::clamp(std::lround(value * static_cast<float>(max)), -max, max));
+}
+
+void draw_circle_button(ImDrawList* drawList, ImVec2 center, float radius, const char* label, bool active, const Layout& layout) noexcept {
+    const ImU32 fill = ImGui::GetColorU32(ImVec4(0.05f, 0.06f, 0.07f, active ? kAlphaActive : kAlphaIdle));
+    const ImU32 edge = ImGui::GetColorU32(ImVec4(0.95f, 0.97f, 1.0f, active ? 0.82f : 0.46f));
+    drawList->AddCircleFilled(center, scaled(radius, layout), fill, 40);
+    drawList->AddCircle(center, scaled(radius, layout), edge, 40, scaled(2.0f, layout));
+    const ImVec2 textSize = ImGui::CalcTextSize(label);
+    drawList->AddText(ImVec2(center.x - textSize.x * 0.5f, center.y - textSize.y * 0.5f), edge, label);
+}
+
+void draw_stick(ImDrawList* drawList, ImVec2 center, Control control, const Layout& layout) noexcept {
+    const bool active = control_held(control);
+    const ImVec2 value = stick_value(control, layout);
+    const ImVec2 knob(center.x + value.x * scaled(kStickRadius * 0.55f, layout),
+        center.y + value.y * scaled(kStickRadius * 0.55f, layout));
+    const ImU32 fill = ImGui::GetColorU32(ImVec4(0.02f, 0.03f, 0.035f, active ? 0.50f : 0.26f));
+    const ImU32 edge = ImGui::GetColorU32(ImVec4(0.95f, 0.97f, 1.0f, active ? 0.72f : 0.36f));
+    drawList->AddCircleFilled(center, scaled(kStickRadius, layout), fill, 48);
+    drawList->AddCircle(center, scaled(kStickRadius, layout), edge, 48, scaled(2.0f, layout));
+    drawList->AddCircleFilled(knob, scaled(28.0f, layout), ImGui::GetColorU32(ImVec4(0.9f, 0.92f, 0.96f, active ? 0.46f : 0.24f)), 32);
+}
+
+void draw_dpad(ImDrawList* drawList, const Layout& layout) noexcept {
+    const bool active = control_held(Control::DPad);
+    const ImU32 fill = ImGui::GetColorU32(ImVec4(0.04f, 0.05f, 0.06f, active ? 0.58f : 0.30f));
+    const ImU32 edge = ImGui::GetColorU32(ImVec4(0.95f, 0.97f, 1.0f, active ? 0.75f : 0.38f));
+    const float arm = scaled(22.0f, layout);
+    const float len = scaled(58.0f, layout);
+    const ImVec2 c = layout.dpad;
+    drawList->AddRectFilled(ImVec2(c.x - arm, c.y - len), ImVec2(c.x + arm, c.y + len), fill, scaled(8.0f, layout));
+    drawList->AddRectFilled(ImVec2(c.x - len, c.y - arm), ImVec2(c.x + len, c.y + arm), fill, scaled(8.0f, layout));
+    drawList->AddRect(ImVec2(c.x - arm, c.y - len), ImVec2(c.x + arm, c.y + len), edge, scaled(8.0f, layout), 0, scaled(2.0f, layout));
+    drawList->AddRect(ImVec2(c.x - len, c.y - arm), ImVec2(c.x + len, c.y + arm), edge, scaled(8.0f, layout), 0, scaled(2.0f, layout));
+}
+
+void draw_shoulder(ImDrawList* drawList, ImVec2 min, ImVec2 max, const char* label, bool active, const Layout& layout) noexcept {
+    const ImU32 fill = ImGui::GetColorU32(ImVec4(0.04f, 0.05f, 0.06f, active ? 0.58f : 0.28f));
+    const ImU32 edge = ImGui::GetColorU32(ImVec4(0.95f, 0.97f, 1.0f, active ? 0.78f : 0.40f));
+    drawList->AddRectFilled(min, max, fill, scaled(14.0f, layout));
+    drawList->AddRect(min, max, edge, scaled(14.0f, layout), 0, scaled(2.0f, layout));
+    const ImVec2 textSize = ImGui::CalcTextSize(label);
+    drawList->AddText(ImVec2((min.x + max.x - textSize.x) * 0.5f, (min.y + max.y - textSize.y) * 0.5f), edge, label);
+}
+
+}  // namespace
+
+void handle_event(const SDL_Event& event) noexcept {
+    if (!enabled_for_port(PAD_CHAN0)) {
+        reset();
+        return;
+    }
+
+    if (!dusk::IsGameLaunched || dusk::ui::any_document_visible() ||
+        ImGui::GetCurrentContext() == nullptr)
+    {
+        reset();
+        return;
+    }
+
+    switch (event.type) {
+    case SDL_EVENT_FINGER_DOWN: {
+        const Layout layout = make_layout();
+        const ImVec2 position = event_position(event.tfinger);
+        const Control control = hit_test(position, layout);
+        if (control == Control::None) {
+            return;
+        }
+
+        if (auto* finger = free_finger()) {
+            *finger = FingerState{
+                .id = event.tfinger.fingerID,
+                .control = control,
+                .start = position,
+                .current = position,
+                .active = true,
+            };
+        }
+        break;
+    }
+    case SDL_EVENT_FINGER_MOTION:
+        if (auto* finger = find_finger(event.tfinger.fingerID)) {
+            finger->current = event_position(event.tfinger);
+        }
+        break;
+    case SDL_EVENT_FINGER_UP:
+    case SDL_EVENT_FINGER_CANCELED:
+        if (auto* finger = find_finger(event.tfinger.fingerID)) {
+            *finger = {};
+        }
+        break;
+    case SDL_EVENT_WINDOW_FOCUS_LOST:
+        reset();
+        break;
+    default:
+        break;
+    }
+}
+
+void apply_pad_state(PADStatus& status, u32 port) noexcept {
+    if (!enabled_for_port(port)) {
+        return;
+    }
+
+    if (!dusk::IsGameLaunched || ImGui::GetCurrentContext() == nullptr) {
+        return;
+    }
+
+    const Layout layout = make_layout();
+    const ImVec2 mainStick = stick_value(Control::MainStick, layout);
+    const ImVec2 cStick = stick_value(Control::CStick, layout);
+    const ImVec2 dpad = dpad_value(layout);
+
+    status.err = PAD_ERR_NONE;
+    status.button |= control_held(Control::A) ? PAD_BUTTON_A : 0;
+    status.button |= control_held(Control::B) ? PAD_BUTTON_B : 0;
+    status.button |= control_held(Control::X) ? PAD_BUTTON_X : 0;
+    status.button |= control_held(Control::Y) ? PAD_BUTTON_Y : 0;
+    status.button |= control_held(Control::Z) ? PAD_TRIGGER_Z : 0;
+    status.button |= control_held(Control::Start) ? PAD_BUTTON_START : 0;
+    status.button |= dpad.x < 0.0f ? PAD_BUTTON_LEFT : 0;
+    status.button |= dpad.x > 0.0f ? PAD_BUTTON_RIGHT : 0;
+    status.button |= dpad.y < 0.0f ? PAD_BUTTON_UP : 0;
+    status.button |= dpad.y > 0.0f ? PAD_BUTTON_DOWN : 0;
+
+    if (control_held(Control::L)) {
+        status.button |= PAD_TRIGGER_L;
+        status.triggerLeft = 255;
+    }
+    if (control_held(Control::R)) {
+        status.button |= PAD_TRIGGER_R;
+        status.triggerRight = 255;
+    }
+
+    if (control_held(Control::MainStick)) {
+        status.stickX = axis_to_pad(mainStick.x);
+        status.stickY = axis_to_pad(-mainStick.y);
+    }
+    if (control_held(Control::CStick)) {
+        status.substickX = axis_to_pad(cStick.x);
+        status.substickY = axis_to_pad(-cStick.y);
+    }
+}
+
+void apply_post_clamp_stick_state(PADStatus& status, u32 port) noexcept {
+    if (!enabled_for_port(port)) {
+        return;
+    }
+
+    if (!dusk::IsGameLaunched || ImGui::GetCurrentContext() == nullptr || status.err != PAD_ERR_NONE) {
+        return;
+    }
+
+    const Layout layout = make_layout();
+    if (control_held(Control::MainStick)) {
+        const ImVec2 mainStick = stick_value(Control::MainStick, layout);
+        status.stickX = axis_to_post_clamp_pad(mainStick.x, 72);
+        status.stickY = axis_to_post_clamp_pad(-mainStick.y, 72);
+    }
+    if (control_held(Control::CStick)) {
+        const ImVec2 cStick = stick_value(Control::CStick, layout);
+        status.substickX = axis_to_post_clamp_pad(cStick.x, 59);
+        status.substickY = axis_to_post_clamp_pad(-cStick.y, 59);
+    }
+}
+
+void draw() noexcept {
+    if (!enabled_for_port(PAD_CHAN0)) {
+        return;
+    }
+
+    if (!dusk::IsGameLaunched || dusk::ui::any_document_visible() ||
+        ImGui::GetCurrentContext() == nullptr)
+    {
+        return;
+    }
+
+    const Layout layout = make_layout();
+    ImDrawList* drawList = ImGui::GetForegroundDrawList();
+    draw_stick(drawList, layout.mainStick, Control::MainStick, layout);
+    draw_dpad(drawList, layout);
+    draw_stick(drawList, layout.cStick, Control::CStick, layout);
+    draw_circle_button(drawList, layout.a, kButtonRadius * 1.18f, "A", control_held(Control::A), layout);
+    draw_circle_button(drawList, layout.b, kButtonRadius, "B", control_held(Control::B), layout);
+    draw_circle_button(drawList, layout.x, kButtonRadius, "X", control_held(Control::X), layout);
+    draw_circle_button(drawList, layout.y, kButtonRadius, "Y", control_held(Control::Y), layout);
+    draw_circle_button(drawList, layout.z, kSmallButtonRadius, "Z", control_held(Control::Z), layout);
+    draw_circle_button(drawList, layout.start, kSmallButtonRadius, "S", control_held(Control::Start), layout);
+    draw_shoulder(drawList, layout.lMin, layout.lMax, "L", control_held(Control::L), layout);
+    draw_shoulder(drawList, layout.rMin, layout.rMax, "R", control_held(Control::R), layout);
+}
+
+void reset() noexcept {
+    for (auto& finger : sFingers) {
+        finger = {};
+    }
+}
+
+bool enabled_for_port(u32 port) noexcept {
+    if (port >= sEnabledPorts.size()) {
+        return false;
+    }
+    load_settings();
+    return sEnabledPorts[port];
+}
+
+void set_enabled_for_port(u32 port, bool enabled) noexcept {
+    if (port >= sEnabledPorts.size()) {
+        return;
+    }
+
+    load_settings();
+    if (enabled) {
+        sEnabledPorts.fill(false);
+    }
+    sEnabledPorts[port] = enabled;
+    if (!enabled) {
+        reset();
+    }
+    save_settings();
+}
+
+int stick_sensitivity_percent() noexcept {
+    load_settings();
+    return sStickSensitivityPercent;
+}
+
+void set_stick_sensitivity_percent(int value) noexcept {
+    load_settings();
+    sStickSensitivityPercent = std::clamp(
+        value, kMinStickSensitivityPercent, kMaxStickSensitivityPercent);
+    save_settings();
+}
+
+const char* controller_name() noexcept {
+    return "Touch Controls";
+}
+
+}  // namespace dusk::touch_controls

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -17,6 +17,12 @@
 
 #include "dusk/action_bindings.h"
 #include "dusk/config.hpp"
+#include "dusk/settings.h"
+#include "dusk/touch_controls.h"
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
 
 namespace dusk::ui {
 namespace {
@@ -26,10 +32,36 @@ bool keyboard_active(int port) {
     return PADGetKeyButtonBindings(static_cast<u32>(port), &count) != nullptr;
 }
 
+bool touch_active(int port) {
+    return dusk::touch_controls::enabled_for_port(static_cast<u32>(port));
+}
+
+void set_touch_active(int port, bool active) {
+    dusk::touch_controls::set_enabled_for_port(static_cast<u32>(port), active);
+#if defined(__APPLE__) && TARGET_OS_IOS && !TARGET_OS_MACCATALYST
+    if (active) {
+        dusk::getSettings().game.gyroMode.setValue(GyroMode::Sensor);
+        dusk::getSettings().game.enableGyroAim.setValue(true);
+        config::Save();
+    }
+#endif
+}
+
+int touch_stick_sensitivity_percent() {
+    return dusk::touch_controls::stick_sensitivity_percent();
+}
+
+void set_touch_stick_sensitivity_percent(int value) {
+    dusk::touch_controls::set_stick_sensitivity_percent(value);
+}
+
 Rml::String current_controller_name(int port) {
     const char* name = PADGetName(port);
     if (name != nullptr) {
         return name;
+    }
+    if (touch_active(port)) {
+        return dusk::touch_controls::controller_name();
     }
     return keyboard_active(port) ? "Keyboard" : "None";
 }
@@ -357,6 +389,21 @@ void ControllerConfigWindow::build_port_tab(Rml::Element* content, int port) {
                 pane.clear();
                 pane.add_text("Restores all binding configurations for the currently selected device to their defaults.");
         });
+
+    leftPane.register_control(leftPane.add_child<NumberButton>(NumberButton::Props{
+                                  .key = "Touch Stick Sensitivity",
+                                  .getValue = [] { return touch_stick_sensitivity_percent(); },
+                                  .setValue = [](int value) { set_touch_stick_sensitivity_percent(value); },
+                                  .isDisabled = [port] { return !touch_active(port); },
+                                  .min = 50,
+                                  .max = 2000,
+                                  .step = 50,
+                                  .suffix = "%",
+                              }),
+        rightPane, [](Pane& pane) {
+            pane.add_text("Adjust how quickly the touch sticks reach full tilt.");
+        });
+
     render_page(rightPane, port, mPage);
 }
 
@@ -369,13 +416,31 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                 {
                     .text = "None",
                 .isSelected =
-                    [port] { return PADGetIndexForPort(port) < 0 && !keyboard_active(port); },
+                    [port] {
+                        return PADGetIndexForPort(port) < 0 && !keyboard_active(port) &&
+                               !touch_active(port);
+                    },
             })
             .on_pressed([this, port] {
                 mDoAud_seStartMenu(kSoundClick);
                 cancel_pending_binding();
                 PADClearPort(port);
                 PADSetKeyboardActive(static_cast<u32>(port), FALSE);
+                set_touch_active(port, false);
+                PADSerializeMappings();
+                ClearAllActionBindings(port);
+            });
+
+        pane.add_button({
+                            .text = "Touch Controls",
+                            .isSelected = [port] { return touch_active(port); },
+                        })
+            .on_pressed([this, port] {
+                mDoAud_seStartMenu(kSoundItemChange);
+                cancel_pending_binding();
+                PADClearPort(port);
+                PADSetKeyboardActive(static_cast<u32>(port), FALSE);
+                set_touch_active(port, true);
                 PADSerializeMappings();
                 ClearAllActionBindings(port);
             });
@@ -389,6 +454,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                 cancel_pending_binding();
                 PADClearPort(port);
                 PADSetKeyboardActive(static_cast<u32>(port), TRUE);
+                set_touch_active(port, false);
                 PADSerializeMappings();
                 ClearAllActionBindings(port);
             });
@@ -410,6 +476,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                     mDoAud_seStartMenu(kSoundClick);
                     cancel_pending_binding();
                     PADSetKeyboardActive(static_cast<u32>(port), FALSE);
+                    set_touch_active(port, false);
                     PADSetPortForIndex(i, port);
                     PADSerializeMappings();
                     ClearAllActionBindings(port);

--- a/src/dusk/ui/overlay.cpp
+++ b/src/dusk/ui/overlay.cpp
@@ -367,6 +367,7 @@ void Overlay::update() {
     u32 count = 0;
     const bool showControllerWarning = PADGetIndexForPort(PAD_CHAN0) < 0 &&
                                        PADGetKeyButtonBindings(PAD_CHAN0, &count) == nullptr &&
+                                       !touch_controller_active() &&
                                        dynamic_cast<Window*>(top_document()) == nullptr &&
                                        dynamic_cast<WindowSmall*>(top_document()) == nullptr;
     if (showControllerWarning && mControllerWarning == nullptr) {

--- a/src/dusk/ui/overlay.cpp
+++ b/src/dusk/ui/overlay.cpp
@@ -3,6 +3,7 @@
 #include "aurora/lib/logging.hpp"
 #include "dusk/achievements.h"
 #include "dusk/action_bindings.h"
+#include "dusk/touch_controls.h"
 #include "controller_config.hpp"
 #include "dusk/livesplit.h"
 #include "dusk/speedrun.h"
@@ -144,11 +145,20 @@ Rml::String back_button_name() {
     return "Back";
 }
 
+bool touch_controller_active() noexcept {
+    return dusk::touch_controls::enabled_for_port(PAD_CHAN0);
+}
+
+const char* menu_notification_prefix() noexcept {
+    if (touch_controller_active()) {
+        return "3-finger tap or";
+    }
 #if defined(TARGET_ANDROID) || (defined(__APPLE__) && TARGET_OS_IOS && !TARGET_OS_MACCATALYST)
-constexpr auto kMenuNotificationPrefix = "3-finger tap or";
+    return "3-finger tap or";
 #else
-constexpr auto kMenuNotificationPrefix = "Press <b>F1</b> or";
+    return "Press <b>F1</b> or";
 #endif
+}
 
 Rml::Element* create_menu_notification(Rml::Element* parent) {
     auto* elem = append(parent, "toast");
@@ -166,7 +176,7 @@ Rml::Element* create_menu_notification(Rml::Element* parent) {
 
     auto* message = append(elem, "message");
     auto* row = append(message, "row");
-    append(row, "span")->SetInnerRML(kMenuNotificationPrefix);
+    append(row, "span")->SetInnerRML(menu_notification_prefix());
     auto* icon = append(row, "icon");
     icon->SetClass("controller", true);
     append(row, "span")->SetInnerRML("<b>" + escape(padButton) + "</b>");

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -972,7 +972,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                         });
                 }
                 pane.add_rml(
-                    "<br/><b>Sensor</b> reads motion directly from a supported controller's gyro via SDL.<br/>"
+                    "<br/><b>Sensor</b> reads motion directly from a supported controller or device gyro via SDL.<br/>"
                     "<br/><b>Mouse</b> treats mouse input as gyro, intended for use with the Steam Deck.<br/>"
                     "<br/>Mouse input cannot currently be used with Gyro Rollgoal.");
             });

--- a/src/dusk/ui/ui.cpp
+++ b/src/dusk/ui/ui.cpp
@@ -12,6 +12,7 @@
 
 #include "aurora/lib/window.hpp"
 #include "dusk/io.hpp"
+#include "dusk/touch_controls.h"
 #include "input.hpp"
 #include "prelaunch.hpp"
 #include "window.hpp"
@@ -120,6 +121,8 @@ const char* connection_state_icon(SDL_JoystickConnectionState state) noexcept {
 }
 
 void handle_event(const SDL_Event& event) noexcept {
+    dusk::touch_controls::handle_event(event);
+
     if (!aurora::rmlui::is_initialized()) {
         return;
     }

--- a/src/m_Do/m_Do_graphic.cpp
+++ b/src/m_Do/m_Do_graphic.cpp
@@ -57,6 +57,7 @@
 #include "dusk/imgui/ImGuiConsole.hpp"
 #include "dusk/logging.h"
 #include "dusk/settings.h"
+#include "dusk/touch_controls.h"
 #endif
 
 class mDoGph_HIO_c : public JORReflexible {
@@ -2743,6 +2744,7 @@ int mDoGph_Painter() {
 
 #if TARGET_PC
     dusk::g_imguiConsole.PostDraw();
+    dusk::touch_controls::draw();
 #endif
 
     mDoGph_gInf_c::endRender();


### PR DESCRIPTION

### iOS & Android  touch controller support

<img width="1434" height="660" alt="IMG_0296 2" src="https://github.com/user-attachments/assets/06fc6b53-8a95-413e-9028-149c54581b71" />

This PR adds an iOS-specific touch controller path so the game can be played without a physical controller or keyboard.

The implementation adds an on-screen GameCube-style controller overlay for iPhone/iPad, including:

- main control stick
- C-stick
- D-pad
- A / B / X / Y buttons
- L / R / Z buttons
- Start button
- gyro aiming

Touch input is converted into the same `PADStatus` data path used by the existing controller system, so the game receives normal GameCube-style button and stick input.

The touch controller can also be selected in the controller settings menu as **Touch Controls**, alongside the existing Keyboard and physical controller options. When selected, it is treated as an assigned controller for Port 1, which prevents the “No controller assigned” warning from appearing on iOS.

This also adds a touch stick sensitivity option for iOS. The sensitivity value is stored in the app’s user data folder and lets users tune how quickly the virtual stick reaches full tilt.

A separate post-clamp stick application step was added because the normal controller clamp path could reduce virtual stick values back into a walking range. The touch stick now reapplies full post-clamp tilt after the standard PAD clamp, so pushing the virtual stick forward correctly makes Link run instead of walk.

The touch controls are compiled only for iOS/iPadOS and do not affect desktop controller behavior.

The game used to crash on iOS when clicking the keyboard as input, which is now fixed.
