### PR TITLE
Use std::chrono for THP playback pacing

### DIFF
--- a/include/d/actor/d_a_movie_player.h
+++ b/include/d/actor/d_a_movie_player.h
@@ -5,6 +5,7 @@
 #include <thp.h>
 #else
 #include <atomic>
+#include <chrono>
 #endif
 #include "f_op/f_op_actor.h"
 #include "d/d_drawlist.h"
@@ -125,6 +126,7 @@ struct daMP_THPPlayer {
 	/* 0x0D4 */ s32 curCount;
 #if TARGET_PC
 	/* 0x0D8 */ std::atomic<s32> videoDecodeCount;
+	std::chrono::steady_clock::time_point thpPlaybackClock;
 #else
 	/* 0x0D8 */ s32 videoDecodeCount;
 #endif

--- a/src/d/actor/d_a_movie_player.cpp
+++ b/src/d/actor/d_a_movie_player.cpp
@@ -29,7 +29,6 @@
 #include "JSystem/JAudio2/JASCriticalSection.h"
 
 #if TARGET_PC
-#include <chrono>
 #include "dusk/gx_helper.h"
 #include "dusk/os.h"
 #include "dusk/layout.hpp"

--- a/src/d/actor/d_a_movie_player.cpp
+++ b/src/d/actor/d_a_movie_player.cpp
@@ -26,14 +26,16 @@
 
 #include "f_op/f_op_overlap_mng.h"
 
+#include "JSystem/JAudio2/JASCriticalSection.h"
+
+#if TARGET_PC
+#include <chrono>
 #include "dusk/gx_helper.h"
 #include "dusk/os.h"
 #include "dusk/layout.hpp"
-
-#include "JSystem/JAudio2/JASCriticalSection.h"
-
 #if MOVIE_SUPPORT
 #include "turbojpeg.h"
+#endif
 #endif
 
 inline s32 daMP_NEXT_READ_SIZE(daMP_THPReadBuffer* readBuf) {
@@ -3912,13 +3914,20 @@ static BOOL daMP_ProperTimingForGettingNextFrame() {
 			return TRUE;
 		}
 	} else {
-		s32 frameRate = daMP_ActivePlayer.header.frameRate * 100.0f;
 #if TARGET_PC
-	    // DUSK HACK: We only fire retrace callbacks *half* as often as the game expects,
-	    // because we only run them once per frame, and normally there should be two scans
-	    // per game frame.
-	    frameRate *= 2;
-#endif
+		const f32 fps = daMP_ActivePlayer.header.frameRate;
+		if (fps > 0.0f) {
+			const f32 elapsed = std::chrono::duration<f32>(
+			    std::chrono::steady_clock::now() - daMP_ActivePlayer.thpPlaybackClock).count();
+			const s32 desired = static_cast<s32>(elapsed * fps);
+			if (desired != daMP_ActivePlayer.prevCount) {
+				daMP_ActivePlayer.prevCount = desired;
+				daMP_ActivePlayer.curCount = desired;
+				return TRUE;
+			}
+		}
+#else
+		s32 frameRate = daMP_ActivePlayer.header.frameRate * 100.0f;
 		if (VIGetTvFormat() == VI_PAL) {
 			daMP_ActivePlayer.curCount = daMP_ActivePlayer.retaceCount * frameRate / 5000;
 		} else {
@@ -3929,6 +3938,7 @@ static BOOL daMP_ProperTimingForGettingNextFrame() {
 			daMP_ActivePlayer.prevCount = daMP_ActivePlayer.curCount;
 			return TRUE;
 		}
+#endif
 	}
 
 	return FALSE;
@@ -4133,6 +4143,9 @@ static BOOL daMP_THPPlayerPlay() {
         daMP_ActivePlayer.prevCount = 0;
         daMP_ActivePlayer.curCount = 0;
         daMP_ActivePlayer.retaceCount = -1;
+#if TARGET_PC
+        daMP_ActivePlayer.thpPlaybackClock = std::chrono::steady_clock::now();
+#endif
         return TRUE;
     }
 


### PR DESCRIPTION
Closes https://github.com/TwilitRealm/dusklight/issues/527

Tested on Windows. Fixes frame pacing when the framerate is unlocked.

Some people reported playback being stuttery on Linux, even with a 30FPS lock in some cases. Testing some distros to see if this resolves any problems there as well would be ideal.