### PR TITLE
fix: item and talk rendering

### DIFF
--- a/include/d/d_msg_scrn_item.h
+++ b/include/d/d_msg_scrn_item.h
@@ -17,8 +17,8 @@ struct dMsgScrnItem_c : public dMsgScrnBase_c {
     void arwAnimeMove();
     void dotAnimeInit();
     void dotAnimeMove();
-    void setSelectString(char*, char*, char*);
-    void setSelectRubyString(char*, char*, char*);
+    void setSelectString(char DUSK_CONST*, char DUSK_CONST*, char DUSK_CONST*);
+    void setSelectRubyString(char DUSK_CONST*, char DUSK_CONST*, char DUSK_CONST*);
     bool isSelect();
     void selectAnimeInit(u8, u8, f32, u8);
     bool selectAnimeMove(u8, u8, bool);

--- a/include/d/d_msg_scrn_talk.h
+++ b/include/d/d_msg_scrn_talk.h
@@ -17,8 +17,8 @@ struct dMsgScrnTalk_c : public dMsgScrnBase_c {
     void arwAnimeMove();
     void dotAnimeInit();
     void dotAnimeMove();
-    void setSelectString(char*, char*, char*);
-    void setSelectRubyString(char*, char*, char*);
+    void setSelectString(char DUSK_CONST*, char DUSK_CONST*, char DUSK_CONST*);
+    void setSelectRubyString(char DUSK_CONST*, char DUSK_CONST*, char DUSK_CONST*);
     bool isSelect();
     void selectAnimeInit(u8, u8, f32, u8);
     bool selectAnimeMove(u8, u8, bool);

--- a/src/d/d_msg_scrn_item.cpp
+++ b/src/d/d_msg_scrn_item.cpp
@@ -504,11 +504,11 @@ void dMsgScrnItem_c::dotAnimeMove() {
     mpArrow_c->dotAnimeMove();
 }
 
-void dMsgScrnItem_c::setSelectString(char* param_0, char* param_1, char* param_2) {
+void dMsgScrnItem_c::setSelectString(char DUSK_CONST* param_0, char DUSK_CONST* param_1, char DUSK_CONST* param_2) {
     mpSelect_c->setString(param_0, param_1, param_2);
 }
 
-void dMsgScrnItem_c::setSelectRubyString(char* param_0, char* param_1, char* param_2) {
+void dMsgScrnItem_c::setSelectRubyString(char DUSK_CONST* param_0, char DUSK_CONST* param_1, char DUSK_CONST* param_2) {
     mpSelect_c->setRubyString(param_0, param_1, param_2);
 }
 

--- a/src/d/d_msg_scrn_talk.cpp
+++ b/src/d/d_msg_scrn_talk.cpp
@@ -383,13 +383,13 @@ void dMsgScrnTalk_c::dotAnimeMove() {
     mpArrow_c->dotAnimeMove();
 }
 
-void dMsgScrnTalk_c::setSelectString(char* param_0, char* param_1, char* param_2) {
+void dMsgScrnTalk_c::setSelectString(char DUSK_CONST* param_0, char DUSK_CONST* param_1, char DUSK_CONST* param_2) {
     if (mpSelect_c != NULL) {
         mpSelect_c->setString(param_0, param_1, param_2);
     }
 }
 
-void dMsgScrnTalk_c::setSelectRubyString(char* param_0, char* param_1, char* param_2) {
+void dMsgScrnTalk_c::setSelectRubyString(char DUSK_CONST* param_0, char DUSK_CONST* param_1, char DUSK_CONST* param_2) {
     if (mpSelect_c != NULL) {
         mpSelect_c->setRubyString(param_0, param_1, param_2);
     }


### PR DESCRIPTION
Fixes some UI elements not rendering. I guess #1864 missed some stuff so these methods are no longer overriding anything since the prototype doesn't match so it just uses the virtual function which does nothing. Maybe it'd be worth adding `override` all over the codebase like the `const`/`contexpr` changes so this is a static compile error.

### Before

<img width="640" height="360" alt="Midna Text Invisible" src="https://github.com/user-attachments/assets/97b64491-89a5-44b0-943b-9218ba96aae7" />

### After

<img width="640" height="360" alt="Midna Text Visible" src="https://github.com/user-attachments/assets/700b4abb-4c8b-4e5c-a825-f70b228ea9ca" />
