### PR TITLE
Revert "Fixed being unable to break through the water surface with the moonjump cheat"

### DIFF
--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -13461,12 +13461,7 @@ void daAlink_c::autoGroundHit() {
             }
         }
     } else if (checkModeFlg(0x40000) && checkNoResetFlg0(FLG0_UNK_80) && current.pos.y > mWaterY && current.pos.y - mWaterY < 1000.0f) {
-#if TARGET_PC
-        if(!(dusk::getSettings().game.moonJump && (mDoCPd_c::getHoldR(PAD_1) && mDoCPd_c::getHoldA(PAD_1))))
-#endif
-        {
-            current.pos.y = mWaterY;
-        }
+        current.pos.y = mWaterY;
     }
 
     if (checkReinRide() || checkSpinnerRide()) {


### PR DESCRIPTION
Reverts TwilitRealm/dusklight#1320

After discussion, the team decided that we should keep the moonjump behavior compatible with Moonjump% speedrun category extension 