### PR TITLE
Add setting to disable targeting letterbox

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -194,6 +194,7 @@ struct UserSettings {
         ConfigVar<Resampler> resampler;
         ConfigVar<bool> enableMapBackground;
         ConfigVar<bool> disableCutscenePillarboxing;
+        ConfigVar<bool> disableTargetingLetterbox;
 
         // Audio
         ConfigVar<bool> noLowHpSound;

--- a/src/d/d_camera.cpp
+++ b/src/d/d_camera.cpp
@@ -2721,6 +2721,12 @@ int dCamera_c::defaultTriming() {
         case 2:
         case 5:
         case 6:
+#if TARGET_PC
+            if (dusk::getSettings().game.disableTargetingLetterbox) {
+                SetTrimSize(0);
+                break;
+            }
+#endif
             SetTrimSize(1);
             break;
         case 4:

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -74,6 +74,7 @@ UserSettings g_userSettings = {
         .resampler {"game.resampler", Resampler::Bilinear},
         .enableMapBackground {"game.enableMapBackground", true},
         .disableCutscenePillarboxing {"game.disableCutscenePillarboxing", false},
+        .disableTargetingLetterbox {"game.disableTargetingLetterbox", false},
 
         // Audio
         .noLowHpSound {"game.noLowHpSound", false},
@@ -279,6 +280,7 @@ void registerSettings() {
     Register(g_userSettings.game.shadowResolutionMultiplier);
     Register(g_userSettings.game.enableMapBackground);
     Register(g_userSettings.game.disableCutscenePillarboxing);
+    Register(g_userSettings.game.disableTargetingLetterbox);
     Register(g_userSettings.game.enableFastIronBoots);
     Register(g_userSettings.game.canTransformAnywhere);
     Register(g_userSettings.game.fastRoll);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -957,6 +957,11 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                             "during some cutscenes, particularly on ultra-wide displays. "
                             "Visuals beyond the original intended framing may appear buggy."
             });
+        config_bool_select(leftPane, rightPane, getSettings().game.disableTargetingLetterbox,
+            {
+                .key = "Disable Targeting Letterbox",
+                .helpText = "Disable the top and bottom black bars during L-targeting and lock-on camera modes."
+            });
     });
 
     add_tab("Input", [this](Rml::Element* content) {


### PR DESCRIPTION
Adds a setting to disable the top and bottom letterbox black bars when L-targeting / holding L.

Closes #1369.