### PR TITLE
feat: more info in player info window

### DIFF
--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -208,6 +208,20 @@ namespace dusk {
             daAlink_c* player = (daAlink_c*)dComIfGp_getPlayer(0);
             daHorse_c* horse = dComIfGp_getHorseActor();
 
+            ImGui::Text("Global");
+            ImGuiStringViewText(
+                player != nullptr
+                ? fmt::format("Stage: {}\n", dComIfGp_getStartStageName()) 
+                : "Stage: ?\n"
+            );
+
+            ImGuiStringViewText(
+                player != nullptr
+                ? fmt::format("Layer: {}\n", dComIfG_play_c::getLayerNo(0)) 
+                : "Layer: ?\n"
+            );
+
+            ImGui::Separator();
             ImGui::Text("Link");
             ImGuiStringViewText(
                 player != nullptr
@@ -225,6 +239,18 @@ namespace dusk {
                 player != nullptr
                 ? fmt::format("Speed: {: .4f}\n", player->speedF)
                 : "Speed: ?\n"
+            );
+
+            ImGuiStringViewText(
+                player != nullptr
+                ? fmt::format("Room: {}\n", fopAcM_GetRoomNo(player)) 
+                : "Room: ?\n"
+            );
+
+            ImGuiStringViewText(
+                player != nullptr
+                ? fmt::format("Entry: {}\n", dComIfGp_getStartStagePoint()) 
+                : "Entry: ?\n"
             );
 
             ImGui::Separator();
@@ -245,6 +271,24 @@ namespace dusk {
                 horse != nullptr
                 ? fmt::format("Speed: {: .4f}\n", horse->speedF)
                 : "Speed: ?\n"
+            );
+
+            ImGuiStringViewText(
+                horse != nullptr
+                ? fmt::format("Room: {}\n", fopAcM_GetRoomNo(horse)) 
+                : "Room: ?\n"
+            );
+
+            ImGuiStringViewText(
+                player != nullptr
+                ? fmt::format("Saved Stage: {}\n", dComIfGs_getHorseRestartStageName())
+                : "Saved Stage: ?\n"
+            );
+
+            ImGuiStringViewText(
+                player != nullptr
+                ? fmt::format("Saved Room: {}\n", dComIfGs_getHorseRestartRoomNo())
+                : "Saved Room: ?\n"
             );
 
             ShowCornerContextMenu(m_playerInfoOverlayCorner, m_debugOverlayCorner);

--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -261,7 +261,7 @@ namespace dusk {
                  player != nullptr
                  ? fmt::format("Angle: {0}\n", player->shape_angle.y)
                  : "Angle: ?\n"
-             );
+            );
 
             ImGuiStringViewText(
                 player != nullptr
@@ -284,15 +284,21 @@ namespace dusk {
             );
 
             ImGuiStringViewText(
-                horse != nullptr
-                ? fmt::format("Angle: {0}\n", horse->shape_angle.y)
-                : "Angle: ?\n"
+                 horse != nullptr
+                 ? fmt::format("Velocity (XYZ): {: .4f}, {: .4f}, {: .4f}\n", horse->speed.x, horse->speed.y, horse->speed.z)
+                 : "Velocity (XYZ): ?, ?, ?\n"
             );
 
             ImGuiStringViewText(
                 horse != nullptr
-                ? fmt::format("Speed: {: .4f}\n", horse->speedF)
-                : "Speed: ?\n"
+                ? fmt::format("Speed (SpeedF): {: .4f}\n", horse->speedF)
+                : "Speed (SpeedF): ?\n"
+            );
+
+            ImGuiStringViewText(
+                horse != nullptr
+                ? fmt::format("Angle: {0}\n", horse->shape_angle.y)
+                : "Angle: ?\n"
             );
 
             ImGuiStringViewText(

--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -208,6 +208,16 @@ namespace dusk {
             daAlink_c* player = (daAlink_c*)dComIfGp_getPlayer(0);
             daHorse_c* horse = dComIfGp_getHorseActor();
 
+            double speedXzy = 0.0;
+            double speedXz = 0.0;
+            if (player != nullptr) {
+                speedXzy = sqrtf(player->speed.x * player->speed.x
+                    + player->speed.z * player->speed.z
+                    + player->speed.y * player->speed.y);
+                speedXz = sqrtf(player->speed.x * player->speed.x
+                    + player->speed.z * player->speed.z);
+            }
+
             ImGui::Text("Global");
             ImGuiStringViewText(
                 player != nullptr
@@ -231,15 +241,27 @@ namespace dusk {
 
             ImGuiStringViewText(
                 player != nullptr
-                ? fmt::format("Angle: {0}\n", player->shape_angle.y)
-                : "Angle: ?\n"
+                ? fmt::format("Velocity (XYZ): {: .4f}, {: .4f}, {: .4f}\n", player->speed.x, player->speed.y, player->speed.z)
+                : "Velocity (XYZ): ?, ?, ?\n"
             );
 
             ImGuiStringViewText(
                 player != nullptr
-                ? fmt::format("Speed: {: .4f}\n", player->speedF)
-                : "Speed: ?\n"
+                ? fmt::format("Speed (SpeedF): {: .4f}\n", player->speedF)
+                : "Speed (SpeedF): ?\n"
             );
+
+            ImGuiStringViewText(
+                player != nullptr
+                ? fmt::format("Speed (3D): {: .4f}\n", speedXzy)
+                : "Speed (3D): ?\n"
+            );
+
+            ImGuiStringViewText(
+                 player != nullptr
+                 ? fmt::format("Angle: {0}\n", player->shape_angle.y)
+                 : "Angle: ?\n"
+             );
 
             ImGuiStringViewText(
                 player != nullptr

--- a/src/dusk/imgui/ImGuiMenuTools.cpp
+++ b/src/dusk/imgui/ImGuiMenuTools.cpp
@@ -209,13 +209,10 @@ namespace dusk {
             daHorse_c* horse = dComIfGp_getHorseActor();
 
             double speedXzy = 0.0;
-            double speedXz = 0.0;
             if (player != nullptr) {
                 speedXzy = sqrtf(player->speed.x * player->speed.x
                     + player->speed.z * player->speed.z
                     + player->speed.y * player->speed.y);
-                speedXz = sqrtf(player->speed.x * player->speed.x
-                    + player->speed.z * player->speed.z);
             }
 
             ImGui::Text("Global");
@@ -227,7 +224,7 @@ namespace dusk {
 
             ImGuiStringViewText(
                 player != nullptr
-                ? fmt::format("Layer: {}\n", dComIfG_play_c::getLayerNo(0)) 
+                ? fmt::format("Layer: {0}\n", dComIfG_play_c::getLayerNo(0))
                 : "Layer: ?\n"
             );
 
@@ -265,13 +262,13 @@ namespace dusk {
 
             ImGuiStringViewText(
                 player != nullptr
-                ? fmt::format("Room: {}\n", fopAcM_GetRoomNo(player)) 
+                ? fmt::format("Room: {0}\n", fopAcM_GetRoomNo(player))
                 : "Room: ?\n"
             );
 
             ImGuiStringViewText(
                 player != nullptr
-                ? fmt::format("Entry: {}\n", dComIfGp_getStartStagePoint()) 
+                ? fmt::format("Entry: {0}\n", dComIfGp_getStartStagePoint())
                 : "Entry: ?\n"
             );
 
@@ -303,7 +300,7 @@ namespace dusk {
 
             ImGuiStringViewText(
                 horse != nullptr
-                ? fmt::format("Room: {}\n", fopAcM_GetRoomNo(horse)) 
+                ? fmt::format("Room: {0}\n", fopAcM_GetRoomNo(horse))
                 : "Room: ?\n"
             );
 
@@ -315,7 +312,7 @@ namespace dusk {
 
             ImGuiStringViewText(
                 player != nullptr
-                ? fmt::format("Saved Room: {}\n", dComIfGs_getHorseRestartRoomNo())
+                ? fmt::format("Saved Room: {0}\n", dComIfGs_getHorseRestartRoomNo())
                 : "Saved Room: ?\n"
             );
 


### PR DESCRIPTION
Closes #126 

Adds some more info to the player info tab in the advanced menus, namely:
- stage
- layer
- room for link
- entrypoint for link
- room for epona
- saved stage for epona
- saved room for epona
- link velocity vector
- epona velocity vector