### PR TITLE
feat: Allow line breaks in UI panes

### DIFF
--- a/res/rml/window.rcss
+++ b/res/rml/window.rcss
@@ -123,6 +123,13 @@ window content pane > spacer {
     pointer-events: none;
 }
 
+window content pane > line-break {
+    display: block;
+    flex: 0 0 8dp;
+    height: 8dp;
+    pointer-events: none;
+}
+
 scrollbarvertical {
     width: 8dp;
     margin: 4dp 4dp 4dp 0;

--- a/src/dusk/ui/pane.cpp
+++ b/src/dusk/ui/pane.cpp
@@ -176,6 +176,10 @@ Rml::Element* Pane::add_text(const Rml::String& text) {
     return elem;
 }
 
+Rml::Element* Pane::add_break() {
+    return append(mRoot, "line-break");
+}
+
 Rml::Element* Pane::add_rml(const Rml::String& rml) {
     auto* elem = append(mRoot, "div");
     elem->SetInnerRML(rml);

--- a/src/dusk/ui/pane.hpp
+++ b/src/dusk/ui/pane.hpp
@@ -31,6 +31,7 @@ public:
         return add_child<ControlledSelectButton>(std::move(props));
     }
     Rml::Element* add_text(const Rml::String& text);
+    Rml::Element* add_break();
     Rml::Element* add_rml(const Rml::String& rml);
     void finalize();
     void clear();


### PR DESCRIPTION
Allow line breaks in UI panes, might be useful like in the following example:

<img width="1216" height="924" alt="Screenshot 2026-05-22 at 20 25 03" src="https://github.com/user-attachments/assets/aeea74fe-7680-4c63-b2a1-7a24a1b6522b" />
