### PR TITLE
Fix mSkipEventName again

### DIFF
--- a/include/d/d_event.h
+++ b/include/d/d_event.h
@@ -196,8 +196,8 @@ public:
     /* 0x108 */ int mSkipTimer;
     /* 0x10C */ int mSkipParameter;
     /* 0x110 */ BOOL mIsSkipFade;
-#if TARGET_PC
-    /* 0x114 */ char mSkipEventName[21];
+#if AVOID_UB
+    /* 0x114 */ char mSkipEventName[32];
 #else
     /* 0x114 */ char mSkipEventName[20];
 #endif


### PR DESCRIPTION
They WAY undersized this in the original game it seems. The event used for the Zora overflows the original buffer size by *6* bytes.

Fixes https://github.com/TwilitRealm/dusklight/issues/1531