### PR TITLE
Allow Sun's Song & Quick Transform to be bound via the Custom Action …

### DIFF
--- a/include/dusk/action_bindings.h
+++ b/include/dusk/action_bindings.h
@@ -13,6 +13,7 @@ enum class ActionBinds {
     TURBO_SPEED_BUTTON,
     QUICK_TRANSFORM,
     SUN_SONG,
+    MOON_JUMP,
     COUNT,
 };
 

--- a/include/dusk/action_bindings.h
+++ b/include/dusk/action_bindings.h
@@ -11,6 +11,8 @@ enum class ActionBinds {
     CALL_MIDNA,
     OPEN_DUSKLIGHT_MENU,
     TURBO_SPEED_BUTTON,
+    QUICK_TRANSFORM,
+    SUN_SONG,
     COUNT,
 };
 

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -249,6 +249,8 @@ struct UserSettings {
         std::array<ActionBindConfigVar, 4> callMidna;
         std::array<ActionBindConfigVar, 4> openDusklightMenu;
         std::array<ActionBindConfigVar, 4> turboSpeedButton;
+        std::array<ActionBindConfigVar, 4> quickTransform;
+        std::array<ActionBindConfigVar, 4> sunSong;
     } actionBindings;
 };
 

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -251,6 +251,7 @@ struct UserSettings {
         std::array<ActionBindConfigVar, 4> turboSpeedButton;
         std::array<ActionBindConfigVar, 4> quickTransform;
         std::array<ActionBindConfigVar, 4> sunSong;
+        std::array<ActionBindConfigVar, 4> moonJump;
     } actionBindings;
 };
 

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -14,6 +14,8 @@ ActionBindsMap& getActionBinds() {
         {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna"}},
         {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu"}},
         {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button"}},
+        {ActionBinds::QUICK_TRANSFORM,     {&getSettings().actionBindings.quickTransform,    "Quick Transform"}},
+        {ActionBinds::SUN_SONG,            {&getSettings().actionBindings.sunSong,           "Sun's Song"}},
     };
     return actionBinds;
 }

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -16,6 +16,7 @@ ActionBindsMap& getActionBinds() {
         {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button"}},
         {ActionBinds::QUICK_TRANSFORM,     {&getSettings().actionBindings.quickTransform,    "Quick Transform"}},
         {ActionBinds::SUN_SONG,            {&getSettings().actionBindings.sunSong,           "Sun's Song"}},
+        {ActionBinds::MOON_JUMP,           {&getSettings().actionBindings.moonJump,          "Moon Jump"}},
     };
     return actionBinds;
 }

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -180,6 +180,12 @@ UserSettings g_userSettings = {
             ActionBindConfigVar{"actionBindings.sunSong_port1", PAD_NATIVE_BUTTON_INVALID},
             ActionBindConfigVar{"actionBindings.sunSong_port2", PAD_NATIVE_BUTTON_INVALID},
             ActionBindConfigVar{"actionBindings.sunSong_port3", PAD_NATIVE_BUTTON_INVALID},
+        },
+        .moonJump {
+            ActionBindConfigVar{"actionBindings.moonJump_port0", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.moonJump_port1", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.moonJump_port2", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.moonJump_port3", PAD_NATIVE_BUTTON_INVALID},
         }
     }
 };
@@ -329,6 +335,10 @@ void registerSettings() {
     Register(g_userSettings.actionBindings.sunSong[1]);
     Register(g_userSettings.actionBindings.sunSong[2]);
     Register(g_userSettings.actionBindings.sunSong[3]);
+    Register(g_userSettings.actionBindings.moonJump[0]);
+    Register(g_userSettings.actionBindings.moonJump[1]);
+    Register(g_userSettings.actionBindings.moonJump[2]);
+    Register(g_userSettings.actionBindings.moonJump[3]);
 }
 
 // Transient settings

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -169,6 +169,18 @@ UserSettings g_userSettings = {
             ActionBindConfigVar{"actionBindings.turboButton_port2", PAD_NATIVE_BUTTON_INVALID},
             ActionBindConfigVar{"actionBindings.turboButton_port3", PAD_NATIVE_BUTTON_INVALID},
         },
+        .quickTransform {
+            ActionBindConfigVar{"actionBindings.quickTransform_port0", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.quickTransform_port1", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.quickTransform_port2", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.quickTransform_port3", PAD_NATIVE_BUTTON_INVALID},
+        },
+        .sunSong {
+            ActionBindConfigVar{"actionBindings.sunSong_port0", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.sunSong_port1", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.sunSong_port2", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBindings.sunSong_port3", PAD_NATIVE_BUTTON_INVALID},
+        }
     }
 };
 
@@ -309,6 +321,14 @@ void registerSettings() {
     Register(g_userSettings.actionBindings.turboSpeedButton[1]);
     Register(g_userSettings.actionBindings.turboSpeedButton[2]);
     Register(g_userSettings.actionBindings.turboSpeedButton[3]);
+    Register(g_userSettings.actionBindings.quickTransform[0]);
+    Register(g_userSettings.actionBindings.quickTransform[1]);
+    Register(g_userSettings.actionBindings.quickTransform[2]);
+    Register(g_userSettings.actionBindings.quickTransform[3]);
+    Register(g_userSettings.actionBindings.sunSong[0]);
+    Register(g_userSettings.actionBindings.sunSong[1]);
+    Register(g_userSettings.actionBindings.sunSong[2]);
+    Register(g_userSettings.actionBindings.sunSong[3]);
 }
 
 // Transient settings

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1175,9 +1175,9 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
         addOption("Show Poe Count on Map", getSettings().game.enhancedMapMenus,
             "Displays collected/total number of Poe Souls for a region on the map.");
         addSpeedrunDisabledOption("Sun's Song (R+X)", getSettings().game.sunsSong,
-            "Allows Wolf Link to howl and change the time of day.");
+            "Allows Wolf Link to howl and change the time of day.<br/><br/>This can also be bound to another input in Custom Action Bindings.");
         addOption("Quick Transform (R+Y)", getSettings().game.enableQuickTransform,
-            "Transform instantly by pressing R and Y simultaneously.");
+            "Transform instantly by pressing R and Y simultaneously.<br/><br/>This can also be bound to another input in Custom Action Bindings.");
 
         leftPane.add_section("Speedrunning");
         config_bool_select(leftPane, rightPane, getSettings().game.speedrunMode,

--- a/src/f_ap/f_ap_game.cpp
+++ b/src/f_ap/f_ap_game.cpp
@@ -757,19 +757,19 @@ static void duskExecute() {
         isRecording = false;
     }
 
-    if (mDoCPd_c::getHoldR(PAD_1) && mDoCPd_c::getTrigX(PAD_1) || IF_DUSK(dusk::getActionBindTrig(dusk::ActionBinds::SUN_SONG, 0))) {
+    if (dusk::getActionBindTrig(dusk::ActionBinds::SUN_SONG, 0) || (!dusk::isActionBound(dusk::ActionBinds::SUN_SONG, 0) && mDoCPd_c::getHoldR(PAD_1) && mDoCPd_c::getTrigX(PAD_1))) {
         if (const auto link = g_dComIfG_gameInfo.play.getPlayer(0)) {
             dynamic_cast<daAlink_c*>(link)->handleWolfHowl();
         }
     }
 
-    if ((mDoCPd_c::getHold(PAD_1) & (PAD_TRIGGER_R | PAD_TRIGGER_L)) == PAD_TRIGGER_R && mDoCPd_c::getTrigY(PAD_1) || IF_DUSK(dusk::getActionBindTrig(dusk::ActionBinds::QUICK_TRANSFORM, 0))) {
+    if (dusk::getActionBindTrig(dusk::ActionBinds::QUICK_TRANSFORM, 0) || (!dusk::isActionBound(dusk::ActionBinds::QUICK_TRANSFORM, 0) && mDoCPd_c::getHoldR(PAD_1) && mDoCPd_c::getTrigY(PAD_1))) {
         if (const auto link = g_dComIfG_gameInfo.play.getPlayer(0)) {
             dynamic_cast<daAlink_c*>(link)->handleQuickTransform();
         }
     }
 
-    if (dusk::getSettings().game.moonJump && (mDoCPd_c::getHoldR(PAD_1) && mDoCPd_c::getHoldA(PAD_1))) {
+    if (dusk::getActionBindTrig(dusk::ActionBinds::MOON_JUMP, 0) || (!dusk::isActionBound(dusk::ActionBinds::MOON_JUMP, 0) && mDoCPd_c::getHoldR(PAD_1) && mDoCPd_c::getTrigA(PAD_1))) {
         if (const auto link = g_dComIfG_gameInfo.play.getPlayer(0)) {
             link->speed.y = 56.0f;
         }

--- a/src/f_ap/f_ap_game.cpp
+++ b/src/f_ap/f_ap_game.cpp
@@ -29,6 +29,7 @@
 #include "tracy/Tracy.hpp"
 #include <dusk/gamepad_color.h>
 #include <dusk/autosave.h>
+#include <dusk/action_bindings.h>
 #endif
 
 fapGm_HIO_c::fapGm_HIO_c() {
@@ -756,13 +757,13 @@ static void duskExecute() {
         isRecording = false;
     }
 
-    if (mDoCPd_c::getHoldR(PAD_1) && mDoCPd_c::getTrigX(PAD_1)) {
+    if (mDoCPd_c::getHoldR(PAD_1) && mDoCPd_c::getTrigX(PAD_1) || IF_DUSK(dusk::getActionBindTrig(dusk::ActionBinds::SUN_SONG, 0))) {
         if (const auto link = g_dComIfG_gameInfo.play.getPlayer(0)) {
             dynamic_cast<daAlink_c*>(link)->handleWolfHowl();
         }
     }
 
-    if ((mDoCPd_c::getHold(PAD_1) & (PAD_TRIGGER_R | PAD_TRIGGER_L)) == PAD_TRIGGER_R && mDoCPd_c::getTrigY(PAD_1)) {
+    if ((mDoCPd_c::getHold(PAD_1) & (PAD_TRIGGER_R | PAD_TRIGGER_L)) == PAD_TRIGGER_R && mDoCPd_c::getTrigY(PAD_1) || IF_DUSK(dusk::getActionBindTrig(dusk::ActionBinds::QUICK_TRANSFORM, 0))) {
         if (const auto link = g_dComIfG_gameInfo.play.getPlayer(0)) {
             dynamic_cast<daAlink_c*>(link)->handleQuickTransform();
         }


### PR DESCRIPTION
…Bindings menu along with default.

This is for people that get irritated with not being able to hit the buttons at the exact same time, without also requiring that Midna be rebound.

EDIT: I guess that this isn't needed like at all since it's not a timing thing at all and it was digital triggers messing things up for me, so this basically doesn't need to be done at all. Can use it if you want to though as a general convenience thing.

EDIT: Added moon jump as well, and disabled the default binds when new ones in Custom Action Bindings are bound