### PR TITLE
Suppress Textinput line break events on BaseStringButton

### DIFF
--- a/src/dusk/ui/string_button.cpp
+++ b/src/dusk/ui/string_button.cpp
@@ -7,7 +7,7 @@ namespace dusk::ui {
 BaseStringButton::BaseStringButton(Rml::Element* parent, Props props)
     : BaseControlledSelectButton(parent, {std::move(props.key)}), mType(std::move(props.type)),
       mMaxLength(props.maxLength) {
-    mInputListeners.reserve(3);
+    mInputListeners.reserve(4);
 }
 
 void BaseStringButton::update() {
@@ -53,7 +53,15 @@ void BaseStringButton::start_editing() {
     // However, mark it as "handled" to ensure that we don't steal focus away
     mRoot->DispatchEvent(Rml::EventId::Submit, {{"handled", Rml::Variant{true}}});
 
-    // Register input listeners
+    mInputListeners.emplace_back(std::make_unique<ScopedEventListener>(
+        mInputElem, Rml::EventId::Textinput, [this](Rml::Event& event) {
+            if (event.GetTargetElement() == mInputElem) {
+                const Rml::String text = event.GetParameter("text", Rml::String{});
+                if (!text.empty() && std::ranges::all_of(text, [](const char c) { return c == '\r' || c == '\n' || c == '\t'; })) {
+                    event.StopImmediatePropagation();
+                }
+            }
+        }));
     mInputListeners.emplace_back(std::make_unique<ScopedEventListener>(
         mInputElem, Rml::EventId::Keydown, [this](Rml::Event& event) {
             const auto cmd = map_nav_event(event);

--- a/src/dusk/ui/string_button.cpp
+++ b/src/dusk/ui/string_button.cpp
@@ -53,6 +53,7 @@ void BaseStringButton::start_editing() {
     // However, mark it as "handled" to ensure that we don't steal focus away
     mRoot->DispatchEvent(Rml::EventId::Submit, {{"handled", Rml::Variant{true}}});
 
+    // Register input listeners
     mInputListeners.emplace_back(std::make_unique<ScopedEventListener>(
         mInputElem, Rml::EventId::Textinput, [this](Rml::Event& event) {
             if (event.GetTargetElement() == mInputElem) {


### PR DESCRIPTION
Closes #1824

Pressing Return/NumpadEnter on a keyboard would send a Textinput event consisting solely a newline char, overwriting any highlighted portion of a string before editing was stopped. I've added an input listener to suppress that.