### PR TITLE
Change default log level to INFO

### DIFF
--- a/include/dusk/action_bindings.h
+++ b/include/dusk/action_bindings.h
@@ -11,6 +11,7 @@ enum class ActionBinds {
     CALL_MIDNA,
     OPEN_DUSKLIGHT_MENU,
     TURBO_SPEED_BUTTON,
+    TOGGLE_TEXTURE_PACK,
     COUNT,
 };
 

--- a/include/dusk/action_bindings.h
+++ b/include/dusk/action_bindings.h
@@ -27,7 +27,9 @@ struct ActionBindPressData {
 
 using ActionBindsMap = std::unordered_map<ActionBinds, ActionBindData>;
 
-ActionBindsMap& getActionBinds();
+ActionBindsMap& getActionBindsGameplay();
+
+ActionBindsMap& getActionBindsInterface();
 
 bool isActionBound(ActionBinds action, u32 port);
 

--- a/include/dusk/action_bindings.h
+++ b/include/dusk/action_bindings.h
@@ -15,9 +15,15 @@ enum class ActionBinds {
     COUNT,
 };
 
+enum class Type {
+    GAMEPLAY,
+    INTERFACE,
+};
+
 struct ActionBindData {
     std::array<config::ActionBindConfigVar, 4>* configVars{};
     std::string actionName{};
+    Type type{};
 };
 
 struct ActionBindPressData {
@@ -27,9 +33,7 @@ struct ActionBindPressData {
 
 using ActionBindsMap = std::unordered_map<ActionBinds, ActionBindData>;
 
-ActionBindsMap& getActionBindsGameplay();
-
-ActionBindsMap& getActionBindsInterface();
+ActionBindsMap& getActionBinds();
 
 bool isActionBound(ActionBinds action, u32 port);
 
@@ -42,5 +46,7 @@ bool getActionBindHold(ActionBinds action, u32 port);
 bool getActionBindHoldAnyPort(ActionBinds action);
 
 int getActionBindButton(ActionBinds action, u32 port);
+
+Type getActionBindType(ActionBinds action);
 
 }

--- a/include/dusk/action_bindings.h
+++ b/include/dusk/action_bindings.h
@@ -15,7 +15,7 @@ enum class ActionBinds {
     COUNT,
 };
 
-enum class Type {
+enum class ActionBindType {
     GAMEPLAY,
     INTERFACE,
 };
@@ -23,7 +23,7 @@ enum class Type {
 struct ActionBindData {
     std::array<config::ActionBindConfigVar, 4>* configVars{};
     std::string actionName{};
-    Type type{};
+    ActionBindType type{};
 };
 
 struct ActionBindPressData {
@@ -47,6 +47,6 @@ bool getActionBindHoldAnyPort(ActionBinds action);
 
 int getActionBindButton(ActionBinds action, u32 port);
 
-Type getActionBindType(ActionBinds action);
+ActionBindType getActionBindType(ActionBinds action);
 
 }

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -234,6 +234,7 @@ struct UserSettings {
         std::array<ActionBindConfigVar, 4> callMidna;
         std::array<ActionBindConfigVar, 4> openDusklightMenu;
         std::array<ActionBindConfigVar, 4> turboSpeedButton;
+        std::array<ActionBindConfigVar, 4> toggleTexturePack;
     } actionBindings;
 };
 

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -1,12 +1,16 @@
 #include "dusk/action_bindings.h"
 
+#include "aurora/gfx.h"
 #include "aurora/lib/input.hpp"
+#include "dusk/config.hpp"
 #include "dusk/settings.h"
 #include "dusk/ui/ui.hpp"
 
 namespace dusk {
 
 static std::array<std::array<ActionBindPressData, static_cast<int>(ActionBinds::COUNT)>, PAD_CHANMAX> actionPressData{};
+
+static void handleActionTriggers();
 
 ActionBindsMap& getActionBinds() {
     static ActionBindsMap actionBinds = {
@@ -68,6 +72,8 @@ void updateActionBindings() {
             }
         }
     }
+
+    handleActionTriggers();
 }
 
 bool getActionBindTrig(ActionBinds action, u32 port) {
@@ -89,6 +95,20 @@ bool getActionBindHoldAnyPort(ActionBinds action) {
         }
     }
     return false;
+}
+
+static void handleActionTriggers() {
+    for (u32 port = 0; port < PAD_CHANMAX; ++port) {
+        if (!getActionBindTrig(ActionBinds::TOGGLE_TEXTURE_PACK, port)) {
+            continue;
+        }
+
+        const bool enabled = !getSettings().game.enableTextureReplacements.getValue();
+        getSettings().game.enableTextureReplacements.setValue(enabled);
+        aurora_set_texture_replacements_enabled(enabled);
+        config::Save();
+        break;
+    }
 }
 
 int getActionBindButton(ActionBinds action, u32 port) {

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -14,6 +14,7 @@ ActionBindsMap& getActionBinds() {
         {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna"}},
         {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu"}},
         {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button"}},
+        {ActionBinds::TOGGLE_TEXTURE_PACK, {&getSettings().actionBindings.toggleTexturePack, "Toggle Texture Pack"}},
     };
     return actionBinds;
 }

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -12,11 +12,11 @@ static std::array<std::array<ActionBindPressData, static_cast<int>(ActionBinds::
 
 ActionBindsMap& getActionBinds() {
     static ActionBindsMap actionBinds = {
-        {ActionBinds::FIRST_PERSON_CAMERA, {&getSettings().actionBindings.firstPersonCamera, "First Person Camera", Type::GAMEPLAY}},
-        {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna", Type::GAMEPLAY}},
-        {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button", Type::GAMEPLAY}},
-        {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu", Type::INTERFACE}},
-        {ActionBinds::TOGGLE_TEXTURE_PACK, {&getSettings().actionBindings.toggleTexturePack, "Toggle Texture Pack", Type::INTERFACE}},
+        {ActionBinds::FIRST_PERSON_CAMERA, {&getSettings().actionBindings.firstPersonCamera, "First Person Camera", ActionBindType::GAMEPLAY}},
+        {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna",          ActionBindType::GAMEPLAY}},
+        {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button",  ActionBindType::GAMEPLAY}},
+        {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu", ActionBindType::INTERFACE}},
+        {ActionBinds::TOGGLE_TEXTURE_PACK, {&getSettings().actionBindings.toggleTexturePack, "Toggle Texture Pack", ActionBindType::INTERFACE}},
     };
     return actionBinds;
 }

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -10,30 +10,21 @@ namespace dusk {
 
 static std::array<std::array<ActionBindPressData, static_cast<int>(ActionBinds::COUNT)>, PAD_CHANMAX> actionPressData{};
 
-// Action Bindings that affect gameplay
-ActionBindsMap& getActionBindsGameplay() {
+ActionBindsMap& getActionBinds() {
     static ActionBindsMap actionBinds = {
-        {ActionBinds::FIRST_PERSON_CAMERA, {&getSettings().actionBindings.firstPersonCamera, "First Person Camera"}},
-        {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna"}},
-        {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button"}},
-    };
-    return actionBinds;
-}
-
-// Action Bindings that affect the interface (menus, etc.)
-ActionBindsMap& getActionBindsInterface() {
-    static ActionBindsMap actionBinds = {
-        {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu"}},
-        {ActionBinds::TOGGLE_TEXTURE_PACK, {&getSettings().actionBindings.toggleTexturePack, "Toggle Texture Pack"}},
+        {ActionBinds::FIRST_PERSON_CAMERA, {&getSettings().actionBindings.firstPersonCamera, "First Person Camera", Type::GAMEPLAY}},
+        {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna", Type::GAMEPLAY}},
+        {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button", Type::GAMEPLAY}},
+        {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu", Type::INTERFACE}},
+        {ActionBinds::TOGGLE_TEXTURE_PACK, {&getSettings().actionBindings.toggleTexturePack, "Toggle Texture Pack", Type::INTERFACE}},
     };
     return actionBinds;
 }
 
 bool isActionBound(ActionBinds action, u32 port) {
-    auto& actionBindsGameplay = getActionBindsGameplay();
-    auto& actionBindsInterface = getActionBindsInterface();
+    auto& actionBinds = getActionBinds();
     // Check to make sure action is properly bound
-    if (!actionBindsGameplay.contains(action) && !actionBindsInterface.contains(action)) {
+    if (!actionBinds.contains(action)) {
         return false;
     }
 
@@ -48,8 +39,8 @@ void updateActionBindings() {
             pressData.pressedCurFrame = false;
         }
 
-        // Update current frame with whether gameplay action button is pressed
-        for (auto& [action, boundAction] : getActionBindsGameplay()) {
+        // Update current frame with whether action button is pressed
+        for (auto& [action, boundAction] : getActionBinds()) {
             // If the action isn't bound, or if documents are visible and the action isn't
             // opening the dusklight menu, don't update. Otherwise, we may accidentally
             // perform actions while the dusklight menu is open.
@@ -77,35 +68,8 @@ void updateActionBindings() {
                     }
                 }
             }
-        }
 
-        // Update current frame for interface binds and handle their triggers separately
-        for (auto& [action, boundAction] : getActionBindsInterface()) {
-            // Interface binds should update regardless of UI visibility
-            if (!isActionBound(action, port) ||
-                (ui::any_document_visible() && action != ActionBinds::OPEN_DUSKLIGHT_MENU)) {
-                continue;
-            }
-
-            int button = boundAction.configVars->at(port);
-
-            u32 count = 0;
-            if (PADGetKeyButtonBindings(port, &count) != nullptr) {
-                int numKeys = 0;
-                const bool* kbState = SDL_GetKeyboardState(&numKeys);
-                if (kbState[button]) {
-                    actionPressData[port][static_cast<int>(action)].pressedCurFrame = true;
-                }
-            } else {
-                auto controller = aurora::input::get_controller_for_player(port);
-                if (controller) {
-                    if (SDL_GetGamepadButton(controller->m_controller, static_cast<SDL_GamepadButton>(button))) {
-                        actionPressData[port][static_cast<int>(action)].pressedCurFrame = true;
-                    }
-                }
-            }
-
-            // Interface-specific triggers (do not apply gameplay UI visibility gating)
+            // Interface-specific triggers
             if (getActionBindTrig(ActionBinds::TOGGLE_TEXTURE_PACK, port)) {
                 const bool enabled = !getSettings().game.enableTextureReplacements.getValue();
                 getSettings().game.enableTextureReplacements.setValue(enabled);
@@ -139,17 +103,6 @@ bool getActionBindHoldAnyPort(ActionBinds action) {
 }
 
 int getActionBindButton(ActionBinds action, u32 port) {
-    auto& gameplayBinds = getActionBindsGameplay();
-    auto& interfaceBinds = getActionBindsInterface();
-
-    if (gameplayBinds.contains(action)) {
-        return (*gameplayBinds[action].configVars)[port];
-    }
-
-    if (interfaceBinds.contains(action)) {
-        return (*interfaceBinds[action].configVars)[port];
-    }
-
-    return PAD_NATIVE_BUTTON_INVALID;
+    return (*getActionBinds()[action].configVars)[port];
 }
 }

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -10,8 +10,6 @@ namespace dusk {
 
 static std::array<std::array<ActionBindPressData, static_cast<int>(ActionBinds::COUNT)>, PAD_CHANMAX> actionPressData{};
 
-static void handleActionTriggers();
-
 ActionBindsMap& getActionBinds() {
     static ActionBindsMap actionBinds = {
         {ActionBinds::FIRST_PERSON_CAMERA, {&getSettings().actionBindings.firstPersonCamera, "First Person Camera"}},
@@ -70,10 +68,17 @@ void updateActionBindings() {
                     }
                 }
             }
+
+            // Handle action triggers
+            if (getActionBindTrig(ActionBinds::TOGGLE_TEXTURE_PACK, port)) {
+                const bool enabled = !getSettings().game.enableTextureReplacements.getValue();
+                getSettings().game.enableTextureReplacements.setValue(enabled);
+                aurora_set_texture_replacements_enabled(enabled);
+                config::Save();
+                break;
+            }
         }
     }
-
-    handleActionTriggers();
 }
 
 bool getActionBindTrig(ActionBinds action, u32 port) {
@@ -95,20 +100,6 @@ bool getActionBindHoldAnyPort(ActionBinds action) {
         }
     }
     return false;
-}
-
-static void handleActionTriggers() {
-    for (u32 port = 0; port < PAD_CHANMAX; ++port) {
-        if (!getActionBindTrig(ActionBinds::TOGGLE_TEXTURE_PACK, port)) {
-            continue;
-        }
-
-        const bool enabled = !getSettings().game.enableTextureReplacements.getValue();
-        getSettings().game.enableTextureReplacements.setValue(enabled);
-        aurora_set_texture_replacements_enabled(enabled);
-        config::Save();
-        break;
-    }
 }
 
 int getActionBindButton(ActionBinds action, u32 port) {

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -10,21 +10,30 @@ namespace dusk {
 
 static std::array<std::array<ActionBindPressData, static_cast<int>(ActionBinds::COUNT)>, PAD_CHANMAX> actionPressData{};
 
-ActionBindsMap& getActionBinds() {
+// Action Bindings that affect gameplay
+ActionBindsMap& getActionBindsGameplay() {
     static ActionBindsMap actionBinds = {
         {ActionBinds::FIRST_PERSON_CAMERA, {&getSettings().actionBindings.firstPersonCamera, "First Person Camera"}},
         {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna"}},
         {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu"}},
         {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button"}},
+    };
+    return actionBinds;
+}
+
+// Action Bindings that affect the interface (menus, etc.)
+ActionBindsMap& getActionBindsInterface() {
+    static ActionBindsMap actionBinds = {
         {ActionBinds::TOGGLE_TEXTURE_PACK, {&getSettings().actionBindings.toggleTexturePack, "Toggle Texture Pack"}},
     };
     return actionBinds;
 }
 
 bool isActionBound(ActionBinds action, u32 port) {
-    auto& actionBinds = getActionBinds();
+    auto& actionBindsGameplay = getActionBindsGameplay();
+    auto& actionBindsInterface = getActionBindsInterface();
     // Check to make sure action is properly bound
-    if (!actionBinds.contains(action)) {
+    if (!actionBindsGameplay.contains(action) && !actionBindsInterface.contains(action)) {
         return false;
     }
 
@@ -39,8 +48,8 @@ void updateActionBindings() {
             pressData.pressedCurFrame = false;
         }
 
-        // Update current frame with whether action button is pressed
-        for (auto& [action, boundAction] : getActionBinds()) {
+        // Update current frame with whether gameplay action button is pressed
+        for (auto& [action, boundAction] : getActionBindsGameplay()) {
             // If the action isn't bound, or if documents are visible and the action isn't
             // opening the dusklight menu, don't update. Otherwise, we may accidentally
             // perform actions while the dusklight menu is open.
@@ -68,8 +77,35 @@ void updateActionBindings() {
                     }
                 }
             }
+        }
 
-            // Handle action triggers
+        // Update current frame for interface binds and handle their triggers separately
+        for (auto& [action, boundAction] : getActionBindsInterface()) {
+            // Interface binds should update regardless of UI visibility
+            if (!isActionBound(action, port) ||
+                (ui::any_document_visible() && action != ActionBinds::OPEN_DUSKLIGHT_MENU)) {
+                continue;
+            }
+
+            int button = boundAction.configVars->at(port);
+
+            u32 count = 0;
+            if (PADGetKeyButtonBindings(port, &count) != nullptr) {
+                int numKeys = 0;
+                const bool* kbState = SDL_GetKeyboardState(&numKeys);
+                if (kbState[button]) {
+                    actionPressData[port][static_cast<int>(action)].pressedCurFrame = true;
+                }
+            } else {
+                auto controller = aurora::input::get_controller_for_player(port);
+                if (controller) {
+                    if (SDL_GetGamepadButton(controller->m_controller, static_cast<SDL_GamepadButton>(button))) {
+                        actionPressData[port][static_cast<int>(action)].pressedCurFrame = true;
+                    }
+                }
+            }
+
+            // Interface-specific triggers (do not apply gameplay UI visibility gating)
             if (getActionBindTrig(ActionBinds::TOGGLE_TEXTURE_PACK, port)) {
                 const bool enabled = !getSettings().game.enableTextureReplacements.getValue();
                 getSettings().game.enableTextureReplacements.setValue(enabled);
@@ -103,6 +139,17 @@ bool getActionBindHoldAnyPort(ActionBinds action) {
 }
 
 int getActionBindButton(ActionBinds action, u32 port) {
-    return (*getActionBinds()[action].configVars)[port];
+    auto& gameplayBinds = getActionBindsGameplay();
+    auto& interfaceBinds = getActionBindsInterface();
+
+    if (gameplayBinds.contains(action)) {
+        return (*gameplayBinds[action].configVars)[port];
+    }
+
+    if (interfaceBinds.contains(action)) {
+        return (*interfaceBinds[action].configVars)[port];
+    }
+
+    return PAD_NATIVE_BUTTON_INVALID;
 }
 }

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -15,7 +15,6 @@ ActionBindsMap& getActionBindsGameplay() {
     static ActionBindsMap actionBinds = {
         {ActionBinds::FIRST_PERSON_CAMERA, {&getSettings().actionBindings.firstPersonCamera, "First Person Camera"}},
         {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna"}},
-        {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu"}},
         {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button"}},
     };
     return actionBinds;
@@ -24,6 +23,7 @@ ActionBindsMap& getActionBindsGameplay() {
 // Action Bindings that affect the interface (menus, etc.)
 ActionBindsMap& getActionBindsInterface() {
     static ActionBindsMap actionBinds = {
+        {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu"}},
         {ActionBinds::TOGGLE_TEXTURE_PACK, {&getSettings().actionBindings.toggleTexturePack, "Toggle Texture Pack"}},
     };
     return actionBinds;

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -279,7 +279,7 @@ void dusk::config::Save() {
 }
 
 void dusk::config::ClearAllActionBindings(int port) {
-    for (auto& actionBinding : getActionBinds() | std::views::values) {
+    for (auto& actionBinding : getActionBindsGameplay() | std::views::values) {
         actionBinding.configVars->at(port).setValue(PAD_NATIVE_BUTTON_INVALID);
     }
     Save();

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -279,7 +279,7 @@ void dusk::config::Save() {
 }
 
 void dusk::config::ClearAllActionBindings(int port) {
-    for (auto& actionBinding : getActionBindsGameplay() | std::views::values) {
+    for (auto& actionBinding : getActionBinds() | std::views::values) {
         actionBinding.configVars->at(port).setValue(PAD_NATIVE_BUTTON_INVALID);
     }
     Save();

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -166,6 +166,12 @@ UserSettings g_userSettings = {
             ActionBindConfigVar{"actionBindings.turboButton_port2", PAD_NATIVE_BUTTON_INVALID},
             ActionBindConfigVar{"actionBindings.turboButton_port3", PAD_NATIVE_BUTTON_INVALID},
         },
+        .toggleTexturePack {
+            ActionBindConfigVar{"actionBindings.toggleTexturePack_port0", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.toggleTexturePack_port1", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.toggleTexturePack_port2", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.toggleTexturePack_port3", PAD_NATIVE_BUTTON_INVALID},
+        },
     }
 };
 
@@ -303,6 +309,10 @@ void registerSettings() {
     Register(g_userSettings.actionBindings.turboSpeedButton[1]);
     Register(g_userSettings.actionBindings.turboSpeedButton[2]);
     Register(g_userSettings.actionBindings.turboSpeedButton[3]);
+    Register(g_userSettings.actionBindings.toggleTexturePack[0]);
+    Register(g_userSettings.actionBindings.toggleTexturePack[1]);
+    Register(g_userSettings.actionBindings.toggleTexturePack[2]);
+    Register(g_userSettings.actionBindings.toggleTexturePack[3]);
 }
 
 // Transient settings

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -961,7 +961,7 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
         pane.add_section("Custom Action Bindings");
         pane.add_rml("A button bound to any action here will REPLACE the default control for"
                       " that action. Only bind buttons here that aren't used anywhere else."
-                      " <br/><br/> Note: The glyphs shown for in game actions will not change."
+                      " <br/><br/> Note: The glyphs shown for in-game actions will not change."
                       " This is not recommended for regular Gamecube controllers.");
 
         auto addActionBinding = [&](auto actionBind, const std::string& key) {

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -938,13 +938,17 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                           " that action. Only bind buttons here that aren't used anywhere else.");
 
             pane.add_section("Gameplay");
-            for (auto& [configVars, actionName] : getActionBindsGameplay() | std::views::values) {
-                addActionBinding(&configVars->at(port), actionName);
+            for (auto& [configVars, actionName, type] : getActionBinds() | std::views::values) {
+                if (type == Type::GAMEPLAY) {
+                    addActionBinding(&configVars->at(port), actionName);
+                }
             }
 
             pane.add_section("Interface");
-            for (auto& [configVars, actionName] : getActionBindsInterface() | std::views::values) {
-                addActionBinding(&configVars->at(port), actionName);
+            for (auto& [configVars, actionName, type] : getActionBinds() | std::views::values) {
+                if (type == Type::INTERFACE) {
+                    addActionBinding(&configVars->at(port), actionName);
+                }
             }
 
             break;
@@ -987,13 +991,17 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
         };
 
         pane.add_section("Gameplay");
-        for (auto& [configVars, actionName] : getActionBindsGameplay() | std::views::values) {
-            addActionBinding(&configVars->at(port), actionName);
+        for (auto& [configVars, actionName, type] : getActionBinds() | std::views::values) {
+            if (type == Type::GAMEPLAY) {
+                addActionBinding(&configVars->at(port), actionName);
+            }
         }
 
         pane.add_section("Interface");
-        for (auto& [configVars, actionName] : getActionBindsInterface() | std::views::values) {
-            addActionBinding(&configVars->at(port), actionName);
+        for (auto& [configVars, actionName, type] : getActionBinds() | std::views::values) {
+            if (type == Type::INTERFACE) {
+                addActionBinding(&configVars->at(port), actionName);
+            }
         }
         break;
     }

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -939,14 +939,14 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
 
             pane.add_section("Gameplay");
             for (auto& [configVars, actionName, type] : getActionBinds() | std::views::values) {
-                if (type == Type::GAMEPLAY) {
+                if (type == ActionBindType::GAMEPLAY) {
                     addActionBinding(&configVars->at(port), actionName);
                 }
             }
 
             pane.add_section("Interface");
             for (auto& [configVars, actionName, type] : getActionBinds() | std::views::values) {
-                if (type == Type::INTERFACE) {
+                if (type == ActionBindType::INTERFACE) {
                     addActionBinding(&configVars->at(port), actionName);
                 }
             }
@@ -992,14 +992,14 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
 
         pane.add_section("Gameplay");
         for (auto& [configVars, actionName, type] : getActionBinds() | std::views::values) {
-            if (type == Type::GAMEPLAY) {
+            if (type == ActionBindType::GAMEPLAY) {
                 addActionBinding(&configVars->at(port), actionName);
             }
         }
 
         pane.add_section("Interface");
         for (auto& [configVars, actionName, type] : getActionBinds() | std::views::values) {
-            if (type == Type::INTERFACE) {
+            if (type == ActionBindType::INTERFACE) {
                 addActionBinding(&configVars->at(port), actionName);
             }
         }

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -936,9 +936,17 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
             pane.add_section("Custom Action Bindings");
             pane.add_text("A key bound to any action here will REPLACE the default control for"
                           " that action. Only bind buttons here that aren't used anywhere else.");
-            for (auto& [configVars, actionName] : getActionBinds() | std::views::values) {
+
+            pane.add_section("Gameplay");
+            for (auto& [configVars, actionName] : getActionBindsGameplay() | std::views::values) {
                 addActionBinding(&configVars->at(port), actionName);
             }
+
+            pane.add_section("Interface");
+            for (auto& [configVars, actionName] : getActionBindsInterface() | std::views::values) {
+                addActionBinding(&configVars->at(port), actionName);
+            }
+
             break;
         }
 
@@ -952,9 +960,10 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
         SDL_Gamepad* gamepad = gamepad_for_port(port);
         pane.add_section("Custom Action Bindings");
         pane.add_text("A button bound to any action here will REPLACE the default control for"
-                      " that action. Only bind buttons here that aren't used anywhere else. The glyphs"
-                      " shown for in game actions will not change. This is not recommended for "
-                      " regular Gamecube controllers.");
+                      " that action. Only bind buttons here that aren't used anywhere else."
+                      " Note: The glyphs shown for in game actions will not change."
+                      " This is not recommended for regular Gamecube controllers.");
+
         auto addActionBinding = [&](auto actionBind, const std::string& key) {
             pane.add_select_button({
                            .key = key,
@@ -977,7 +986,13 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
                 });
         };
 
-        for (auto& [configVars, actionName] : getActionBinds() | std::views::values) {
+        pane.add_section("Gameplay");
+        for (auto& [configVars, actionName] : getActionBindsGameplay() | std::views::values) {
+            addActionBinding(&configVars->at(port), actionName);
+        }
+
+        pane.add_section("Interface");
+        for (auto& [configVars, actionName] : getActionBindsInterface() | std::views::values) {
             addActionBinding(&configVars->at(port), actionName);
         }
         break;

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -959,9 +959,9 @@ void ControllerConfigWindow::render_page(Pane& pane, int port, Page page) {
 
         SDL_Gamepad* gamepad = gamepad_for_port(port);
         pane.add_section("Custom Action Bindings");
-        pane.add_text("A button bound to any action here will REPLACE the default control for"
+        pane.add_rml("A button bound to any action here will REPLACE the default control for"
                       " that action. Only bind buttons here that aren't used anywhere else."
-                      " Note: The glyphs shown for in game actions will not change."
+                      " <br/><br/> Note: The glyphs shown for in game actions will not change."
                       " This is not recommended for regular Gamecube controllers.");
 
         auto addActionBinding = [&](auto actionBind, const std::string& key) {

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -509,7 +509,7 @@ int game_main(int argc, char* argv[]) {
         cxxopts::Options arg_options("Dusklight", "PC Port of a classic adventure game");
 
         arg_options.add_options()
-            ("l,log-level", "Log level from " + std::to_string(AuroraLogLevel::LOG_DEBUG) + " to " + std::to_string(AuroraLogLevel::LOG_FATAL), cxxopts::value<uint8_t>()->default_value("0"))
+            ("l,log-level", "Log level from " + std::to_string(AuroraLogLevel::LOG_DEBUG) + " to " + std::to_string(AuroraLogLevel::LOG_FATAL), cxxopts::value<uint8_t>()->default_value("1"))
             ("h,help", "Print usage")
             ("console", "Show the Windows console window for logs", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
             ("dvd", "Path to DVD image file", cxxopts::value<std::string>())


### PR DESCRIPTION
Changes default log level from `0=LOG_DEBUG` to `1=LOG_INFO`, preventing cluttering the journal.

I think this is useful for end users, during development devs can just open the app with the `-l 0` flag anyways.

Closes #1000