### PR TITLE
Feat: Add homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ First, make sure your dump of the game is clean and supported by Dusklight. You 
 
 ### 2. Download [Dusklight](https://github.com/TwilitRealm/dusklight/releases)
 
+**macOS users:** can alternatively install via Homebrew with the following command
+
+```
+brew install --cask dusklight
+```
+
 ### 3. Setup the game
 **Windows / macOS / Linux**
 - Extract the .zip file

--- a/README.md
+++ b/README.md
@@ -33,13 +33,20 @@ First, make sure your dump of the game is clean and supported by Dusklight. You 
 
 *Support for other versions of the game is planned in the future.
 
-### 2. Download [Dusklight](https://github.com/TwilitRealm/dusklight/releases)
+### 2. Download Dusklight
 
-**macOS users:** can alternatively install via Homebrew with the following command
+**Windows / macOS / Linux**
 
-```
-brew install --cask dusklight
-```
+Download the latest [release](https://github.com/TwilitRealm/dusklight/releases) .zip file for your platform
+
+**macOS**
+
+- Requires MacOS version Big Sur (11.0) or later.
+- Dusklight can alternatively be installed via Homebrew with the following command
+
+    ```sh
+    brew install --cask dusklight
+    ```
 
 ### 3. Setup the game
 **Windows / macOS / Linux**


### PR DESCRIPTION
Closes #1748 

macOS users can now install Dusklight via homebrew using the following command on the terminal:

```sh
brew install --cask dusklight
```