### PR TITLE
[Randomizer] No logic, Random spawn point

### DIFF
--- a/include/dusk/io.hpp
+++ b/include/dusk/io.hpp
@@ -31,6 +31,11 @@ public:
     ~FileStream();
 
     /**
+     * \brief Flush buffered writes and throw if the flush fails.
+     */
+    void Flush();
+
+    /**
      * \brief Open a file for reading at the given path.
      */
     static FileStream OpenRead(const char* utf8Path);

--- a/src/d/d_com_inf_game.cpp
+++ b/src/d/d_com_inf_game.cpp
@@ -33,6 +33,7 @@
 #include "dusk/randomizer/game/stages.h"
 #include "dusk/randomizer/game/flags.h"
 #include "dusk/randomizer/game/randomizer_context.hpp"
+#include "dusk/randomizer/generator/randomizer.hpp"
 #endif
 
 
@@ -2982,6 +2983,11 @@ void dComIfGs_setupRandomizerSave() {
     // Set starting inventory
     for (const auto& itemId: randoData.mStartingInventory) {
         execItemGet(itemId);
+    }
+
+    // Set random spawn check (success)
+    if (randoData.mStartLocation.has_value()) {
+        g_randomizerState.mPendingStartLocation = true;
     }
 
     DuskLog.debug("Created Rando Save");

--- a/src/d/d_model.cpp
+++ b/src/d/d_model.cpp
@@ -45,6 +45,20 @@ void dMdl_c::create(J3DModelData* i_modelData, u16 i_materialId, dKy_tevstr_c* i
 }
 
 void dMdl_c::entryObj(dMdl_obj_c* i_obj) {
+#ifdef TARGET_PC
+    // if field_0x1a is false, this dMdl_c is not in the drawlist
+    // if true, we need to make sure with interp enabled
+    if (dusk::frame_interp::is_enabled() && field_0x1a) {
+        auto pkt = dComIfGd_getListPacket()->mpBuffer[0];
+        while (pkt && pkt != this) {
+            pkt = pkt->getNextPacket();
+        }
+        if (!pkt) {
+            field_0x1a = false;
+        }
+    }
+#endif
+
     if (!field_0x1a) {
         dComIfGd_getListPacket()->entryImm(this, 0);
         field_0x1a = true;

--- a/src/d/d_s_name.cpp
+++ b/src/d/d_s_name.cpp
@@ -14,6 +14,8 @@
 #include "dusk/memory.h"
 #include "dusk/speedrun.h"
 #include "dusk/settings.h"
+#include "dusk/randomizer/game/randomizer_context.hpp"
+#include "dusk/randomizer/game/stages.h"
 #include "f_op/f_op_overlap_mng.h"
 #include "f_op/f_op_scene_mng.h"
 #include "m_Do/m_Do_Reset.h"
@@ -410,7 +412,21 @@ void dScnName_c::changeGameScene() {
         dComIfGp_offEnableNextStage();
 
         if (dFs_c->isDataNew(dFs_c->getSelectNum())) {
+#if TARGET_PC
+            // Set random starting spawn and unset mPendingStartLocation
+            auto& randoData = randomizer_GetContext();
+            const auto& spawn = randoData.mStartLocation;
+            const int stageCount = static_cast<int>(sizeof(allStages) / sizeof(allStages[0]));
+            if (spawn.has_value() && spawn->stage >= 0 && spawn->stage < stageCount) {
+                g_randomizerState.mPendingStartLocation = false;
+                dComIfGp_setNextStage(
+                    allStages[spawn->stage], spawn->point, spawn->room, spawn->layer);
+            } else {
+                dComIfGp_setNextStage("F_SP108", 21, 1, 13);
+            }
+#else
             dComIfGp_setNextStage("F_SP108", 21, 1, 13);
+#endif
         }
         
         dKy_clear_game_init();

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -8,6 +8,8 @@
 #include "dusk/settings.h"
 
 #include <limits>
+#include <filesystem>
+#include <system_error>
 #include <string>
 
 #include "dusk/main.h"
@@ -24,8 +26,24 @@ aurora::Module DuskConfigLog("dusk::config");
 static absl::flat_hash_map<std::string_view, ConfigVarBase*> RegisteredConfigVars;
 static bool RegistrationDone = false;
 
-static std::u8string GetConfigJsonPath() {
-    return (dusk::ConfigPath / ConfigFileName).u8string();
+static std::filesystem::path GetConfigJsonPath() {
+    return dusk::ConfigPath / ConfigFileName;
+}
+
+static std::filesystem::path GetTempConfigJsonPath(const std::filesystem::path& configJsonPath) {
+    auto tempPath = configJsonPath;
+    tempPath.replace_filename(fmt::format(".{}.tmp", configJsonPath.filename().string()));
+    return tempPath;
+}
+
+static void ReplaceFile(const std::filesystem::path& source, const std::filesystem::path& target) {
+    std::error_code ec;
+    std::filesystem::rename(source, target, ec);
+    if (ec) {
+        const auto renameError = ec;
+        std::filesystem::remove(source, ec);
+        throw std::system_error(renameError);
+    }
 }
 
 ConfigVarBase::ConfigVarBase(const char* name, const ConfigImplBase* impl) : name(name), registered(false), layer(ConfigVarLayer::Default), impl(impl) {
@@ -211,7 +229,8 @@ void dusk::config::LoadFromUserPreferences() {
     if (configJsonPath.empty()) {
         return;
     }
-    LoadFromFileName(reinterpret_cast<const char*>(configJsonPath.c_str()));
+    const auto configPathString = io::fs_path_to_string(configJsonPath);
+    LoadFromFileName(configPathString.c_str());
 }
 
 static void LoadFromPath(const char* path) {
@@ -254,6 +273,10 @@ void dusk::config::LoadFromFileName(const char* path) {
         } else {
             DuskConfigLog.error("Failed to load from config! {}", e.what());
         }
+    } catch (const nlohmann::json::parse_error& e) {
+        DuskConfigLog.error("Failed to parse config JSON, staying with defaults: {}", e.what());
+    } catch (const std::exception& e) {
+        DuskConfigLog.error("Failed to load from config, staying with defaults: {}", e.what());
     }
 }
 
@@ -262,10 +285,11 @@ void dusk::config::Save() {
     if (configJsonPath.empty()) {
         return;
     }
+    const auto configPathString = io::fs_path_to_string(configJsonPath);
 
     DuskConfigLog.info(
         "Saving config to '{}'",
-        reinterpret_cast<const char*>(configJsonPath.c_str()));
+        configPathString);
 
     json j;
 
@@ -276,7 +300,13 @@ void dusk::config::Save() {
         }
     }
 
-    io::FileStream::WriteAllText(reinterpret_cast<const char*>(configJsonPath.c_str()), j.dump(4));
+    try {
+        const auto tempConfigJsonPath = GetTempConfigJsonPath(configJsonPath);
+        io::FileStream::WriteAllText(tempConfigJsonPath, j.dump(4));
+        ReplaceFile(tempConfigJsonPath, configJsonPath);
+    } catch (const std::exception& e) {
+        DuskConfigLog.error("Failed to save config to '{}': {}", configPathString, e.what());
+    }
 }
 
 void dusk::config::ClearAllActionBindings(int port) {

--- a/src/dusk/crash_handler.cpp
+++ b/src/dusk/crash_handler.cpp
@@ -64,6 +64,15 @@ struct CrashContext {
 };
 CrashContext g_ctx;
 
+struct ModuleInfo {
+    uintptr_t base = 0;
+    uintptr_t size = 0;
+    char path[1024] = {};
+    uint8_t buildId[64] = {};
+    unsigned buildIdLen = 0;
+    unsigned pdbAge = 0;
+};
+
 void rawWrite(int fd, const char* data, size_t len) {
     if (fd < 0) {
         return;
@@ -119,14 +128,68 @@ void writeHexBytes(int fd, const uint8_t* data, unsigned len) {
     }
 }
 
-const char* moduleName() {
-    const char* name = g_ctx.modulePath;
-    for (const char* p = g_ctx.modulePath; *p != '\0'; ++p) {
+void writeHexByte(int fd, uint8_t value) {
+    char buf[2];
+    buf[0] = kHexDigits[value >> 4];
+    buf[1] = kHexDigits[value & 0xF];
+    rawWrite(fd, buf, 2);
+}
+
+void writeQuoted(int fd, const char* s) {
+    writeStr(fd, "\"");
+    if (s != nullptr) {
+        for (const char* p = s; *p != '\0'; ++p) {
+            if (*p == '"' || *p == '\\') {
+                rawWrite(fd, "\\", 1);
+            }
+            rawWrite(fd, p, 1);
+        }
+    }
+    writeStr(fd, "\"");
+}
+
+const char* baseName(const char* path) {
+    const char* name = path;
+    for (const char* p = path; p != nullptr && *p != '\0'; ++p) {
         if (*p == '/' || *p == '\\') {
             name = p + 1;
         }
     }
     return name[0] != '\0' ? name : "(unknown)";
+}
+
+void writeBuildId(int fd, const uint8_t* buildId, unsigned buildIdLen, unsigned pdbAge) {
+    if (buildIdLen == 0) {
+        writeStr(fd, "(unavailable)");
+        return;
+    }
+#if defined(_WIN32)
+    if (buildIdLen == 16) {
+        writeHexByte(fd, buildId[3]);
+        writeHexByte(fd, buildId[2]);
+        writeHexByte(fd, buildId[1]);
+        writeHexByte(fd, buildId[0]);
+        writeStr(fd, "-");
+        writeHexByte(fd, buildId[5]);
+        writeHexByte(fd, buildId[4]);
+        writeStr(fd, "-");
+        writeHexByte(fd, buildId[7]);
+        writeHexByte(fd, buildId[6]);
+        writeStr(fd, "-");
+        writeHexByte(fd, buildId[8]);
+        writeHexByte(fd, buildId[9]);
+        writeStr(fd, "-");
+        writeHexBytes(fd, buildId + 10, 6);
+        if (pdbAge != 0) {
+            writeStr(fd, "-");
+            writeDec(fd, pdbAge);
+        }
+        return;
+    }
+#else
+    (void)pdbAge;
+#endif
+    writeHexBytes(fd, buildId, buildIdLen);
 }
 
 const char* symbolFor(uintptr_t pc, unsigned long long* disp) {
@@ -156,7 +219,47 @@ const char* symbolFor(uintptr_t pc, unsigned long long* disp) {
 #endif
 }
 
+void fallbackModuleInfo(ModuleInfo& info) {
+    info = {};
+    info.base = g_ctx.moduleBase;
+    std::strncpy(info.path, g_ctx.modulePath, sizeof(info.path) - 1);
+    if (g_ctx.buildIdLen > sizeof(info.buildId)) {
+        info.buildIdLen = sizeof(info.buildId);
+    } else {
+        info.buildIdLen = g_ctx.buildIdLen;
+    }
+    if (info.buildIdLen != 0) {
+        std::memcpy(info.buildId, g_ctx.buildId, info.buildIdLen);
+    }
+    info.pdbAge = g_ctx.pdbAge;
+}
+
+bool findModuleInfo(uintptr_t pc, ModuleInfo& info);
+
+void emitAddressDetail(int fd, uintptr_t pc) {
+    ModuleInfo info;
+    findModuleInfo(pc, info);
+    const uintptr_t rva = pc >= info.base ? pc - info.base : 0ull;
+    writeHex(fd, pc);
+    writeStr(fd, " module_base=");
+    writeHex(fd, info.base);
+    if (info.size != 0) {
+        writeStr(fd, " image_size=");
+        writeHex(fd, info.size);
+    }
+    writeStr(fd, " rva=");
+    writeHex(fd, rva);
+    writeStr(fd, " module=");
+    writeQuoted(fd, info.path[0] != '\0' ? info.path : baseName(g_ctx.modulePath));
+    writeStr(fd, " build_id=");
+    writeBuildId(fd, info.buildId, info.buildIdLen, info.pdbAge);
+}
+
 void emitFrame(int fd, int index, uintptr_t pc) {
+    ModuleInfo info;
+    findModuleInfo(pc, info);
+    const uintptr_t rva = pc >= info.base ? pc - info.base : 0ull;
+
     writeStr(fd, "#");
     if (index < 10) {
         writeStr(fd, "0");
@@ -164,10 +267,18 @@ void emitFrame(int fd, int index, uintptr_t pc) {
     writeDec(fd, static_cast<unsigned int>(index));
     writeStr(fd, " abs=");
     writeHex(fd, pc);
+    writeStr(fd, " module_base=");
+    writeHex(fd, info.base);
+    if (info.size != 0) {
+        writeStr(fd, " image_size=");
+        writeHex(fd, info.size);
+    }
     writeStr(fd, " rva=");
-    writeHex(fd, pc >= g_ctx.moduleBase ? pc - g_ctx.moduleBase : 0ull);
-    writeStr(fd, " ");
-    writeStr(fd, moduleName());
+    writeHex(fd, rva);
+    writeStr(fd, " module=");
+    writeQuoted(fd, info.path[0] != '\0' ? info.path : baseName(g_ctx.modulePath));
+    writeStr(fd, " build_id=");
+    writeBuildId(fd, info.buildId, info.buildIdLen, info.pdbAge);
     unsigned long long disp = 0;
     const char* sym = symbolFor(pc, &disp);
     if (sym != nullptr && sym[0] != '\0') {
@@ -191,18 +302,7 @@ void emitHeader(int fd, const char* reason, unsigned long long code, bool hasCod
     writeStr(fd, "\nModule base: ");
     writeHex(fd, g_ctx.moduleBase);
     writeStr(fd, "\nBuild-ID:    ");
-    if (g_ctx.buildIdLen != 0) {
-        writeHexBytes(fd, g_ctx.buildId, g_ctx.buildIdLen);
-#if defined(_WIN32)
-        if (g_ctx.pdbAge != 0) {
-            writeStr(fd, " (Age=");
-            writeDec(fd, g_ctx.pdbAge);
-            writeStr(fd, ")");
-        }
-#endif
-    } else {
-        writeStr(fd, "(unavailable)");
-    }
+    writeBuildId(fd, g_ctx.buildId, g_ctx.buildIdLen, g_ctx.pdbAge);
     writeStr(fd, "\nReason:      ");
     writeStr(fd, reason);
     if (hasCode) {
@@ -214,9 +314,7 @@ void emitHeader(int fd, const char* reason, unsigned long long code, bool hasCod
     writeHex(fd, faultAddr);
     writeStr(fd, "\nCrash PC:    ");
     if (crashPcKnown) {
-        writeHex(fd, crashPc);
-        writeStr(fd, " rva=");
-        writeHex(fd, crashPc >= g_ctx.moduleBase ? crashPc - g_ctx.moduleBase : 0ull);
+        emitAddressDetail(fd, crashPc);
     } else {
         writeStr(fd, "(unavailable on this platform)");
     }
@@ -233,23 +331,25 @@ void emitFooter(int fd) {
 LONG g_inHandler = 0;
 LPTOP_LEVEL_EXCEPTION_FILTER g_prevFilter = nullptr;
 
-void captureBuildId() {
-    const auto* base = reinterpret_cast<const uint8_t*>(g_ctx.moduleBase);
+bool readPeModuleInfo(uintptr_t moduleBase, ModuleInfo& info) {
+    const auto* base = reinterpret_cast<const uint8_t*>(moduleBase);
     if (base == nullptr) {
-        return;
+        return false;
     }
     const auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(base);
     if (dos->e_magic != IMAGE_DOS_SIGNATURE) {
-        return;
+        return false;
     }
     const auto* nt = reinterpret_cast<const IMAGE_NT_HEADERS*>(base + dos->e_lfanew);
     if (nt->Signature != IMAGE_NT_SIGNATURE) {
-        return;
+        return false;
     }
+    info.base = moduleBase;
+    info.size = nt->OptionalHeader.SizeOfImage;
     const IMAGE_DATA_DIRECTORY& dir =
         nt->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_DEBUG];
     if (dir.VirtualAddress == 0 || dir.Size == 0) {
-        return;
+        return true;
     }
     const auto* dbg = reinterpret_cast<const IMAGE_DEBUG_DIRECTORY*>(base + dir.VirtualAddress);
     const unsigned count = dir.Size / sizeof(IMAGE_DEBUG_DIRECTORY);
@@ -261,11 +361,40 @@ void captureBuildId() {
         if (std::memcmp(cv, "RSDS", 4) != 0) {
             continue;
         }
-        std::memcpy(g_ctx.buildId, cv + 4, sizeof(GUID));
-        g_ctx.buildIdLen = sizeof(GUID);
-        std::memcpy(&g_ctx.pdbAge, cv + 4 + sizeof(GUID), sizeof(g_ctx.pdbAge));
+        std::memcpy(info.buildId, cv + 4, sizeof(GUID));
+        info.buildIdLen = sizeof(GUID);
+        std::memcpy(&info.pdbAge, cv + 4 + sizeof(GUID), sizeof(info.pdbAge));
         break;
     }
+    return true;
+}
+
+void captureBuildId() {
+    ModuleInfo info;
+    if (!readPeModuleInfo(g_ctx.moduleBase, info)) {
+        return;
+    }
+    g_ctx.buildIdLen = info.buildIdLen;
+    if (g_ctx.buildIdLen != 0) {
+        std::memcpy(g_ctx.buildId, info.buildId, g_ctx.buildIdLen);
+    }
+    g_ctx.pdbAge = info.pdbAge;
+}
+
+bool findModuleInfo(uintptr_t pc, ModuleInfo& info) {
+    fallbackModuleInfo(info);
+    MEMORY_BASIC_INFORMATION mbi;
+    if (VirtualQuery(reinterpret_cast<LPCVOID>(pc), &mbi, sizeof(mbi)) == 0 ||
+        mbi.AllocationBase == nullptr) {
+        return false;
+    }
+    const auto moduleBase = reinterpret_cast<uintptr_t>(mbi.AllocationBase);
+    info = {};
+    info.base = moduleBase;
+    GetModuleFileNameA(reinterpret_cast<HMODULE>(moduleBase), info.path,
+        static_cast<DWORD>(sizeof(info.path) - 1));
+    readPeModuleInfo(moduleBase, info);
+    return true;
 }
 
 const char* exceptionName(DWORD code) {
@@ -512,22 +641,34 @@ void prewarmUnwinder() {
 
 #if defined(__APPLE__)
 
-void captureBuildId() {
-    const auto* header = reinterpret_cast<const struct mach_header_64*>(g_ctx.moduleBase);
+bool readMachBuildId(uintptr_t moduleBase, ModuleInfo& info) {
+    const auto* header = reinterpret_cast<const struct mach_header_64*>(moduleBase);
     if (header == nullptr || header->magic != MH_MAGIC_64) {
-        return;
+        return false;
     }
     const auto* lc = reinterpret_cast<const struct load_command*>(
         reinterpret_cast<const char*>(header) + sizeof(struct mach_header_64));
     for (uint32_t i = 0; i < header->ncmds; ++i) {
         if (lc->cmd == LC_UUID) {
             const auto* uuid = reinterpret_cast<const struct uuid_command*>(lc);
-            std::memcpy(g_ctx.buildId, uuid->uuid, sizeof(uuid->uuid));
-            g_ctx.buildIdLen = sizeof(uuid->uuid);
-            return;
+            std::memcpy(info.buildId, uuid->uuid, sizeof(uuid->uuid));
+            info.buildIdLen = sizeof(uuid->uuid);
+            return true;
         }
         lc = reinterpret_cast<const struct load_command*>(
             reinterpret_cast<const char*>(lc) + lc->cmdsize);
+    }
+    return true;
+}
+
+void captureBuildId() {
+    ModuleInfo info;
+    if (!readMachBuildId(g_ctx.moduleBase, info)) {
+        return;
+    }
+    g_ctx.buildIdLen = info.buildIdLen;
+    if (g_ctx.buildIdLen != 0) {
+        std::memcpy(g_ctx.buildId, info.buildId, g_ctx.buildIdLen);
     }
 }
 
@@ -547,7 +688,28 @@ bool segmentContains(const dl_phdr_info* info, uintptr_t addr) {
     return false;
 }
 
-bool readGnuBuildId(const dl_phdr_info* info) {
+void readElfModuleInfo(const dl_phdr_info* info, ModuleInfo& module) {
+    uintptr_t minAddr = ~static_cast<uintptr_t>(0);
+    uintptr_t maxAddr = 0;
+    for (int i = 0; i < info->dlpi_phnum; ++i) {
+        const ElfW(Phdr)& ph = info->dlpi_phdr[i];
+        if (ph.p_type != PT_LOAD) {
+            continue;
+        }
+        const uintptr_t start = info->dlpi_addr + ph.p_vaddr;
+        const uintptr_t end = start + ph.p_memsz;
+        if (start < minAddr) {
+            minAddr = start;
+        }
+        if (end > maxAddr) {
+            maxAddr = end;
+        }
+    }
+    if (minAddr <= maxAddr && maxAddr != 0) {
+        module.base = minAddr;
+        module.size = maxAddr - minAddr;
+    }
+
     for (int i = 0; i < info->dlpi_phnum; ++i) {
         const ElfW(Phdr)& ph = info->dlpi_phdr[i];
         if (ph.p_type != PT_NOTE) {
@@ -563,17 +725,16 @@ bool readGnuBuildId(const dl_phdr_info* info) {
             if (nh->n_type == NT_GNU_BUILD_ID && nh->n_namesz == 4 &&
                 std::memcmp(name, "GNU", 4) == 0) {
                 unsigned n = nh->n_descsz;
-                if (n > sizeof(g_ctx.buildId)) {
-                    n = sizeof(g_ctx.buildId);
+                if (n > sizeof(module.buildId)) {
+                    n = sizeof(module.buildId);
                 }
-                std::memcpy(g_ctx.buildId, desc, n);
-                g_ctx.buildIdLen = n;
-                return true;
+                std::memcpy(module.buildId, desc, n);
+                module.buildIdLen = n;
+                return;
             }
             p = desc + ((nh->n_descsz + 3) & ~3u);
         }
     }
-    return false;
 }
 
 int elfBuildIdCallback(dl_phdr_info* info, size_t, void* arg) {
@@ -581,7 +742,12 @@ int elfBuildIdCallback(dl_phdr_info* info, size_t, void* arg) {
     if (!segmentContains(info, self)) {
         return 0;
     }
-    readGnuBuildId(info);
+    ModuleInfo module;
+    readElfModuleInfo(info, module);
+    g_ctx.buildIdLen = module.buildIdLen;
+    if (g_ctx.buildIdLen != 0) {
+        std::memcpy(g_ctx.buildId, module.buildId, g_ctx.buildIdLen);
+    }
     return 1;
 }
 
@@ -591,6 +757,50 @@ void captureBuildId() {
 }
 
 #endif
+
+#if !defined(__APPLE__)
+struct ElfModuleSearch {
+    uintptr_t pc;
+    ModuleInfo* module;
+};
+
+int elfModuleInfoCallback(dl_phdr_info* info, size_t, void* arg) {
+    auto* search = static_cast<ElfModuleSearch*>(arg);
+    if (!segmentContains(info, search->pc)) {
+        return 0;
+    }
+    if (info->dlpi_name != nullptr && info->dlpi_name[0] != '\0') {
+        std::strncpy(search->module->path, info->dlpi_name,
+            sizeof(search->module->path) - 1);
+    }
+    readElfModuleInfo(info, *search->module);
+    return 1;
+}
+#endif
+
+bool findModuleInfo(uintptr_t pc, ModuleInfo& info) {
+    fallbackModuleInfo(info);
+    Dl_info moduleInfo;
+    if (dladdr(reinterpret_cast<void*>(pc), &moduleInfo) == 0) {
+        return false;
+    }
+    if (moduleInfo.dli_fbase != nullptr) {
+        info.base = reinterpret_cast<uintptr_t>(moduleInfo.dli_fbase);
+    }
+    if (moduleInfo.dli_fname != nullptr && moduleInfo.dli_fname[0] != '\0') {
+        info.path[0] = '\0';
+        std::strncpy(info.path, moduleInfo.dli_fname, sizeof(info.path) - 1);
+    }
+    info.buildIdLen = 0;
+    info.pdbAge = 0;
+#if defined(__APPLE__)
+    readMachBuildId(info.base, info);
+#else
+    ElfModuleSearch search{pc, &info};
+    dl_iterate_phdr(&elfModuleInfoCallback, &search);
+#endif
+    return true;
+}
 
 const char* signalName(int sig) {
     switch (sig) {

--- a/src/dusk/io.cpp
+++ b/src/dusk/io.cpp
@@ -1,5 +1,7 @@
+#include <cerrno>
 #include <cstdio>
 #include <filesystem>
+#include <system_error>
 
 #include "dusk/io.hpp"
 
@@ -30,6 +32,9 @@ static FILE* ThrowIfNotOpen(const FileStream& file) {
 }
 
 [[noreturn]] static void ThrowForError(int code) {
+    if (code == 0) {
+        throw std::system_error(std::make_error_code(std::errc::io_error));
+    }
     throw std::system_error(std::make_error_code(static_cast<std::errc>(code)));
 }
 
@@ -75,6 +80,14 @@ FileStream::FileStream(FileStream&& other) noexcept {
 FileStream::~FileStream() {
     if (file)
         fclose(static_cast<FILE*>(file));
+}
+
+void FileStream::Flush() {
+    FILE* fileHandle = ThrowIfNotOpen(*this);
+
+    if (fflush(fileHandle) != 0) {
+        ThrowForError(errno);
+    }
 }
 
 FileStream FileStream::OpenRead(const char* utf8Path) {
@@ -163,6 +176,7 @@ void FileStream::WriteAllText(const char* utf8Path, const std::string_view text)
 void FileStream::WriteAllText(const std::filesystem::path& path, const std::string_view text) {
     auto handle = Create(path);
     handle.Write(text.data(), text.size());
+    handle.Flush();
 }
 
 FILE* FileStream::ToInner() {

--- a/src/dusk/randomizer/game/randomizer_context.cpp
+++ b/src/dusk/randomizer/game/randomizer_context.cpp
@@ -10,6 +10,8 @@
 #include "dusk/randomizer/game/verify_item_functions.h"
 #include "dusk/randomizer/generator/utility/endian.hpp"
 #include "dusk/randomizer/generator/utility/yaml.hpp"
+#include "dusk/randomizer/generator/logic/entrance.hpp"
+#include "dusk/randomizer/generator/logic/world.hpp"
 #include "dusk/randomizer/generator/randomizer.hpp"
 #include "dusk/randomizer/generator/utility/text.hpp"
 
@@ -86,6 +88,14 @@ std::optional<std::string> RandomizerContext::WriteToFile() {
 
     out["mStartHour"] = static_cast<u16>(this->mStartHour);
     out["mMapBits"] = static_cast<u16>(this->mMapBits);
+
+    if (this->mStartLocation.has_value()) {
+        const auto& s = this->mStartLocation.value();
+        out["mStartLocation"]["stage"] = static_cast<int>(s.stage);
+        out["mStartLocation"]["point"] = static_cast<int>(s.point);
+        out["mStartLocation"]["room"] = static_cast<int>(s.room);
+        out["mStartLocation"]["layer"] = static_cast<int>(s.layer);
+    }
 
     for (const auto& [stageRoomLayer, actorPatches] : this->mObjectPatches) {
         for (const auto& [actorCRC, actorPatch] : actorPatches) {
@@ -228,6 +238,16 @@ std::optional<std::string> RandomizerContext::LoadFromHash(const std::string& ha
     this->mStartHour = in["mStartHour"].as<u8>();
     // Starting map bits
     this->mMapBits = in["mMapBits"].as<u8>();
+
+    // Starting spawn override (optional)
+    if (in["mStartLocation"]) {
+        StartLocation s;
+        s.stage = static_cast<s16>(in["mStartLocation"]["stage"].as<int>());
+        s.point = static_cast<s16>(in["mStartLocation"]["point"].as<int>());
+        s.room = static_cast<s8>(in["mStartLocation"]["room"].as<int>());
+        s.layer = static_cast<s8>(in["mStartLocation"]["layer"].as<int>());
+        this->mStartLocation = s;
+    }
 
     // Object Patches
     for (const auto& stageRoomLayerNode: in["mObjectPatches"]) {
@@ -1164,6 +1184,29 @@ RandomizerContext WriteSeedData(randomizer::logic::world::World* world) {
         randoData.mStartHour = 18;
     else if (startTimeSetting == "Night")
         randoData.mStartHour = 24;
+
+    // Starting spawn override
+    if (world->Setting("Randomize Starting Spawn") == "On") {
+        auto* spawnEntrance = world->GetEntrance("Links Spawn -> Outside Links House");
+        if (spawnEntrance != nullptr) {
+            auto* replacement = spawnEntrance->GetReplaces();
+            if (replacement != nullptr && replacement->HasWarpData()) {
+                RandomizerContext::StartLocation spawn{};
+                spawn.stage = static_cast<s16>(replacement->GetWarpStage());
+                spawn.room = static_cast<s8>(replacement->GetWarpRoom());
+                spawn.point = static_cast<s16>(replacement->GetWarpSpawn());
+                spawn.layer = static_cast<s8>(replacement->GetWarpLayer());
+                randoData.mStartLocation = spawn;
+                DuskLog.debug("Randomizer starting spawn: stage={} room={} point={} layer={}",
+                              spawn.stage, spawn.room, spawn.point, spawn.layer);
+            } else {
+                // Shouldn't really happen, a different spawn is chosen
+                // when there's no warp data (a few are invalid in the yaml)
+                DuskLog.debug("Randomizer starting spawn enabled but the chosen entrance has "
+                              "no warp data populated; using vanilla spawn.");
+            }
+        }
+    }
 
     // Actor Patches
     auto actorPatches = LOAD_EMBED_YAML(RANDO_DATA_PATH "object_patches.yaml");

--- a/src/dusk/randomizer/game/randomizer_context.hpp
+++ b/src/dusk/randomizer/game/randomizer_context.hpp
@@ -68,14 +68,14 @@ public:
     // };
     std::unordered_map<u32, std::string> mTextOverrides{};
 
-    // TODO: hook this up to generator data
-    struct {
-        // for now use hardcoded values for this
-        std::string mapName = "F_SP103"; // (Ordon) Outside Link's House
-        int pointNo = 1;
-        int roomNo = 1;
-        int mapLayer = -1;
-    } mStartLocation;
+    // Overrides Link's spawn point when a new randomizer save is created
+    struct StartLocation {
+        s16 stage{-1};  // game::allStages[]
+        s16 point{0};
+        s8 room{0};
+        s8 layer{-1};
+    };
+    std::optional<StartLocation> mStartLocation{};
 
     std::optional<std::string> WriteToFile();
     std::optional<std::string> LoadFromHash(const std::string& hash);
@@ -173,6 +173,10 @@ public:
     u8 mTimeChange{};
     u8 mEventItemQueue[EVENT_ITEM_QUEUE_SIZE];
     bool mRoomReloadingState{false};
+
+    // setupRandomizerSave sets this when a save is made
+    // with a starting spawn override, dComIfGs_gameStart unsets
+    bool mPendingStartLocation{false};
 
     // Used to store an item id for a flow message override so that we can give the item
     // once the textbox is closed instead of when the message appears. This lines up

--- a/src/dusk/randomizer/generator/data/entrance_shuffle_data.yaml
+++ b/src/dusk/randomizer/generator/data/entrance_shuffle_data.yaml
@@ -5,11 +5,11 @@
 - Type: Spawn
   Forward:
     Connection: Links Spawn -> Outside Links House
-    Stage: -1
-    Room: -1
-    Spawn: ""
-    Spawn Type: ""
-    Parameters: ""
+    Stage: 43
+    Room: 1
+    Spawn: "01"
+    Spawn Type: "00"
+    Parameters: "F01F"
     State: "FF"
 
 ###############################
@@ -1019,11 +1019,11 @@
 - Type: Interior
   Forward:
     Connection: Ordon Village -> Ordon Shield House Upper Ledge
-    Stage: 
-    Room: 
-    Spawn: ""
-    Spawn Type: ""
-    Parameters: ""
+    Stage: 43
+    Room: 2
+    Spawn: "01"
+    Spawn Type: "B0"
+    Parameters: "F09F"
     State: "FF"
   Return:
     Connection: Ordon Shield House Upper Ledge -> Ordon Village
@@ -1045,11 +1045,11 @@
     State: "FF"
   Return:
     Connection: Ordon Fados House -> Ordon Village
-    Stage: 
-    Room: 
-    Spawn: ""
-    Spawn Type: ""
-    Parameters: ""
+    Stage: 43
+    Room: 0
+    Spawn: "07"
+    Spawn Type: "A0"
+    Parameters: "F09F"
     State: "FF"
 
 - Type: Interior
@@ -1222,7 +1222,7 @@
   Forward:
     Connection: Kakariko Renados Sanctuary -> Kakariko Renados Sanctuary Basement
     Stage: 75
-    Room: 5
+    Room: 7
     Spawn: "00"
     Spawn Type: "FF"
     Parameters: "FFFF"
@@ -2369,7 +2369,7 @@
     Stage: 56
     Room: 10
     Spawn: "02"
-    Spawn Type: D0""
+    Spawn Type: "D0"
     Parameters: "00FF"
     State: "FF"
   Return:

--- a/src/dusk/randomizer/generator/logic/entrance.cpp
+++ b/src/dusk/randomizer/generator/logic/entrance.cpp
@@ -109,6 +109,40 @@ namespace randomizer::logic::entrance
         return this->_id;
     }
 
+    void Entrance::SetWarpData(int stage, int room, int spawn, int layer)
+    {
+        this->_warpStage = stage;
+        this->_warpRoom = room;
+        this->_warpSpawn = spawn;
+        this->_warpLayer = layer;
+        this->_hasWarpData = stage >= 0 && room >= 0;
+    }
+
+    bool Entrance::HasWarpData() const
+    {
+        return this->_hasWarpData;
+    }
+
+    int Entrance::GetWarpStage() const
+    {
+        return this->_warpStage;
+    }
+
+    int Entrance::GetWarpRoom() const
+    {
+        return this->_warpRoom;
+    }
+
+    int Entrance::GetWarpSpawn() const
+    {
+        return this->_warpSpawn;
+    }
+
+    int Entrance::GetWarpLayer() const
+    {
+        return this->_warpLayer;
+    }
+
     std::string Entrance::GetCurrentName() const
     {
         std::string parentName = this->_parentArea ? this->_parentArea->GetName() : "None";

--- a/src/dusk/randomizer/generator/logic/entrance.hpp
+++ b/src/dusk/randomizer/generator/logic/entrance.hpp
@@ -74,6 +74,15 @@ namespace randomizer::logic::entrance
 
         void SetID(const int& id);
         int GetID() const;
+        /**
+         * @brief Set the in-game warp data parsed from entrance_shuffle_data.
+         */
+        void SetWarpData(int stage, int room, int spawn, int layer);
+        bool HasWarpData() const;
+        int GetWarpStage() const;
+        int GetWarpRoom() const;
+        int GetWarpSpawn() const;
+        int GetWarpLayer() const;
         std::string GetCurrentName() const;
         std::string GetOriginalName() const;
         void SetAlias(const std::string& alias);
@@ -169,6 +178,15 @@ namespace randomizer::logic::entrance
          * world graph.
          */
         requirement::Requirement _computedRequirement;
+
+        /**
+         * @brief In-game warp data parsed from entrance_shuffle_data.
+         */
+        bool _hasWarpData = false;
+        int _warpStage = -1;
+        int _warpRoom = -1;
+        int _warpSpawn = 0;
+        int _warpLayer = -1;
 
         // Variables used for entrance shuffling
         bool _canStartAt = false;

--- a/src/dusk/randomizer/generator/logic/entrance_shuffle.cpp
+++ b/src/dusk/randomizer/generator/logic/entrance_shuffle.cpp
@@ -35,6 +35,80 @@ namespace randomizer::logic::entrance_shuffle
         ValidateWorld(world, worlds, nullptr, completeItemPool);
     }
 
+    namespace
+    {
+        // Parse decimal values from YAML
+        int ReadDecimalField(const YAML::Node& node, int fallback)
+        {
+            if (!node)
+            {
+                return fallback;
+            }
+            try
+            {
+                return node.as<int>();
+            }
+            catch (const std::exception&)
+            {
+                return fallback;
+            }
+        }
+
+        // Parse hex string Spawn values from YAML
+        int ReadSpawnHexField(const YAML::Node& node, int fallback)
+        {
+            if (!node || !node.IsScalar())
+            {
+                return fallback;
+            }
+            auto str = node.as<std::string>();
+            if (str.empty())
+            {
+                return fallback;
+            }
+            try
+            {
+                return static_cast<int>(std::stoul(str, nullptr, 16));
+            }
+            catch (const std::exception&)
+            {
+                return fallback;
+            }
+        }
+
+        // Parse hex string Layer/State values from YAML
+        int ReadLayerHexField(const YAML::Node& node, int fallback)
+        {
+            if (!node || !node.IsScalar())
+            {
+                return fallback;
+            }
+            auto str = node.as<std::string>();
+            if (str.empty())
+            {
+                return fallback;
+            }
+            try
+            {
+                auto raw = std::stoul(str, nullptr, 16);
+                return static_cast<int>(static_cast<int8_t>(raw));
+            }
+            catch (const std::exception&)
+            {
+                return fallback;
+            }
+        }
+
+        void ApplyWarpDataFromYaml(entrance::Entrance* entrance, const YAML::Node& entry)
+        {
+            const int stage = ReadDecimalField(entry["Stage"], -1);
+            const int room = ReadDecimalField(entry["Room"], -1);
+            const int spawn = ReadSpawnHexField(entry["Spawn"], 0);
+            const int layer = ReadLayerHexField(entry["State"], -1);
+            entrance->SetWarpData(stage, room, spawn, layer);
+        }
+    }
+
     void SetAllEntrancesData(world::World* world)
     {
         // Keep track of which double door entrances are together
@@ -60,7 +134,7 @@ namespace randomizer::logic::entrance_shuffle
 
             auto forwardEntrance = world->GetEntrance(forwardEntry["Connection"].as<std::string>());
             forwardEntrance->SetType(type);
-            // TODO: Set actual entrance data
+            ApplyWarpDataFromYaml(forwardEntrance, forwardEntry);
             forwardEntrance->SetID(world->GetNewEntranceID());
             forwardEntrance->SetPrimary(true);
             forwardEntrance->SetAlias(
@@ -73,7 +147,7 @@ namespace randomizer::logic::entrance_shuffle
 
                 auto returnEntrance = world->GetEntrance(returnEntry["Connection"].as<std::string>());
                 returnEntrance->SetType(type);
-                // TODO: Set actual entrance data
+                ApplyWarpDataFromYaml(returnEntrance, returnEntry);
                 returnEntrance->SetID(world->GetNewEntranceID());
                 returnEntrance->SetAlias(
                     returnEntry["Alias"] ? returnEntry["Alias"].as<std::string>() : "");
@@ -305,6 +379,13 @@ namespace randomizer::logic::entrance_shuffle
                 {
                     for (const auto& entrance : world->GetShuffleableEntrances(typeForSpawn))
                     {
+                        if (!entrance->HasWarpData()) // Never pick an empty warp for spawn point
+                        {
+                            LOG_TO_DEBUG("Skipping spawn candidate without warp data: " +
+                                         entrance->GetOriginalName());
+                            continue;
+                        }
+
                         auto newTarget = entrance->GetNewTarget();
                         spawnPool.push_back(newTarget);
 

--- a/src/dusk/randomizer/generator/logic/fill.cpp
+++ b/src/dusk/randomizer/generator/logic/fill.cpp
@@ -122,9 +122,10 @@ namespace randomizer::logic::fill
                 // Loop through the shuffled locations until we find a valid one.
                 // If a world is only checking for beatable logic, then we can ignore
                 // any access checks and just choose a random location if the world is already beatable
+                auto noLogic = itemToPlace->GetWorld()->Setting("Logic Rules") == "No Logic";
                 auto beatableOnlyLogic = itemToPlace->GetWorld()->Setting("Logic Rules") == "Beatable Only";
                 bool canChooseAnyLocation =
-                    search._ownedItems.contains(itemToPlace->GetWorld()->GetGameWinningItem()) && beatableOnlyLogic;
+                    noLogic || search._ownedItems.contains(itemToPlace->GetWorld()->GetGameWinningItem()) && beatableOnlyLogic;
 
                 for (const auto& location : allowedLocations)
                 {

--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -95,7 +95,6 @@ void set_value(GraphicsOption option, int value) {
         getSettings().game.bloomMultiplier.setValue(std::clamp(value, 0, 100) / 100.0f);
         break;
     }
-    config::Save();
 }
 
 Rml::Element* create_stepped_carousel_root(Rml::Element* parent) {
@@ -292,6 +291,7 @@ void GraphicsTuner::show() {
 }
 
 void GraphicsTuner::hide(bool close) {
+    config::Save();
     mRoot->RemoveAttribute("open");
     if (close) {
         mPendingClose = true;

--- a/src/dusk/ui/rando_config.cpp
+++ b/src/dusk/ui/rando_config.cpp
@@ -12,6 +12,7 @@
 #include "pane.hpp"
 #include "string_button.hpp"
 #include "dusk/randomizer/game/tools.h"
+#include "dusk/randomizer/game/stages.h"
 #include "dusk/randomizer/generator/seedgen/seed.hpp"
 
 namespace dusk::ui {
@@ -464,7 +465,13 @@ RandomizerWindow::RandomizerWindow() {
             leftPane.register_control(leftPane.add_button("Warp to Start").on_pressed([] {
                 mDoAud_seStartMenu(kSoundClick);
                 auto& locData = randomizer_GetContext().mStartLocation;
-                dComIfGp_setNextStage(locData.mapName.c_str(), locData.pointNo, locData.roomNo, locData.mapLayer);
+                const int stageCount = static_cast<int>(sizeof(allStages) / sizeof(allStages[0]));
+                if (locData.has_value() && locData->stage >= 0 && locData->stage < stageCount) {
+                    dComIfGp_setNextStage(
+                        allStages[locData->stage], locData->point, locData->room, locData->layer);
+                } else {
+                    dComIfGp_setNextStage("F_SP108", 21, 1, 13);
+                }
             }), rightPane, [](Pane& pane) {
                 pane.clear();
                 pane.add_rml("Respawns the player at their appropriate starting location.");

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1501,4 +1501,9 @@ void SettingsWindow::update() {
     Window::update();
 }
 
+void SettingsWindow::hide(bool close) {
+    config::Save();
+    Window::hide(close);
+}
+
 }  // namespace dusk::ui

--- a/src/dusk/ui/settings.hpp
+++ b/src/dusk/ui/settings.hpp
@@ -8,6 +8,7 @@ public:
     SettingsWindow(bool prelaunch = false);
 
     void update() override;
+    void hide(bool close) override;
 
 protected:
     bool mPrelaunch;

--- a/src/dusk/ui/string_button.cpp
+++ b/src/dusk/ui/string_button.cpp
@@ -7,7 +7,7 @@ namespace dusk::ui {
 BaseStringButton::BaseStringButton(Rml::Element* parent, Props props)
     : BaseControlledSelectButton(parent, {std::move(props.key)}), mType(std::move(props.type)),
       mMaxLength(props.maxLength) {
-    mInputListeners.reserve(3);
+    mInputListeners.reserve(4);
 }
 
 void BaseStringButton::update() {
@@ -54,6 +54,15 @@ void BaseStringButton::start_editing() {
     mRoot->DispatchEvent(Rml::EventId::Submit, {{"handled", Rml::Variant{true}}});
 
     // Register input listeners
+    mInputListeners.emplace_back(std::make_unique<ScopedEventListener>(
+        mInputElem, Rml::EventId::Textinput, [this](Rml::Event& event) {
+            if (event.GetTargetElement() == mInputElem) {
+                const Rml::String text = event.GetParameter("text", Rml::String{});
+                if (!text.empty() && std::ranges::all_of(text, [](const char c) { return c == '\r' || c == '\n' || c == '\t'; })) {
+                    event.StopImmediatePropagation();
+                }
+            }
+        }));
     mInputListeners.emplace_back(std::make_unique<ScopedEventListener>(
         mInputElem, Rml::EventId::Keydown, [this](Rml::Event& event) {
             const auto cmd = map_nav_event(event);

--- a/src/dusk/ui/ui.cpp
+++ b/src/dusk/ui/ui.cpp
@@ -61,7 +61,6 @@ bool initialize() noexcept {
 }
 
 void shutdown() noexcept {
-    config::Save();
     sDocumentStack.clear();
     sPassiveDocuments.clear();
     sConnectedGamepads.clear();


### PR DESCRIPTION
- Implements No Logic (Just 2 changes to fill.cpp, idk if I'm just stupid but it didn't seem to be working at all before, wasn't checked anywhere) _*Spheres still get generated, however it's clear that no logic is now working_

- Fills in a few entries in entrance_shuffle_data and fixed typos (?)

- Implements Random Spawn Location (Gets warp data from yaml and warp menu data, validates and sets next stage)

- Tested a loop to validate all spawns in the pool and only 6 of them fail, which are the ones with invalid data in the yaml (Wii 1.0 exclusive, Fado's house, one-way entrances, etc) and they all get skipped as spawn candidates. Filled in the few that exist

I'm unsure how to structure rando PRs because it's all still super in progress, and I'm sure others are working on both of these. I've been running seeds with this code for a couple weeks and it's been solid. Random spawn currently skips the prologue cutscene however I also tested keeping the cutscene and it would work fine