### PR TITLE
build.yml revisions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,23 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - '*.md'
       - '*LICENSE'
   pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,19 +2,10 @@ name: Build
 
 on:
   push:
-    branches:
-      - main
     paths-ignore:
       - '*.md'
       - '*LICENSE'
   pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}


### PR DESCRIPTION
Made a few changes to build.yml to hopefully improve the CI experience at least a little:

1. Only process push on the main branch, preventing CI runs from doubling up when new branches are created and pull requests are opened
2. Only process pull_request when they intend to merge into main. The types ensure that CI still reruns when an already opened PR receives new commits
3. Use concurrency to automatically cancel running workflows in a pull request if new commits are made before the old ones have finished