### PR TITLE
Draw shadows before translucent textures

### DIFF
--- a/mods/shadow_mod/mod.json
+++ b/mods/shadow_mod/mod.json
@@ -1,7 +1,7 @@
 {
   "id": "dev.twilitrealm.shadow_mod",
   "name": "[Demo] Dynamic Shadows",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "encounter",
   "description": "Demo showcasing dynamic shadow maps: re-renders geometry from the sun (or moon) point of view and composites real-time shadows over the world, with screen-space contact shadows for fine detail."
 }

--- a/mods/shadow_mod/res/shadow.wgsl
+++ b/mods/shadow_mod/res/shadow.wgsl
@@ -21,6 +21,7 @@ struct Uniforms {
     bias: f32,                // shadow-map depth bias (reversed-depth units)
     size: vec2f,              // shadow map size in texels
     inv_size: vec2f,
+    edge_fade_width: f32,
     strength: f32,            // final darkening amount, horizon fade baked in
     pcf_taps: f32,            // 0 = single tap, 1 = 3x3, 2 = 5x5
     contact_enabled: f32,
@@ -28,7 +29,6 @@ struct Uniforms {
     contact_length: f32,      // view-space march distance
     debug_mode: u32,          // 0 = composite; nonzero modes are diagnostic views
     _pad0: f32,
-    _pad1: f32,
 }
 
 @group(0) @binding(0) var scene_depth: texture_2d<f32>;
@@ -95,10 +95,11 @@ fn sample_shadow_pcf(light_uv: vec2f, receiver: f32) -> f32 {
 // Softly fades shadows out over a small band near the shadow-map edge so receivers do not
 // disappear abruptly when they leave the light's coverage area.
 fn shadow_edge_fade(light_uv: vec2f) -> f32 {
-    let edge_texels = 24.0;
+    let edge_texels = uniforms.edge_fade_width;
     let edge_uv = edge_texels * max(uniforms.inv_size.x, uniforms.inv_size.y);
     let distance_to_edge = min(min(light_uv.x, 1.0 - light_uv.x), min(light_uv.y, 1.0 - light_uv.y));
-    return saturate(distance_to_edge / edge_uv);
+    // Avoid division by zero when the fade width is zero (no fade).
+    return select(1.0, saturate(distance_to_edge / edge_uv), edge_uv > 0.0);
 }
 
 fn scene_depth_at(uv: vec2f) -> f32 {

--- a/mods/shadow_mod/res/shadow.wgsl
+++ b/mods/shadow_mod/res/shadow.wgsl
@@ -92,6 +92,15 @@ fn sample_shadow_pcf(light_uv: vec2f, receiver: f32) -> f32 {
     return sum / count;
 }
 
+// Softly fades shadows out over a small band near the shadow-map edge so receivers do not
+// disappear abruptly when they leave the light's coverage area.
+fn shadow_edge_fade(light_uv: vec2f) -> f32 {
+    let edge_texels = 24.0;
+    let edge_uv = edge_texels * max(uniforms.inv_size.x, uniforms.inv_size.y);
+    let distance_to_edge = min(min(light_uv.x, 1.0 - light_uv.x), min(light_uv.y, 1.0 - light_uv.y));
+    return saturate(distance_to_edge / edge_uv);
+}
+
 fn scene_depth_at(uv: vec2f) -> f32 {
     let size = vec2<i32>(textureDimensions(scene_depth));
     let texel = clamp(vec2<i32>(uv * vec2f(size)), vec2<i32>(0i), size - 1i);
@@ -240,6 +249,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     var occlusion = 0.0;
     if in_shadow_bounds {
         occlusion = sample_shadow_pcf(light_uv, receiver);
+        occlusion *= shadow_edge_fade(light_uv);
     }
 
     if uniforms.debug_mode == 3u {

--- a/mods/shadow_mod/src/mod.cpp
+++ b/mods/shadow_mod/src/mod.cpp
@@ -57,6 +57,7 @@ ConfigVarHandle g_cvarStrength = 0;
 ConfigVarHandle g_cvarPcf = 0;
 ConfigVarHandle g_cvarBias = 0;
 ConfigVarHandle g_cvarBoxRadius = 0;
+ConfigVarHandle g_cvarEdgeFadeWidth = 0;
 ConfigVarHandle g_cvarContactShadows = 0;
 ConfigVarHandle g_cvarDebugView = 0;
 
@@ -107,6 +108,7 @@ struct ShadowUniforms {
     float bias;
     float size[2];
     float inv_size[2];
+    float edge_fade_width;
     float strength;
     float pcf_taps;
     float contact_enabled;
@@ -114,7 +116,6 @@ struct ShadowUniforms {
     float contact_length;
     uint32_t debug_mode;
     float _pad0;
-    float _pad1;
 };
 static_assert(sizeof(ShadowUniforms) % 16 == 0);
 
@@ -792,6 +793,8 @@ void on_frame_before_hud(ModContext*, const GfxStageContext*, void*) {
     uniforms.size[1] = static_cast<float>(mapPass.mapSize);
     uniforms.inv_size[0] = 1.0f / uniforms.size[0];
     uniforms.inv_size[1] = 1.0f / uniforms.size[1];
+    uniforms.edge_fade_width =
+        static_cast<float>(std::clamp<int64_t>(get_int_option(g_cvarEdgeFadeWidth, 32), 0, 128));
     uniforms.strength =
         mapPass.fade *
         static_cast<float>(std::clamp<int64_t>(get_int_option(g_cvarStrength, 45), 0, 100)) /
@@ -867,6 +870,8 @@ ModResult build_controls_tab(
         "dynamic shadows. This can be expensive.");
     add_number(left, "Coverage", g_cvarBoxRadius, 1000, 20000, 500, nullptr,
         "Radius of the shadowed area around the camera, in world units. Smaller is sharper.");
+    add_number(left, "Fade Out", g_cvarEdgeFadeWidth, 0, 128, 32, " texels",
+        "Fade out shadows gradually near the edge of the coverage area.");
 
     svc_ui->pane_add_section(mod_ctx, left, "Appearance");
     add_number(left, "Strength", g_cvarStrength, 0, 100, 5, "%", "How dark shadowed areas become.");
@@ -992,6 +997,10 @@ MOD_EXPORT ModResult mod_initialize(ModError* error) {
     if (result != MOD_OK) {
         return result;
     }
+    result = register_int_option("edgeFadeWidth", 32, g_cvarEdgeFadeWidth, error);
+    if (result != MOD_OK) {
+        return result;
+    }
     result = register_bool_option("contactShadows", true, g_cvarContactShadows, error);
     if (result != MOD_OK) {
         return result;
@@ -1087,7 +1096,8 @@ MOD_EXPORT ModResult mod_shutdown(ModError*) {
     }
     g_cvarEnabled = g_cvarMapSize = g_cvarNoFrustumClipping = 0;
     g_cvarStrength = 0;
-    g_cvarPcf = g_cvarBias = g_cvarBoxRadius = g_cvarContactShadows = g_cvarDebugView = 0;
+    g_cvarPcf = g_cvarBias = g_cvarBoxRadius = g_cvarEdgeFadeWidth = g_cvarContactShadows =
+        g_cvarDebugView = 0;
     g_drawType = g_sceneBeginHook = g_sceneAfterTerrainHook = g_frameBeforeHudHook = 0;
     g_controlsWindow = 0;
     g_mapPass = {};

--- a/mods/shadow_mod/src/mod.cpp
+++ b/mods/shadow_mod/src/mod.cpp
@@ -794,7 +794,7 @@ void on_frame_before_hud(ModContext*, const GfxStageContext*, void*) {
     uniforms.inv_size[0] = 1.0f / uniforms.size[0];
     uniforms.inv_size[1] = 1.0f / uniforms.size[1];
     uniforms.edge_fade_width =
-        static_cast<float>(std::clamp<int64_t>(get_int_option(g_cvarEdgeFadeWidth, 32), 0, 128));
+        static_cast<float>(std::clamp<int64_t>(get_int_option(g_cvarEdgeFadeWidth, 32), 0, 256));
     uniforms.strength =
         mapPass.fade *
         static_cast<float>(std::clamp<int64_t>(get_int_option(g_cvarStrength, 45), 0, 100)) /
@@ -870,7 +870,7 @@ ModResult build_controls_tab(
         "dynamic shadows. This can be expensive.");
     add_number(left, "Coverage", g_cvarBoxRadius, 1000, 20000, 500, nullptr,
         "Radius of the shadowed area around the camera, in world units. Smaller is sharper.");
-    add_number(left, "Fade Out", g_cvarEdgeFadeWidth, 0, 128, 32, " texels",
+    add_number(left, "Fade Out", g_cvarEdgeFadeWidth, 0, 256, 32, " texels",
         "Fade out shadows gradually near the edge of the coverage area.");
 
     svc_ui->pane_add_section(mod_ctx, left, "Appearance");
@@ -997,7 +997,7 @@ MOD_EXPORT ModResult mod_initialize(ModError* error) {
     if (result != MOD_OK) {
         return result;
     }
-    result = register_int_option("edgeFadeWidth", 32, g_cvarEdgeFadeWidth, error);
+    result = register_int_option("edgeFadeWidth", 128, g_cvarEdgeFadeWidth, error);
     if (result != MOD_OK) {
         return result;
     }

--- a/mods/shadow_mod/src/mod.cpp
+++ b/mods/shadow_mod/src/mod.cpp
@@ -64,6 +64,7 @@ ConfigVarHandle g_cvarDebugView = 0;
 GfxDrawTypeHandle g_drawType = 0;
 GfxStageHookHandle g_sceneBeginHook = 0;
 GfxStageHookHandle g_sceneAfterTerrainHook = 0;
+GfxStageHookHandle g_sceneAfterOpaqueHook = 0;
 GfxStageHookHandle g_frameBeforeHudHook = 0;
 UiWindowHandle g_controlsWindow = 0;
 ResourceBuffer g_shaderSource = RESOURCE_BUFFER_INIT;
@@ -746,8 +747,8 @@ void render_shadow_map(
     g_mapPass.ready = true;
 }
 
-// Game thread, after the full 3D scene: deferred composite.
-void on_frame_before_hud(ModContext*, const GfxStageContext*, void*) {
+// Game thread, after opaque scene draws and before translucent/fog overlays: deferred composite.
+void on_scene_after_opaque(ModContext*, const GfxStageContext*, void*) {
     const int64_t debugMode = get_debug_mode();
     restore_actual_light_debug();
 
@@ -812,6 +813,11 @@ void on_frame_before_hud(ModContext*, const GfxStageContext*, void*) {
     const DrawPayload payload{resolved.depth, mapPass.shadowMap, mapPass.lightColor,
         uniformRange.offset, uniformRange.size, static_cast<uint32_t>(debugMode)};
     svc_gfx->push_draw(mod_ctx, g_drawType, &payload, sizeof(payload));
+}
+
+// Frame tail hook: only needed to restore light-view debug camera state before HUD.
+void on_frame_before_hud(ModContext*, const GfxStageContext*, void*) {
+    restore_actual_light_debug();
 }
 
 void add_control(UiElementHandle pane, const UiControlDesc& desc) {
@@ -1038,6 +1044,12 @@ MOD_EXPORT ModResult mod_initialize(ModError* error) {
     {
         return dusk::mods::set_error(error, MOD_ERROR, "failed to register stage hook");
     }
+    stageDesc.callback = on_scene_after_opaque;
+    if (svc_gfx->register_stage_hook(
+            mod_ctx, GFX_STAGE_SCENE_AFTER_OPAQUE, &stageDesc, &g_sceneAfterOpaqueHook) != MOD_OK)
+    {
+        return dusk::mods::set_error(error, MOD_ERROR, "failed to register stage hook");
+    }
     stageDesc.callback = on_frame_before_hud;
     if (svc_gfx->register_stage_hook(
             mod_ctx, GFX_STAGE_FRAME_BEFORE_HUD, &stageDesc, &g_frameBeforeHudHook) != MOD_OK)
@@ -1098,7 +1110,8 @@ MOD_EXPORT ModResult mod_shutdown(ModError*) {
     g_cvarStrength = 0;
     g_cvarPcf = g_cvarBias = g_cvarBoxRadius = g_cvarEdgeFadeWidth = g_cvarContactShadows =
         g_cvarDebugView = 0;
-    g_drawType = g_sceneBeginHook = g_sceneAfterTerrainHook = g_frameBeforeHudHook = 0;
+    g_drawType = g_sceneBeginHook = g_sceneAfterTerrainHook = g_sceneAfterOpaqueHook =
+        g_frameBeforeHudHook = 0;
     g_controlsWindow = 0;
     g_mapPass = {};
     g_sceneCamera.valid = false;


### PR DESCRIPTION
Draws shadows before translucent overlays, makes the scene look cleaner. This is more noticeable when the shadow strength is higher. 

This PR does not include the debug on/off toggle, it was just to show the difference

https://github.com/user-attachments/assets/3ca4f066-5a74-4702-b926-d5247852156a

*Comparison*
Before:
<img width="2206" height="1492" alt="image" src="https://github.com/user-attachments/assets/c240a6c3-9539-4be4-86f3-578160930649" />

After:
<img width="2206" height="1492" alt="image" src="https://github.com/user-attachments/assets/21e67d81-6607-42d6-a4be-6375470c0bd6" />

