### PR TITLE
Fixed invincible enemies cheat not deactivating on game startup when speedrun mode is activated

### DIFF
--- a/src/dusk/speedrun.cpp
+++ b/src/dusk/speedrun.cpp
@@ -34,6 +34,7 @@ void resetForSpeedrunMode() {
     getSettings().game.fastRoll.setSpeedrunValue(false);
     getSettings().game.fastSpinner.setSpeedrunValue(false);
     getSettings().game.armorRupeeDrain.setSpeedrunValue(MagicArmorMode::NORMAL);
+    getSettings().game.invincibleEnemies.setSpeedrunValue(false);
 
     getSettings().game.pauseOnFocusLost.setSpeedrunValue(false);
     aurora_set_pause_on_focus_lost(false);


### PR DESCRIPTION
Invincible enemies deactivation was missing in the function `resetForSpeedrunMode()` and was not missing in the function `reset_for_speedrun_mode()` this is why the bug happened only when restarting the game and not when deactivating the speedrun mode parameter.
I advise to combine this two functions because they do exactly the same and it may in the future introduce another bug similar to this one.

Fix issue #2154