### PR TITLE
Various fixes for configuration persistence

### DIFF
--- a/include/dusk/io.hpp
+++ b/include/dusk/io.hpp
@@ -31,6 +31,11 @@ public:
     ~FileStream();
 
     /**
+     * \brief Flush buffered writes and throw if the flush fails.
+     */
+    void Flush();
+
+    /**
      * \brief Open a file for reading at the given path.
      */
     static FileStream OpenRead(const char* utf8Path);

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -8,6 +8,8 @@
 #include "dusk/settings.h"
 
 #include <limits>
+#include <filesystem>
+#include <system_error>
 #include <string>
 
 #include "dusk/main.h"
@@ -24,8 +26,24 @@ aurora::Module DuskConfigLog("dusk::config");
 static absl::flat_hash_map<std::string_view, ConfigVarBase*> RegisteredConfigVars;
 static bool RegistrationDone = false;
 
-static std::u8string GetConfigJsonPath() {
-    return (dusk::ConfigPath / ConfigFileName).u8string();
+static std::filesystem::path GetConfigJsonPath() {
+    return dusk::ConfigPath / ConfigFileName;
+}
+
+static std::filesystem::path GetTempConfigJsonPath(const std::filesystem::path& configJsonPath) {
+    auto tempPath = configJsonPath;
+    tempPath.replace_filename(fmt::format(".{}.tmp", configJsonPath.filename().string()));
+    return tempPath;
+}
+
+static void ReplaceFile(const std::filesystem::path& source, const std::filesystem::path& target) {
+    std::error_code ec;
+    std::filesystem::rename(source, target, ec);
+    if (ec) {
+        const auto renameError = ec;
+        std::filesystem::remove(source, ec);
+        throw std::system_error(renameError);
+    }
 }
 
 ConfigVarBase::ConfigVarBase(const char* name, const ConfigImplBase* impl) : name(name), registered(false), layer(ConfigVarLayer::Default), impl(impl) {
@@ -211,7 +229,8 @@ void dusk::config::LoadFromUserPreferences() {
     if (configJsonPath.empty()) {
         return;
     }
-    LoadFromFileName(reinterpret_cast<const char*>(configJsonPath.c_str()));
+    const auto configPathString = io::fs_path_to_string(configJsonPath);
+    LoadFromFileName(configPathString.c_str());
 }
 
 static void LoadFromPath(const char* path) {
@@ -254,6 +273,10 @@ void dusk::config::LoadFromFileName(const char* path) {
         } else {
             DuskConfigLog.error("Failed to load from config! {}", e.what());
         }
+    } catch (const nlohmann::json::parse_error& e) {
+        DuskConfigLog.error("Failed to parse config JSON, staying with defaults: {}", e.what());
+    } catch (const std::exception& e) {
+        DuskConfigLog.error("Failed to load from config, staying with defaults: {}", e.what());
     }
 }
 
@@ -262,10 +285,11 @@ void dusk::config::Save() {
     if (configJsonPath.empty()) {
         return;
     }
+    const auto configPathString = io::fs_path_to_string(configJsonPath);
 
     DuskConfigLog.info(
         "Saving config to '{}'",
-        reinterpret_cast<const char*>(configJsonPath.c_str()));
+        configPathString);
 
     json j;
 
@@ -276,7 +300,13 @@ void dusk::config::Save() {
         }
     }
 
-    io::FileStream::WriteAllText(reinterpret_cast<const char*>(configJsonPath.c_str()), j.dump(4));
+    try {
+        const auto tempConfigJsonPath = GetTempConfigJsonPath(configJsonPath);
+        io::FileStream::WriteAllText(tempConfigJsonPath, j.dump(4));
+        ReplaceFile(tempConfigJsonPath, configJsonPath);
+    } catch (const std::exception& e) {
+        DuskConfigLog.error("Failed to save config to '{}': {}", configPathString, e.what());
+    }
 }
 
 void dusk::config::ClearAllActionBindings(int port) {

--- a/src/dusk/io.cpp
+++ b/src/dusk/io.cpp
@@ -1,5 +1,7 @@
+#include <cerrno>
 #include <cstdio>
 #include <filesystem>
+#include <system_error>
 
 #include "dusk/io.hpp"
 
@@ -30,6 +32,9 @@ static FILE* ThrowIfNotOpen(const FileStream& file) {
 }
 
 [[noreturn]] static void ThrowForError(int code) {
+    if (code == 0) {
+        throw std::system_error(std::make_error_code(std::errc::io_error));
+    }
     throw std::system_error(std::make_error_code(static_cast<std::errc>(code)));
 }
 
@@ -75,6 +80,14 @@ FileStream::FileStream(FileStream&& other) noexcept {
 FileStream::~FileStream() {
     if (file)
         fclose(static_cast<FILE*>(file));
+}
+
+void FileStream::Flush() {
+    FILE* fileHandle = ThrowIfNotOpen(*this);
+
+    if (fflush(fileHandle) != 0) {
+        ThrowForError(errno);
+    }
 }
 
 FileStream FileStream::OpenRead(const char* utf8Path) {
@@ -163,6 +176,7 @@ void FileStream::WriteAllText(const char* utf8Path, const std::string_view text)
 void FileStream::WriteAllText(const std::filesystem::path& path, const std::string_view text) {
     auto handle = Create(path);
     handle.Write(text.data(), text.size());
+    handle.Flush();
 }
 
 FILE* FileStream::ToInner() {

--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -95,7 +95,6 @@ void set_value(GraphicsOption option, int value) {
         getSettings().game.bloomMultiplier.setValue(std::clamp(value, 0, 100) / 100.0f);
         break;
     }
-    config::Save();
 }
 
 Rml::Element* create_stepped_carousel_root(Rml::Element* parent) {
@@ -292,6 +291,7 @@ void GraphicsTuner::show() {
 }
 
 void GraphicsTuner::hide(bool close) {
+    config::Save();
     mRoot->RemoveAttribute("open");
     if (close) {
         mPendingClose = true;

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1501,4 +1501,9 @@ void SettingsWindow::update() {
     Window::update();
 }
 
+void SettingsWindow::hide(bool close) {
+    config::Save();
+    Window::hide(close);
+}
+
 }  // namespace dusk::ui

--- a/src/dusk/ui/settings.hpp
+++ b/src/dusk/ui/settings.hpp
@@ -8,6 +8,7 @@ public:
     SettingsWindow(bool prelaunch = false);
 
     void update() override;
+    void hide(bool close) override;
 
 protected:
     bool mPrelaunch;

--- a/src/dusk/ui/ui.cpp
+++ b/src/dusk/ui/ui.cpp
@@ -61,7 +61,6 @@ bool initialize() noexcept {
 }
 
 void shutdown() noexcept {
-    config::Save();
     sDocumentStack.clear();
     sPassiveDocuments.clear();
     sConnectedGamepads.clear();


### PR DESCRIPTION
- Adds an explicit flush to FileStream::WriteAllText
- Removes config save on shutdown (seems to break on some Androids)
- Write config.json to a temp file and rename instead of overwriting directly
- Properly catch exceptions for invalid JSON & general errors
- Only save graphics tuner setting when backing out of the menu (so if it crashes with too high res, it won't persist)
- Explicitly save config when hiding settings menu