### PR TITLE
Add "Fullscreen Resolution" option

### DIFF
--- a/files.cmake
+++ b/files.cmake
@@ -1439,6 +1439,8 @@ set(DUSK_FILES
         include/dusk/menu_pointer.h
         src/dusk/menu_pointer.cpp
         src/dusk/mouse.cpp
+        include/dusk/display.h
+        src/dusk/display.cpp
 		src/dusk/gamepad_color.cpp
 		src/dusk/autosave.cpp
         src/dusk/http/http.hpp

--- a/include/dusk/display.h
+++ b/include/dusk/display.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+
+namespace dusk::display {
+
+struct Resolution {
+    int width;
+    int height;
+};
+
+// Distinct fullscreen resolutions offered by the display the window is currently on, sorted from
+// largest to smallest. Includes driver-injected modes (e.g. NVIDIA DSR/DLDSR) when enabled.
+std::vector<Resolution> enumerate_resolutions();
+
+// Refresh rates offered for a given resolution on the current display, sorted descending.
+std::vector<float> enumerate_refresh_rates(int width, int height);
+
+// Applies the fullscreen resolution/refresh rate stored in user settings to the window. A width or
+// height of 0 selects borderless-desktop fullscreen (the default). If the saved resolution is not
+// available on the current display, the setting is reset to Desktop so the user isn't stranded.
+void apply_fullscreen_mode();
+
+}  // namespace dusk::display

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -144,6 +144,9 @@ struct UserSettings {
         ConfigVar<bool> rememberWindowSize;
         ConfigVar<int> lastWindowWidth;
         ConfigVar<int> lastWindowHeight;
+        ConfigVar<int> fullscreenWidth;
+        ConfigVar<int> fullscreenHeight;
+        ConfigVar<float> fullscreenRefreshRate;
     } video;
 
     struct {

--- a/src/dusk/display.cpp
+++ b/src/dusk/display.cpp
@@ -1,0 +1,153 @@
+#include "dusk/display.h"
+
+#include "dusk/config.hpp"
+#include "dusk/settings.h"
+
+#include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL_video.h>
+#include <aurora/lib/window.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+namespace dusk::display {
+namespace {
+
+// Two refresh rates are treated as the same entry when within this tolerance, collapsing near
+// duplicates such as 59.94 and 60.0 in the picker.
+constexpr float kRefreshEpsilon = 0.5f;
+
+SDL_DisplayID current_display() {
+    SDL_Window* window = aurora::window::get_sdl_window();
+    if (window == nullptr) {
+        return 0;
+    }
+    return SDL_GetDisplayForWindow(window);
+}
+
+}  // namespace
+
+std::vector<Resolution> enumerate_resolutions() {
+    std::vector<Resolution> resolutions;
+    const SDL_DisplayID display = current_display();
+    if (display == 0) {
+        return resolutions;
+    }
+
+    int count = 0;
+    SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(display, &count);
+    if (modes == nullptr) {
+        return resolutions;
+    }
+    for (int i = 0; i < count; ++i) {
+        const SDL_DisplayMode* mode = modes[i];
+        const bool exists = std::any_of(resolutions.begin(), resolutions.end(),
+            [&](const Resolution& r) { return r.width == mode->w && r.height == mode->h; });
+        if (!exists) {
+            resolutions.push_back({mode->w, mode->h});
+        }
+    }
+    SDL_free(modes);
+
+    std::sort(resolutions.begin(), resolutions.end(), [](const Resolution& a, const Resolution& b) {
+        if (a.width != b.width) {
+            return a.width > b.width;
+        }
+        return a.height > b.height;
+    });
+    return resolutions;
+}
+
+std::vector<float> enumerate_refresh_rates(int width, int height) {
+    std::vector<float> rates;
+    const SDL_DisplayID display = current_display();
+    if (display == 0) {
+        return rates;
+    }
+
+    int count = 0;
+    SDL_DisplayMode** modes = SDL_GetFullscreenDisplayModes(display, &count);
+    if (modes == nullptr) {
+        return rates;
+    }
+    for (int i = 0; i < count; ++i) {
+        const SDL_DisplayMode* mode = modes[i];
+        if (mode->w != width || mode->h != height) {
+            continue;
+        }
+        const bool exists = std::any_of(rates.begin(), rates.end(),
+            [&](float rate) { return std::fabs(rate - mode->refresh_rate) < kRefreshEpsilon; });
+        if (!exists) {
+            rates.push_back(mode->refresh_rate);
+        }
+    }
+    SDL_free(modes);
+
+    std::sort(rates.begin(), rates.end(), [](float a, float b) { return a > b; });
+    return rates;
+}
+
+void apply_fullscreen_mode() {
+    SDL_Window* window = aurora::window::get_sdl_window();
+    if (window == nullptr) {
+        return;
+    }
+
+    auto& video = getSettings().video;
+    const int width = video.fullscreenWidth.getValue();
+    const int height = video.fullscreenHeight.getValue();
+
+    // Desktop / borderless fullscreen: no exclusive mode, output follows the desktop resolution.
+    if (width <= 0 || height <= 0) {
+        SDL_SetWindowFullscreenMode(window, nullptr);
+        return;
+    }
+
+    const float requestedRefresh = video.fullscreenRefreshRate.getValue();
+    const SDL_DisplayID display = SDL_GetDisplayForWindow(window);
+
+    // SDL_GetFullscreenDisplayModes returns a single allocation owned by SDL; copy the chosen mode
+    // out before freeing, since SDL_SetWindowFullscreenMode takes its own copy.
+    SDL_DisplayMode chosen{};
+    bool found = false;
+    int count = 0;
+    SDL_DisplayMode** modes =
+        display != 0 ? SDL_GetFullscreenDisplayModes(display, &count) : nullptr;
+    if (modes != nullptr) {
+        for (int i = 0; i < count; ++i) {
+            const SDL_DisplayMode* mode = modes[i];
+            if (mode->w != width || mode->h != height) {
+                continue;
+            }
+            if (!found) {
+                chosen = *mode;
+                found = true;
+            } else if (requestedRefresh <= 0.0f) {
+                // Auto: highest available refresh rate for this resolution.
+                if (mode->refresh_rate > chosen.refresh_rate) {
+                    chosen = *mode;
+                }
+            } else if (std::fabs(mode->refresh_rate - requestedRefresh) <
+                       std::fabs(chosen.refresh_rate - requestedRefresh))
+            {
+                chosen = *mode;
+            }
+        }
+        SDL_free(modes);
+    }
+
+    if (found) {
+        SDL_SetWindowFullscreenMode(window, &chosen);
+        return;
+    }
+
+    // The saved resolution is no longer available (e.g. a different monitor, or DSR/DLDSR was
+    // disabled). Fall back to borderless desktop so the user isn't stranded.
+    video.fullscreenWidth.setValue(0);
+    video.fullscreenHeight.setValue(0);
+    video.fullscreenRefreshRate.setValue(0.0f);
+    config::save();
+    SDL_SetWindowFullscreenMode(window, nullptr);
+}
+
+}  // namespace dusk::display

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -15,6 +15,9 @@ UserSettings g_userSettings = {
         .rememberWindowSize {"video.rememberWindowSize", false},
         .lastWindowWidth {"video.lastWindowWidth", 0},
         .lastWindowHeight {"video.lastWindowHeight", 0},
+        .fullscreenWidth {"video.fullscreenWidth", 0},
+        .fullscreenHeight {"video.fullscreenHeight", 0},
+        .fullscreenRefreshRate {"video.fullscreenRefreshRate", 0.0f},
     },
 
     .audio = {
@@ -224,6 +227,9 @@ void registerSettings() {
     Register(g_userSettings.video.rememberWindowSize);
     Register(g_userSettings.video.lastWindowWidth);
     Register(g_userSettings.video.lastWindowHeight);
+    Register(g_userSettings.video.fullscreenWidth);
+    Register(g_userSettings.video.fullscreenHeight);
+    Register(g_userSettings.video.fullscreenRefreshRate);
 
     // Audio
     Register(g_userSettings.audio.masterVolume);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -10,6 +10,7 @@
 #include "dusk/config.hpp"
 #include "dusk/hotkeys.h"
 #include "dusk/data.hpp"
+#include "dusk/display.h"
 #include "dusk/file_select.hpp"
 #include "dusk/imgui/ImGuiEngine.hpp"
 #include "dusk/io.hpp"
@@ -408,6 +409,15 @@ const Rml::String kUnlockFramerateHelpText =
     "visual artifacts or animation glitches.";
 const Rml::String kTextureReplacementHelpText =
     "Enable installed texture replacements.";
+const Rml::String kFullscreenResolutionHelpText =
+    "<br/>Override the monitor resolution used in fullscreen. \"Desktop\" keeps borderless fullscreen "
+    "at your current desktop resolution; choosing a specific resolution switches to exclusive "
+    "fullscreen and changes the monitor's output resolution.<br/><br/>Useful with NVIDIA DSR/DLDSR or "
+    "AMD VSR (Virtual Super Resolution) to run above native resolution without changing your Windows "
+    "display settings.";
+const Rml::String kRefreshRateHelpText =
+    "<br/>Select the refresh rate used when a fullscreen resolution is set. \"Auto\" uses the highest "
+    "refresh rate available for the chosen resolution.";
 
 int float_setting_percent(ConfigVar<float>& var) {
     return static_cast<int>(var.getValue() * 100.0f + 0.5f);
@@ -764,6 +774,138 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             VICenterWindow();
         }),
             rightPane, [](Pane& pane) { pane.clear(); });
+        leftPane.register_control(
+            leftPane.add_select_button({
+                .key = "Fullscreen Resolution",
+                .getValue =
+                    [] {
+                        const int w = getSettings().video.fullscreenWidth.getValue();
+                        const int h = getSettings().video.fullscreenHeight.getValue();
+                        if (w <= 0 || h <= 0) {
+                            return Rml::String{"Desktop"};
+                        }
+                        return Rml::String{fmt::format("{} × {}", w, h)};
+                    },
+                .isModified =
+                    [] {
+                        return getSettings().video.fullscreenWidth.getValue() != 0 ||
+                               getSettings().video.fullscreenHeight.getValue() != 0;
+                    },
+            }),
+            rightPane, [](Pane& pane) {
+                pane.add_button(
+                        {
+                            .text = "Desktop (Borderless)",
+                            .isSelected =
+                                [] {
+                                    return getSettings().video.fullscreenWidth.getValue() <= 0 ||
+                                           getSettings().video.fullscreenHeight.getValue() <= 0;
+                                },
+                        })
+                    .on_pressed([] {
+                        mDoAud_seStartMenu(kSoundItemChange);
+                        getSettings().video.fullscreenWidth.setValue(0);
+                        getSettings().video.fullscreenHeight.setValue(0);
+                        getSettings().video.fullscreenRefreshRate.setValue(0.0f);
+                        dusk::display::apply_fullscreen_mode();
+                        config::save();
+                    });
+                for (const auto res : dusk::display::enumerate_resolutions()) {
+                    pane.add_button(
+                            {
+                                .text =
+                                    Rml::String{fmt::format("{} × {}", res.width, res.height)},
+                                .isSelected =
+                                    [res] {
+                                        return getSettings().video.fullscreenWidth.getValue() ==
+                                                   res.width &&
+                                               getSettings().video.fullscreenHeight.getValue() ==
+                                                   res.height;
+                                    },
+                            })
+                        .on_pressed([res] {
+                            mDoAud_seStartMenu(kSoundItemChange);
+                            getSettings().video.fullscreenWidth.setValue(res.width);
+                            getSettings().video.fullscreenHeight.setValue(res.height);
+                            // If the current refresh rate isn't offered at the new resolution,
+                            // revert to Auto so we don't request an unavailable mode.
+                            const auto rates =
+                                dusk::display::enumerate_refresh_rates(res.width, res.height);
+                            const float current =
+                                getSettings().video.fullscreenRefreshRate.getValue();
+                            const bool available =
+                                std::any_of(rates.begin(), rates.end(), [current](float rate) {
+                                    return (current > rate ? current - rate : rate - current) <
+                                           0.5f;
+                                });
+                            if (!available) {
+                                getSettings().video.fullscreenRefreshRate.setValue(0.0f);
+                            }
+                            dusk::display::apply_fullscreen_mode();
+                            config::save();
+                        });
+                }
+                pane.add_rml(kFullscreenResolutionHelpText);
+            });
+        leftPane.register_control(
+            leftPane.add_select_button({
+                .key = "Refresh Rate",
+                .getValue =
+                    [] {
+                        const float rate = getSettings().video.fullscreenRefreshRate.getValue();
+                        if (rate <= 0.0f) {
+                            return Rml::String{"Auto"};
+                        }
+                        return Rml::String{fmt::format("{} Hz", static_cast<int>(rate + 0.5f))};
+                    },
+                .isDisabled =
+                    [] {
+                        return getSettings().video.fullscreenWidth.getValue() <= 0 ||
+                               getSettings().video.fullscreenHeight.getValue() <= 0;
+                    },
+                .isModified =
+                    [] { return getSettings().video.fullscreenRefreshRate.getValue() != 0.0f; },
+            }),
+            rightPane, [](Pane& pane) {
+                pane.add_button(
+                        {
+                            .text = "Auto",
+                            .isSelected =
+                                [] {
+                                    return getSettings().video.fullscreenRefreshRate.getValue() <=
+                                           0.0f;
+                                },
+                        })
+                    .on_pressed([] {
+                        mDoAud_seStartMenu(kSoundItemChange);
+                        getSettings().video.fullscreenRefreshRate.setValue(0.0f);
+                        dusk::display::apply_fullscreen_mode();
+                        config::save();
+                    });
+                const int w = getSettings().video.fullscreenWidth.getValue();
+                const int h = getSettings().video.fullscreenHeight.getValue();
+                for (const float rate : dusk::display::enumerate_refresh_rates(w, h)) {
+                    pane.add_button(
+                            {
+                                .text = Rml::String{
+                                    fmt::format("{} Hz", static_cast<int>(rate + 0.5f))},
+                                .isSelected =
+                                    [rate] {
+                                        const float current =
+                                            getSettings().video.fullscreenRefreshRate.getValue();
+                                        return (current > rate ? current - rate : rate - current) <
+                                               0.5f;
+                                    },
+                            })
+                        .on_pressed([rate] {
+                            mDoAud_seStartMenu(kSoundItemChange);
+                            getSettings().video.fullscreenRefreshRate.setValue(rate);
+                            dusk::display::apply_fullscreen_mode();
+                            config::save();
+                        });
+                }
+                pane.add_rml(kRefreshRateHelpText);
+            });
         config_bool_select(leftPane, rightPane, getSettings().video.enableVsync,
             {
                 .key = "Enable VSync",

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -52,6 +52,7 @@
 #include "dusk/crash_handler.h"
 #include "dusk/crash_reporting.h"
 #include "dusk/data.hpp"
+#include "dusk/display.h"
 #include "dusk/dusk.h"
 #include "dusk/frame_interpolation.h"
 #include "dusk/game_clock.h"
@@ -627,6 +628,7 @@ int game_main(int argc, char* argv[]) {
         AuroraSetViewportPolicy(AURORA_VIEWPORT_STRETCH);
     }
     VISetFrameBufferScale(dusk::getSettings().game.internalResolutionScale.getValue());
+    dusk::display::apply_fullscreen_mode();
     switch (dusk::getSettings().game.resampler.getValue()) {
     case dusk::Resampler::Area:
         aurora_set_resampler(SAMPLER_AREA);


### PR DESCRIPTION
Adds Video > Display dropdowns to override the monitor resolution and refresh rate while in exclusive fullscreen.
Enables using NVIDIA DSR / AMD VSR to run above native resolution without changing Windows display settings.
"Desktop" keeps the existing borderless-fullscreen behavior.
Implements my [pull request](https://github.com/TwilitRealm/dusklight/issues/2059)