### PR TITLE
Skip CI build jobs on documentation-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - '*.md'
       - '*LICENSE'
+      - 'docs/**'
   pull_request:
     paths-ignore:
       - '*.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - '*.md'
       - '*LICENSE'
   pull_request:
+    paths-ignore:
+      - '*.md'
+      - '*LICENSE'
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}


### PR DESCRIPTION
Build workflows should be skipped on documentation-only changes to save computing resources and unnecessary checks.

Bonus: set a retention policy of 5 days for artifacts to save up on storage