### PR TITLE
feat: Change Menu Scaling option to graphics_tuner_control

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -54,7 +54,7 @@ enum class FrameInterpMode : u8 {
 enum class MenuScaling : u8 {
     GameCube = 0,
     Wii = 1,
-    Dusklight = 2,
+    Dusk = 2,
 };
 
 namespace config {
@@ -103,7 +103,7 @@ struct ConfigEnumRange<FrameInterpMode> {
 template <>
 struct ConfigEnumRange<MenuScaling> {
     static constexpr auto min = MenuScaling::GameCube;
-    static constexpr auto max = MenuScaling::Dusklight;
+    static constexpr auto max = MenuScaling::Dusk;
 };
 }  // namespace config
 

--- a/src/d/d_file_select.cpp
+++ b/src/d/d_file_select.cpp
@@ -225,7 +225,7 @@ dFile_select_c::~dFile_select_c() {
 
     mpFileSelect3d->_delete();
     JKR_DELETE(mpFileSelect3d);
-    
+
     #if PLATFORM_GCN
     JKR_DELETE(mpFadePict);
     dComIfGp_getMain2DArchive()->removeResourceAll();
@@ -240,7 +240,7 @@ void dFile_select_c::_create() {
     int i;
 
     mDoGph_gInf_c::setFadeColor(static_cast<JUtility::TColor&>(g_blackColor));
-    
+
     stick = JKR_NEW STControl(2, 2, 1, 1, 0.9f, 0.5f, 0, 0x2000);
     JUT_ASSERT(355, stick != NULL);
 
@@ -1166,7 +1166,7 @@ void dFile_select_c::menuSelect() {
     // if a was pressed, do the menu selection process
     if (mDoCPd_c::getTrigA(PAD_1)) {
         menuSelectStart();
-    } 
+    }
     // if b was pressed, do the menu cancel process
     else if (mDoCPd_c::getTrigB(PAD_1)) {
         menuSelectCansel();
@@ -1691,7 +1691,7 @@ void dFile_select_c::setSaveDataForCopySel() {
             datBase->show();
             noDatBase->hide();
         }
- 
+
         pSave++;
         notSelectedIndex++;
     }
@@ -2178,7 +2178,7 @@ void dFile_select_c::yesNoSelectStart() {
             field_0x0209 = 1;
             break;
         }
-    
+
         modoruTxtDispAnmInit(0);
         ketteiTxtDispAnmInit(0);
         mDataSelProc = DATASELPROC_CMD_EXEC_PANE_MOVE0;
@@ -3757,7 +3757,7 @@ void dFile_select_c::fileSelectWide() {
         for (PaneCache& entry : mSelDtPanes) {
             J2DPane* pane = mSelDt.ScrDt->search(entry.tag);
             if (!entry.cached) {
-                entry.origTransX = pane->getTranslateX(); 
+                entry.origTransX = pane->getTranslateX();
                 entry.origTransY = pane->getTranslateY();
                 entry.cached = true;
             }
@@ -3766,7 +3766,7 @@ void dFile_select_c::fileSelectWide() {
             J2DPane* pane = fileSel.Scr->search(entry.tag);
             if (!entry.cached) {
                 entry.origTransX = pane->getTranslateX();
-                entry.origTransY = pane->getTranslateY(); 
+                entry.origTransY = pane->getTranslateY();
                 entry.cached = true;
             }
         }
@@ -3874,7 +3874,7 @@ void dFile_select_c::fileSelectWide() {
             mSelIcon2->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
         }
         break;
-    case (dusk::MenuScaling::Dusklight):
+    case (dusk::MenuScaling::Dusk):
         constexpr f32 minAspect = 4.0f / 2.94f;
         constexpr f32 wideAspect = 16.0f / 9.0f + 0.05f;
         constexpr f32 ultraAspect = 21.0f / 9.0f + 0.05f;
@@ -3913,7 +3913,7 @@ void dFile_select_c::fileSelectWide() {
                     pane->translate(mDoGph_gInf_c::hudAspectScaleDown * entry.origTransX + wideShiftFactor - 60.0f * (1.0f - mDoGph_gInf_c::hudAspectScaleDown), pane->getTranslateY());
                 }
             } else if (screenAspect >= minAspect && screenAspect >= wideAspect && screenAspect <= ultraAspect) // Handle ultrawide
-            { 
+            {
                 if (entry.tag == MULTI_CHAR('b_base')) { // Slots BG
                     pane->translate((entry.origTransX + 18.0f) * ultraScaleFactor, pane->getTranslateY());
                 }
@@ -4410,7 +4410,7 @@ void dFile_select_c::MemCardLoadWait() {
             #endif
 
             dataSelectInAnmSet();
-            
+
             #if PLATFORM_GCN
             if (field_0x014a || field_0x014b)
             #else
@@ -4800,7 +4800,7 @@ void dFile_select_c::MemCardErrMsgWaitNoSaveSel() {
 
         headerTxtSet(901, 1, 0);
         mSelIcon->setAlphaRate(1.0f);
-    
+
         char namebuf[32];
         dMeter2Info_getString(0x382, namebuf, 0);
         dComIfGs_setPlayerName(namebuf);
@@ -4808,7 +4808,7 @@ void dFile_select_c::MemCardErrMsgWaitNoSaveSel() {
         dComIfGs_setHorseName(namebuf);
         mpName->setNextNameStr(dComIfGs_getPlayerName());
         mpName->initial();
-    
+
         modoruTxtChange(1);
         nameMoveAnmInitSet(3359, 3369);
         yesnoMenuMoveAnmInitSet(1149, 1139);
@@ -4953,13 +4953,13 @@ void dFile_select_c::MemCardMakeGameFileSel() {
             #else
             errorTxtSet(27);
             field_0x03b1 = 1;
-            #endif 
+            #endif
         } else {
             #if PLATFORM_WII
             errorTxtSet(0xEEB);
             #else
             errorTxtSet(25);
-            #endif 
+            #endif
         }
         ketteiTxtDispAnmInit(0);
         yesnoMenuMoveAnmInitSet(0x47d, 0x473);
@@ -5012,13 +5012,13 @@ void dFile_select_c::MemCardMakeGameFileWait() {
             errorTxtSet(0xEEE);
             #else
             errorTxtSet(0x1C);
-            #endif 
+            #endif
         } else if (field_0x03b4 == 2) {
             #if PLATFORM_WII
             errorTxtSet(0xEED);
             #else
             errorTxtSet(0x1A);
-            #endif 
+            #endif
         }
         mCardCheckProc = MEMCARDCHECKPROC_MAKE_GAMEFILE_CHECK;
     }
@@ -5060,7 +5060,7 @@ void dFile_select_c::gameFileInitSel() {
 void dFile_select_c::gameFileInitSelDisp() {
     bool isErrorTxtChange = errorTxtChangeAnm();
     bool isYnMenuMove = yesnoMenuMoveAnm();
-    
+
     if (isErrorTxtChange == true && isYnMenuMove == true) {
         mWaitTimer = g_fsHIO.card_wait_frames;
         setInitSaveData();

--- a/src/d/d_menu_collect.cpp
+++ b/src/d/d_menu_collect.cpp
@@ -206,7 +206,7 @@ void dMenu_Collect2D_c::menuCollectWide() {
             mpDrawCursor->refreshAspectScale(mDoGph_gInf_c::hudAspectScaleUp);
         }
         break;
-    case dusk::MenuScaling::Dusklight:
+    case dusk::MenuScaling::Dusk:
         // Main Canvas
         mpScreen->scale(mDoGph_gInf_c::hudAspectScaleUp, 1.0f);
         mpScreen->translate(mDoGph_gInf_c::getSafeMinXF(), 0.0f);

--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -98,7 +98,7 @@ void set_value(GraphicsOption option, int value) {
         break;
     case GraphicsOption::MenuScaling:
         getSettings().game.menuScalingMode.setValue(static_cast<MenuScaling>(std::clamp(
-            value, static_cast<int>(MenuScaling::GameCube), static_cast<int>(MenuScaling::Dusklight))));
+            value, static_cast<int>(MenuScaling::GameCube), static_cast<int>(MenuScaling::Dusk))));
         break;
     }
 }
@@ -243,7 +243,7 @@ Rml::String format_graphics_setting_value(GraphicsOption option, int value) {
             return "GameCube";
         case MenuScaling::Wii:
             return "Wii";
-        case MenuScaling::Dusklight:
+        case MenuScaling::Dusk:
             return "Dusklight";
         }
         break;

--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -54,6 +54,8 @@ int get_value(GraphicsOption option) {
             100);
     case GraphicsOption::DepthOfFieldMode:
         return static_cast<int>(getSettings().game.depthOfFieldMode.getValue());
+    case GraphicsOption::MenuScaling:
+        return static_cast<int>(getSettings().game.menuScalingMode.getValue());
     }
     return 0;
 }
@@ -93,6 +95,10 @@ void set_value(GraphicsOption option, int value) {
         break;
     case GraphicsOption::BloomMultiplier:
         getSettings().game.bloomMultiplier.setValue(std::clamp(value, 0, 100) / 100.0f);
+        break;
+    case GraphicsOption::MenuScaling:
+        getSettings().game.menuScalingMode.setValue(static_cast<MenuScaling>(std::clamp(
+            value, static_cast<int>(MenuScaling::GameCube), static_cast<int>(MenuScaling::Dusklight))));
         break;
     }
 }
@@ -231,6 +237,16 @@ Rml::String format_graphics_setting_value(GraphicsOption option, int value) {
         break;
     case GraphicsOption::BloomMultiplier:
         return fmt::format("{}%", value);
+    case GraphicsOption::MenuScaling:
+        switch (static_cast<MenuScaling>(value)) {
+        case MenuScaling::GameCube:
+            return "GameCube";
+        case MenuScaling::Wii:
+            return "Wii";
+        case MenuScaling::Dusklight:
+            return "Dusklight";
+        }
+        break;
     }
     return "";
 }

--- a/src/dusk/ui/graphics_tuner.hpp
+++ b/src/dusk/ui/graphics_tuner.hpp
@@ -46,6 +46,7 @@ enum class GraphicsOption {
     BloomMode,
     BloomMultiplier,
     DepthOfFieldMode,
+    MenuScaling,
 };
 
 Rml::String format_graphics_setting_value(GraphicsOption option, int value);

--- a/src/dusk/ui/preset.cpp
+++ b/src/dusk/ui/preset.cpp
@@ -50,7 +50,7 @@ void applyPresetDusk() {
     s.game.shadowResolutionMultiplier.setValue(4);
     s.game.enableGyroAim.setValue(true);
     s.game.autoSave.setValue(true);
-    s.game.menuScalingMode.setValue(MenuScaling::Dusklight);
+    s.game.menuScalingMode.setValue(MenuScaling::Dusk);
     s.game.enhancedMapMenus.setValue(true);
 }
 

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -376,6 +376,8 @@ const Rml::String kDepthOfFieldHelpText =
 const Rml::String kUnlockFramerateHelpText =
     "<br/>Uses inter-frame interpolation to enable higher frame rates.<br/><br/>May introduce minor "
     "visual artifacts or animation glitches.";
+const Rml::String kMenuScalingModeHelpText =
+    "Configure how the Collection and File Select menus scale to your aspect ratio.";
 
 int float_setting_percent(ConfigVar<float>& var) {
     return static_cast<int>(var.getValue() * 100.0f + 0.5f);
@@ -1445,43 +1447,15 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .isDisabled = [] { return !getSettings().game.showInputViewer; },
             });
         leftPane.add_section("Game");
-        leftPane.register_control(
-            leftPane.add_select_button({
-                .key = "Menu Scaling Mode",
-                .getValue =
-                    [] {
-                        return kMenuScalingModeLabels[static_cast<u8>(
-                            getSettings().game.menuScalingMode.getValue())];
-                    },
-                .isModified =
-                    [] {
-                        const auto& mode = getSettings().game.menuScalingMode;
-                        return mode.getValue() != mode.getDefaultValue();
-                    },
-            }),
-            rightPane, [](Pane& pane) {
-                for (int i = 0; i < static_cast<int>(kMenuScalingModeLabels.size()); ++i) {
-                    pane
-                        .add_button({
-                            .text = kMenuScalingModeLabels[i],
-                            .isSelected =
-                                [i] {
-                                    return getSettings().game.menuScalingMode.getValue() ==
-                                           static_cast<MenuScaling>(i);
-                                    ;
-                                },
-                        })
-                        .on_pressed([i] {
-                            mDoAud_seStartMenu(kSoundItemChange);
-                            getSettings().game.menuScalingMode.setValue(
-                                static_cast<MenuScaling>(i));
-                            ;
-                            config::Save();
-                        });
-                }
-                pane.add_rml("<br/>Changes how the Collection and File Select menus scale to your "
-                             "aspect ratio.");
-            });
+        graphics_tuner_control(*this, leftPane, rightPane, getSettings().game.menuScalingMode,
+            GraphicsTunerProps{
+                .option = GraphicsOption::MenuScaling,
+                .title = "Menu Scaling Mode",
+                .helpText = kMenuScalingModeHelpText,
+                .valueMin = static_cast<int>(MenuScaling::GameCube),
+                .valueMax = static_cast<int>(MenuScaling::Dusklight),
+                .defaultValue = static_cast<int>(MenuScaling::Wii),
+            }, mPrelaunch);
         config_bool_select(leftPane, rightPane, getSettings().game.hideTvSettingsScreen,
             {
                 .key = "Skip TV Settings Screen",

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1453,7 +1453,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 .title = "Menu Scaling Mode",
                 .helpText = kMenuScalingModeHelpText,
                 .valueMin = static_cast<int>(MenuScaling::GameCube),
-                .valueMax = static_cast<int>(MenuScaling::Dusklight),
+                .valueMax = static_cast<int>(MenuScaling::Dusk),
                 .defaultValue = static_cast<int>(MenuScaling::Wii),
             }, mPrelaunch);
         config_bool_select(leftPane, rightPane, getSettings().game.hideTvSettingsScreen,


### PR DESCRIPTION
Similar to #1599 

Lets users preview the menu scaling option without the settings pane obstructing the view

# Before

https://github.com/user-attachments/assets/cbd3ba8d-5b71-4e49-816e-bda0b7aeb935

# After

https://github.com/user-attachments/assets/40c7a9bd-c3ea-4701-a3ec-77454a4f94f5

