### PR TITLE
Change default log level from DEBUG to  INFO

### DIFF
--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -489,7 +489,7 @@ int game_main(int argc, char* argv[]) {
         cxxopts::Options arg_options("Dusklight", "PC Port of a classic adventure game");
 
         arg_options.add_options()
-            ("l,log-level", "Log level from " + std::to_string(AuroraLogLevel::LOG_DEBUG) + " to " + std::to_string(AuroraLogLevel::LOG_FATAL), cxxopts::value<uint8_t>()->default_value("0"))
+            ("l,log-level", "Log level from " + std::to_string(AuroraLogLevel::LOG_DEBUG) + " to " + std::to_string(AuroraLogLevel::LOG_FATAL), cxxopts::value<uint8_t>()->default_value("1"))
             ("h,help", "Print usage")
             ("console", "Show the Windows console window for logs", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
             ("dvd", "Path to DVD image file", cxxopts::value<std::string>())


### PR DESCRIPTION
Changes default log level from 0=LOG_DEBUG to 1=LOG_INFO, preventing cluttering the journal.

I think this is useful for end users, during development devs can just open the app with the `-l 0` flag anyways.

Closes https://github.com/TwilitRealm/dusklight/issues/1000