### PR TITLE
Update build.gradle to reflect correct Version Name

### DIFF
--- a/platforms/android/app/build.gradle
+++ b/platforms/android/app/build.gradle
@@ -21,7 +21,7 @@ android {
         minSdk 26
         targetSdk 36
         versionCode 1
-        versionName '0.1.0'
+        versionName '1.2.0'
     }
 
     buildTypes {


### PR DESCRIPTION
versionName should match the actual version number so the Android system can display the current software version without having to actually launch the program to find it.