### PR TITLE
UI/copy tweaks

### DIFF
--- a/res/rml/prelaunch.rcss
+++ b/res/rml/prelaunch.rcss
@@ -447,6 +447,7 @@ body.animate-in .intro-item {
         top: auto;
         text-align: right;
         font-size: 16dp;
+        gap: 8dp;
     }
 
     #disc-status {
@@ -468,6 +469,7 @@ body.animate-in .intro-item {
         top: 32dp;
         text-align: right;
         font-size: 16dp;
+        gap: 8dp;
     }
 
     .update {

--- a/src/dusk/achievements.cpp
+++ b/src/dusk/achievements.cpp
@@ -442,7 +442,7 @@ std::vector<AchievementSystem::Entry> AchievementSystem::makeEntries() {
             {
                 "dark_hammer_one_hit",
                 "Mortal Edge",
-                "Defeat Dark Hammer in a single hit.",
+                "Defeat Darkhammer in a single hit.",
                 AchievementCategory::Misc,
                 false, 0, 0, false
             },

--- a/src/dusk/imgui/ImGuiConsole.cpp
+++ b/src/dusk/imgui/ImGuiConsole.cpp
@@ -322,8 +322,8 @@ namespace dusk {
             }
             ImGui::PushFont(ImGuiEngine::fontLarge);
             ImGuiTextCenter("Failed to initialize any graphics backend.");
-            ImGuiTextCenter("\nDusklight requires Vulkan 1.1+, or Direct X 12.0.");
-            ImGuiTextCenter("\nTry updating your Operating System and GPU drivers.");
+            ImGuiTextCenter("\nDusklight requires at least Vulkan 1.1 or Direct3D 12.");
+            ImGuiTextCenter("\nTry updating your operating system and GPU drivers.");
             const auto& style = ImGui::GetStyle();
             const auto retrySize = ImGui::CalcTextSize("Retry (Auto backend)");
             const auto quitSize = ImGui::CalcTextSize("Quit");

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -887,14 +887,19 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
         config_bool_select(leftPane, rightPane, getSettings().game.enableDepthOfField,
             {
                 .key = "Enable Depth of Field",
+                .helpText = "Render a blurring effect for out-of-focus areas in some situations. May impact performance."
             });
         config_bool_select(leftPane, rightPane, getSettings().game.enableMapBackground,
             {
                 .key = "Enable Mini-Map Shadows",
+                .helpText = "Render a thick shadow around the mini-map. May impact performance."
             });
         config_bool_select(leftPane, rightPane, getSettings().game.disableCutscenePillarboxing,
             {
                 .key = "Disable Cutscene Pillarboxing",
+                .helpText = "Disable black bars on the left and right sides of the screen "
+                            "during some cutscenes, particularly on ultra-wide displays. "
+                            "Visuals beyond the original intended framing may appear buggy."
             });
     });
 


### PR DESCRIPTION
- Adds descriptions for the depth-of-field, mini-map shadows, and cutscene pillarboxing options.
- Tighten up the copy for the graphics API initialization failure message.
- Tighten spacing for version and disc info on mobile prelaunch layout.
- Change "Dark Hammer" to "Darkhammer" in the description for the "Mortal Edge" achievement. This seems to be the more common rendering of the name,