### PR TITLE
Nix: add miniz and fix submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,7 @@ find_package(Threads REQUIRED)
 set(GAME_COMPILE_DEFS DUSK_BUILDING_GAME=1)
 set(GAME_LIBS aurora::core aurora::gx aurora::gd aurora::si aurora::vi aurora::pad aurora::mtx aurora::os aurora::dvd
     aurora::card freeverb cxxopts::cxxopts absl::flat_hash_map nlohmann_json::nlohmann_json TracyClient fmt::fmt
-    Threads::Threads zstd::libzstd dusklight_game_headers)
+    Threads::Threads zstd::libzstd dusklight_game_headers miniz)
 if (DUSK_ENABLE_CODE_MODS)
     list(APPEND GAME_LIBS funchook-static)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,7 @@ find_package(Threads REQUIRED)
 set(GAME_COMPILE_DEFS DUSK_BUILDING_GAME=1)
 set(GAME_LIBS aurora::core aurora::gx aurora::gd aurora::si aurora::vi aurora::pad aurora::mtx aurora::os aurora::dvd
     aurora::card freeverb cxxopts::cxxopts absl::flat_hash_map nlohmann_json::nlohmann_json TracyClient fmt::fmt
-    Threads::Threads zstd::libzstd dusklight_game_headers miniz)
+    Threads::Threads zstd::libzstd dusklight_game_headers)
 if (DUSK_ENABLE_CODE_MODS)
     list(APPEND GAME_LIBS funchook-static)
 endif ()

--- a/flake.nix
+++ b/flake.nix
@@ -59,21 +59,6 @@
           hasNodPrebuilt = nodPrebuiltInfo ? ${system};
 
           aurora = builtins.pathExists "${self}/extern/aurora/CMakeLists.txt";
-          needSubmodules = ''
-            dusklight: The aurora submodule is not vendored. Add submodules=1 to build.
-
-            As a flake input:
-
-            dusklight.url = "git+https://github.com/TwilitRealm/dusklight?ref=main&submodules=1";
-
-            nix command:
-
-            nix run 'git+https://github.com/TwilitRealm/dusklight?submodules=1'
-
-            Local checkout:
-
-            nix run '.?submodules=1#dusklight'
-          '';
 
           dawn = pkgs.fetchzip {
             url = "https://github.com/encounter/dawn/releases/download/${dawnVersion}/dawn-${dawnInfo.${system}.triple}.tar.gz";
@@ -174,20 +159,16 @@
           };
 
           dusklight =
-            if !aurora then
-              throw needSubmodules
-            else
-              pkgs.stdenv.mkDerivation {
-                enableParallelBuilding = true;
-                pname = "dusklight";
-                version = versionSuffix;
-                src = ./.;
+            pkgs.stdenv.mkDerivation {
+              pname = "dusklight";
+              version = versionSuffix;
+              src = ./.;
 
-                postUnpack = ''
-                  chmod -R u+w "$sourceRoot"
-                  substituteInPlace "$sourceRoot/extern/aurora/CMakeLists.txt" \
-                    --replace-warn "add_subdirectory(tests)" ""
-                '';
+              postUnpack = ''
+                chmod -R u+w "$sourceRoot"
+                substituteInPlace "$sourceRoot/extern/aurora/CMakeLists.txt" \
+                  --replace-warn "add_subdirectory(tests)" ""
+              '';
 
                 nativeBuildInputs = [
                   pkgs.cmake

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,7 @@
               nodFromSource;
 
           fetchContentDirs = {
+            MINIZ = pkgs.miniz.src;
             DAWN_PREBUILT = dawn;
             NOD_PREBUILT = nod;
             CXXOPTS = pkgs.cxxopts.src;
@@ -195,6 +196,7 @@
                   pkgs.cxxopts
                   pkgs.nlohmann_json
                   pkgs.xxhash
+                  pkgs.miniz
                   pkgs.abseil-cpp
                   pkgs.zlib
                   pkgs.libpng

--- a/flake.nix
+++ b/flake.nix
@@ -170,6 +170,7 @@
               throw needSubmodules
             else
               pkgs.stdenv.mkDerivation {
+                enableParallelBuilding = true;
                 pname = "dusklight";
                 version = versionSuffix;
                 src = ./.;

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "Dusklight — native PC port of the Twilight Princess decompilation";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  inputs.self.submodules = true;
 
   outputs =
     { self, nixpkgs }:
@@ -134,13 +135,20 @@
               nodFromSource;
 
           fetchContentDirs = {
-            MINIZ = pkgs.miniz.src;
             DAWN_PREBUILT = dawn;
             NOD_PREBUILT = nod;
             CXXOPTS = pkgs.cxxopts.src;
             JSON = pkgs.nlohmann_json.src;
             XXHASH = pkgs.xxhash.src;
             ZSTD = pkgs.zstd.src;
+
+
+            MINIZ = pkgs.fetchzip {
+              url = "https://github.com/richgel999/miniz/releases/download/3.0.2/miniz-3.0.2.zip";
+              hash = "sha256-DXysXkQEmoDAMMg1F8KexkwpXNyiHNzLJqXR9SMEkxk=";
+              stripRoot = false;
+            };
+
             FMT = pkgs.fetchzip {
               url = "https://github.com/fmtlib/fmt/archive/refs/tags/12.1.0.tar.gz";
               hash = "sha256-ZmI1Dv0ZabPlxa02OpERI47jp7zFfjpeWCy1WyuPYZ0=";
@@ -197,7 +205,6 @@
                   pkgs.cxxopts
                   pkgs.nlohmann_json
                   pkgs.xxhash
-                  pkgs.miniz
                   pkgs.abseil-cpp
                   pkgs.zlib
                   pkgs.libpng


### PR DESCRIPTION
Hi, and thank you for this wonderful port. I was building locally and noticed that nix build wasn't working because of `miniz`. I added it in so that it compiles and runs now. Happy to report that nix and cmake's builds both work on my arm linux machine.

Also, nix should now include submodules without issue.