### PR TITLE
Start annotating functions with override properly

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -255,5 +255,6 @@ using std::isnan;
 
 #define DUSK_CONST IF_DUSK(const)
 #define DUSK_CONSTEXPR IF_DUSK(constexpr)
+#define DUSK_OVERRIDE IF_DUSK(override)
 
 #endif

--- a/include/m_Do/m_Do_ext.h
+++ b/include/m_Do/m_Do_ext.h
@@ -592,9 +592,9 @@ public:
     void update(int, GXColor&, dKy_tevstr_c*);
     void update(int, f32, GXColor&, u16, dKy_tevstr_c*);
 #endif
-    int getMaterialID() { return 1; }
-    void setMaterial();
-    void draw();
+    int getMaterialID() DUSK_OVERRIDE { return 1; }
+    void setMaterial() DUSK_OVERRIDE;
+    void draw() DUSK_OVERRIDE;
 #if TARGET_PC
     void refreshGeometryForPresentationEye(const cXyz& eye) override;
 #endif

--- a/libs/JSystem/include/JSystem/JKernel/JKRAram.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRAram.h
@@ -18,7 +18,7 @@ private:
     JKRAram(u32, u32, s32);
     virtual ~JKRAram();
 
-    /* vt[03] */ void* run(void); /* override */
+    /* vt[03] */ void* run(void) DUSK_OVERRIDE;
 
 public:
     u32 getAudioMemory() const { return mAudioMemoryPtr; }

--- a/libs/JSystem/include/JSystem/JKernel/JKRAramArchive.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRAramArchive.h
@@ -22,9 +22,9 @@ public:
     u32 getAramAddress_Entry(SDIFileEntry*);
     u32 getAramAddress(char const*);
 
-    /* vt[15] */ u32 getExpandedResSize(const void*) const;            /* override */
-    /* vt[16] */ void* fetchResource(SDIFileEntry*, u32*);             /* override */
-    /* vt[17] */ void* fetchResource(void*, u32, SDIFileEntry*, u32*); /* override */
+    /* vt[15] */ u32 getExpandedResSize(const void*) const DUSK_OVERRIDE;
+    /* vt[16] */ void* fetchResource(SDIFileEntry*, u32*) DUSK_OVERRIDE;
+    /* vt[17] */ void* fetchResource(void*, u32, SDIFileEntry*, u32*) DUSK_OVERRIDE;
 
 public:
     static u32 fetchResource_subroutine(u32, u32, u8*, u32, int);

--- a/libs/JSystem/include/JSystem/JKernel/JKRAramStream.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRAramStream.h
@@ -48,7 +48,7 @@ private:
     JKRAramStream(s32);
     virtual ~JKRAramStream();
 
-    /* vt[03] */ void* run(void); /* override */
+    /* vt[03] */ void* run(void) DUSK_OVERRIDE;
 
 public:
     static JKRAramStream* create(s32);

--- a/libs/JSystem/include/JSystem/JKernel/JKRArchive.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRArchive.h
@@ -171,17 +171,17 @@ public:
     SDIFileEntry* findIdResource(u16) const;
 
 public:
-    /* vt[04] */ virtual bool becomeCurrent(const char*);                /* override */
-    /* vt[05] */ virtual void* getResource(const char*);                 /* override */
-    /* vt[06] */ virtual void* getResource(u32, const char*);            /* override */
-    /* vt[07] */ virtual u32 readResource(void*, u32, const char*);      /* override */
-    /* vt[08] */ virtual u32 readResource(void*, u32, u32, const char*); /* override */
-    /* vt[09] */ virtual void removeResourceAll(void);                   /* override */
-    /* vt[10] */ virtual bool removeResource(void*);                     /* override */
-    /* vt[11] */ virtual bool detachResource(void*);                     /* override */
-    /* vt[12] */ virtual u32 getResSize(const void*) const;              /* override */
-    /* vt[13] */ virtual u32 countFile(const char*) const;               /* override */
-    /* vt[14] */ virtual JKRFileFinder* getFirstFile(const char*) const; /* override */
+    /* vt[04] */ virtual bool becomeCurrent(const char*) DUSK_OVERRIDE;
+    /* vt[05] */ virtual void* getResource(const char*) DUSK_OVERRIDE;
+    /* vt[06] */ virtual void* getResource(u32, const char*) DUSK_OVERRIDE;
+    /* vt[07] */ virtual u32 readResource(void*, u32, const char*) DUSK_OVERRIDE;
+    /* vt[08] */ virtual u32 readResource(void*, u32, u32, const char*) DUSK_OVERRIDE;
+    /* vt[09] */ virtual void removeResourceAll(void) DUSK_OVERRIDE;
+    /* vt[10] */ virtual bool removeResource(void*) DUSK_OVERRIDE;
+    /* vt[11] */ virtual bool detachResource(void*) DUSK_OVERRIDE;
+    /* vt[12] */ virtual u32 getResSize(const void*) const DUSK_OVERRIDE;
+    /* vt[13] */ virtual u32 countFile(const char*) const DUSK_OVERRIDE;
+    /* vt[14] */ virtual JKRFileFinder* getFirstFile(const char*) const DUSK_OVERRIDE;
     /* vt[15] */ virtual u32 getExpandedResSize(const void* res) const { return getResSize(res); }
     /* vt[16] */ virtual void* fetchResource(SDIFileEntry*, u32*) = 0;
     /* vt[17] */ virtual void* fetchResource(void*, u32, SDIFileEntry*, u32*) = 0;

--- a/libs/JSystem/include/JSystem/JKernel/JKRAssertHeap.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRAssertHeap.h
@@ -14,23 +14,23 @@ protected:
     virtual ~JKRAssertHeap();
 
 public:
-    /* vt[04] */ virtual u32 getHeapType(void);            /* override */
-    /* vt[05] */ virtual bool check(void);                 /* override */
-    /* vt[06] */ virtual bool dump_sort(void);             /* override */
-    /* vt[07] */ virtual bool dump(void);                  /* override */
-    /* vt[08] */ virtual void do_destroy(void);            /* override */
-    /* vt[19] */ virtual s32 do_changeGroupID(u8) { JUT_ASSERT(41, 0&& "illegal changeGroupID()"); return 0; }
-    /* vt[20] */ virtual u8 do_getCurrentGroupId(void) { return 0; }
-    /* vt[09] */ virtual void* do_alloc(u32, int alignment) { UNUSED(alignment); JUT_ASSERT(47, 0&& "illegal alloc"); return NULL; }
-    /* vt[10] */ virtual void do_free(void*) { JUT_ASSERT(51, 0&& "illegal free"); }
-    /* vt[11] */ virtual void do_freeAll(void) { JUT_ASSERT(53, 0&& "illegal freeAll()"); }
-    /* vt[12] */ virtual void do_freeTail(void) { JUT_ASSERT(55, 0&& "illegal freeTail()"); }
-    /* vt[13] */ virtual void do_fillFreeArea(void) {}
-    /* vt[14] */ virtual s32 do_resize(void*, u32) { JUT_ASSERT(61, 0&& "illegal resize"); return 0; }
-    /* vt[15] */ virtual s32 do_getSize(void*) { return 0; }
-    /* vt[16] */ virtual s32 do_getFreeSize(void) { return 0; }
-    /* vt[17] */ virtual void* do_getMaxFreeBlock(void) { return 0; }
-    /* vt[18] */ virtual s32 do_getTotalFreeSize(void) { return 0; }
+    /* vt[04] */ virtual u32 getHeapType(void) DUSK_OVERRIDE;
+    /* vt[05] */ virtual bool check(void) DUSK_OVERRIDE;
+    /* vt[06] */ virtual bool dump_sort(void) DUSK_OVERRIDE;
+    /* vt[07] */ virtual bool dump(void) DUSK_OVERRIDE;
+    /* vt[08] */ virtual void do_destroy(void) DUSK_OVERRIDE;
+    /* vt[19] */ virtual s32 do_changeGroupID(u8) DUSK_OVERRIDE { JUT_ASSERT(41, 0&& "illegal changeGroupID()"); return 0; }
+    /* vt[20] */ virtual u8 do_getCurrentGroupId(void) DUSK_OVERRIDE { return 0; }
+    /* vt[09] */ virtual void* do_alloc(u32, int alignment) DUSK_OVERRIDE { UNUSED(alignment); JUT_ASSERT(47, 0&& "illegal alloc"); return NULL; }
+    /* vt[10] */ virtual void do_free(void*) DUSK_OVERRIDE { JUT_ASSERT(51, 0&& "illegal free"); }
+    /* vt[11] */ virtual void do_freeAll(void) DUSK_OVERRIDE { JUT_ASSERT(53, 0&& "illegal freeAll()"); }
+    /* vt[12] */ virtual void do_freeTail(void) DUSK_OVERRIDE { JUT_ASSERT(55, 0&& "illegal freeTail()"); }
+    /* vt[13] */ virtual void do_fillFreeArea(void) DUSK_OVERRIDE {}
+    /* vt[14] */ virtual s32 do_resize(void*, u32) DUSK_OVERRIDE { JUT_ASSERT(61, 0&& "illegal resize"); return 0; }
+    /* vt[15] */ virtual s32 do_getSize(void*) DUSK_OVERRIDE { return 0; }
+    /* vt[16] */ virtual s32 do_getFreeSize(void) DUSK_OVERRIDE { return 0; }
+    /* vt[17] */ virtual void* do_getMaxFreeBlock(void) DUSK_OVERRIDE { return 0; }
+    /* vt[18] */ virtual s32 do_getTotalFreeSize(void) DUSK_OVERRIDE { return 0; }
 
 
 public:

--- a/libs/JSystem/include/JSystem/JKernel/JKRCompArchive.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRCompArchive.h
@@ -17,12 +17,12 @@ public:
 
     bool open(s32);
 
-    /* vt[09] */ void removeResourceAll(void); /* override */
-    /* vt[10] */ bool removeResource(void*);   /* override */
+    /* vt[09] */ void removeResourceAll(void) DUSK_OVERRIDE;
+    /* vt[10] */ bool removeResource(void*) DUSK_OVERRIDE;
 
-    /* vt[15] */ u32 getExpandedResSize(const void*) const;                  /* override */
-    /* vt[16] */ void* fetchResource(SDIFileEntry*, u32*);             /* override */
-    /* vt[17] */ void* fetchResource(void*, u32, SDIFileEntry*, u32*); /* override */
+    /* vt[15] */ u32 getExpandedResSize(const void*) const DUSK_OVERRIDE;
+    /* vt[16] */ void* fetchResource(SDIFileEntry*, u32*) DUSK_OVERRIDE;
+    /* vt[17] */ void* fetchResource(void*, u32, SDIFileEntry*, u32*) DUSK_OVERRIDE;
 
 public:
 private:

--- a/libs/JSystem/include/JSystem/JKernel/JKRDecomp.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRDecomp.h
@@ -44,7 +44,7 @@ private:
     JKRDecomp(s32);
     virtual ~JKRDecomp();
 
-    /* vt[03] */ virtual void* run(); /* override */
+    /* vt[03] */ virtual void* run() DUSK_OVERRIDE;
 
 public:
     static JKRDecomp* create(s32);

--- a/libs/JSystem/include/JSystem/JKernel/JKRDvdArchive.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRDvdArchive.h
@@ -16,9 +16,9 @@ public:
 
     bool open(s32);
 
-    /* vt[15] */ virtual u32 getExpandedResSize(const void*) const;            /* override */
-    /* vt[16] */ virtual void* fetchResource(SDIFileEntry*, u32*);             /* override */
-    /* vt[17] */ virtual void* fetchResource(void*, u32, SDIFileEntry*, u32*); /* override */
+    /* vt[15] */ virtual u32 getExpandedResSize(const void*) const DUSK_OVERRIDE;
+    /* vt[16] */ virtual void* fetchResource(SDIFileEntry*, u32*) DUSK_OVERRIDE;
+    /* vt[17] */ virtual void* fetchResource(void*, u32, SDIFileEntry*, u32*) DUSK_OVERRIDE;
 
 public:
     static u32 fetchResource_subroutine(s32, u32, u32, u8*, u32, JKRCompression, JKRCompression);

--- a/libs/JSystem/include/JSystem/JKernel/JKRDvdFile.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRDvdFile.h
@@ -31,11 +31,11 @@ public:
     int getStatus() const { return DVDGetCommandBlockStatus(&mFileInfo.cb); }
 
 public:
-    /* vt[03] */ virtual bool open(const char*);               /* override */
-    /* vt[04] */ virtual void close(void);                     /* override */
-    /* vt[05] */ virtual s32 readData(void*, s32, s32);        /* override */
-    /* vt[06] */ virtual s32 writeData(const void*, s32, s32); /* override */
-    /* vt[07] */ virtual s32 getFileSize(void) const;          /* override */
+    /* vt[03] */ virtual bool open(const char*) DUSK_OVERRIDE;
+    /* vt[04] */ virtual void close(void) DUSK_OVERRIDE;
+    /* vt[05] */ virtual s32 readData(void*, s32, s32) DUSK_OVERRIDE;
+    /* vt[06] */ virtual s32 writeData(const void*, s32, s32) DUSK_OVERRIDE;
+    /* vt[07] */ virtual s32 getFileSize(void) const DUSK_OVERRIDE;
     /* vt[08] */ virtual bool open(s32);
 
 // private:

--- a/libs/JSystem/include/JSystem/JKernel/JKRExpHeap.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRExpHeap.h
@@ -81,26 +81,26 @@ public:
     }
 
 public:
-    /* vt[04] */ virtual u32 getHeapType();                                     /* override */
-    /* vt[05] */ virtual bool check();                                          /* override */
-    /* vt[06] */ virtual bool dump_sort();                                      /* override */
-    /* vt[07] */ virtual bool dump();                                           /* override */
-    /* vt[08] */ virtual void do_destroy();                                     /* override */
-    /* vt[09] */ virtual void* do_alloc(u32 size, int alignment);               /* override */
-    /* vt[10] */ virtual void do_free(void* ptr);                               /* override */
-    /* vt[11] */ virtual void do_freeAll();                                     /* override */
-    /* vt[12] */ virtual void do_freeTail();                                    /* override */
-    /* vt[13] */ virtual void do_fillFreeArea();                                /* override */
-    /* vt[14] */ virtual s32 do_resize(void* ptr, u32 size);                    /* override */
-    /* vt[15] */ virtual s32 do_getSize(void* ptr);                             /* override */
-    /* vt[16] */ virtual s32 do_getFreeSize();                                  /* override */
-    /* vt[17] */ virtual void* do_getMaxFreeBlock();                            /* override */
-    /* vt[18] */ virtual s32 do_getTotalFreeSize();                             /* override */
-    /* vt[19] */ virtual s32 do_changeGroupID(u8 newGroupID);                   /* override */
-    /* vt[20] */ virtual u8 do_getCurrentGroupId();                             /* override */
-    /* vt[21] */ virtual void state_register(JKRHeap::TState* p, u32 id) const; /* override */
+    /* vt[04] */ virtual u32 getHeapType() DUSK_OVERRIDE;
+    /* vt[05] */ virtual bool check() DUSK_OVERRIDE;
+    /* vt[06] */ virtual bool dump_sort() DUSK_OVERRIDE;
+    /* vt[07] */ virtual bool dump() DUSK_OVERRIDE;
+    /* vt[08] */ virtual void do_destroy() DUSK_OVERRIDE;
+    /* vt[09] */ virtual void* do_alloc(u32 size, int alignment) DUSK_OVERRIDE;
+    /* vt[10] */ virtual void do_free(void* ptr) DUSK_OVERRIDE;
+    /* vt[11] */ virtual void do_freeAll() DUSK_OVERRIDE;
+    /* vt[12] */ virtual void do_freeTail() DUSK_OVERRIDE;
+    /* vt[13] */ virtual void do_fillFreeArea() DUSK_OVERRIDE;
+    /* vt[14] */ virtual s32 do_resize(void* ptr, u32 size) DUSK_OVERRIDE;
+    /* vt[15] */ virtual s32 do_getSize(void* ptr) DUSK_OVERRIDE;
+    /* vt[16] */ virtual s32 do_getFreeSize() DUSK_OVERRIDE;
+    /* vt[17] */ virtual void* do_getMaxFreeBlock() DUSK_OVERRIDE;
+    /* vt[18] */ virtual s32 do_getTotalFreeSize() DUSK_OVERRIDE;
+    /* vt[19] */ virtual s32 do_changeGroupID(u8 newGroupID) DUSK_OVERRIDE;
+    /* vt[20] */ virtual u8 do_getCurrentGroupId() DUSK_OVERRIDE;
+    /* vt[21] */ virtual void state_register(JKRHeap::TState* p, u32 id) const DUSK_OVERRIDE;
     /* vt[22] */ virtual bool state_compare(JKRHeap::TState const& r1,
-                                            JKRHeap::TState const& r2) const; /* override */
+                                            JKRHeap::TState const& r2) const DUSK_OVERRIDE;
 
     /* 0x6C */ u8 mAllocMode;
     /* 0x6D */ u8 mCurrentGroupId;

--- a/libs/JSystem/include/JSystem/JKernel/JKRFileCache.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRFileCache.h
@@ -35,17 +35,17 @@ protected:
     void convStrLower(char*) const;
 
 public:
-    /* vt[04] */ virtual bool becomeCurrent(const char*);                /* override */
-    /* vt[05] */ virtual void* getResource(const char*);                 /* override */
-    /* vt[06] */ virtual void* getResource(u32, const char*);            /* override */
-    /* vt[07] */ virtual u32 readResource(void*, u32, const char*);      /* override */
-    /* vt[08] */ virtual u32 readResource(void*, u32, u32, const char*); /* override */
-    /* vt[09] */ virtual void removeResourceAll(void);                   /* override */
-    /* vt[10] */ virtual bool removeResource(void*);                     /* override */
-    /* vt[11] */ virtual bool detachResource(void*);                     /* override */
-    /* vt[12] */ virtual u32 getResSize(const void*) const;              /* override */
-    /* vt[13] */ virtual u32 countFile(const char*) const;               /* override */
-    /* vt[14] */ virtual JKRFileFinder* getFirstFile(const char*) const; /* override */
+    /* vt[04] */ virtual bool becomeCurrent(const char*) DUSK_OVERRIDE;
+    /* vt[05] */ virtual void* getResource(const char*) DUSK_OVERRIDE;
+    /* vt[06] */ virtual void* getResource(u32, const char*) DUSK_OVERRIDE;
+    /* vt[07] */ virtual u32 readResource(void*, u32, const char*) DUSK_OVERRIDE;
+    /* vt[08] */ virtual u32 readResource(void*, u32, u32, const char*) DUSK_OVERRIDE;
+    /* vt[09] */ virtual void removeResourceAll(void) DUSK_OVERRIDE;
+    /* vt[10] */ virtual bool removeResource(void*) DUSK_OVERRIDE;
+    /* vt[11] */ virtual bool detachResource(void*) DUSK_OVERRIDE;
+    /* vt[12] */ virtual u32 getResSize(const void*) const DUSK_OVERRIDE;
+    /* vt[13] */ virtual u32 countFile(const char*) const DUSK_OVERRIDE;
+    /* vt[14] */ virtual JKRFileFinder* getFirstFile(const char*) const DUSK_OVERRIDE;
     /* vt[15] */ virtual void* getFsResource(const char*);
     /* vt[16] */ virtual void* getNameResource(u32, const char*);
     /* vt[17] */ virtual u32 readFsResource(void*, u32, const char*);

--- a/libs/JSystem/include/JSystem/JKernel/JKRFileFinder.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRFileFinder.h
@@ -45,7 +45,7 @@ public:
     inline virtual ~JKRArcFinder() {}
 
 public:
-    /* vt[3] */ virtual bool findNextFile(void); /* override */
+    /* vt[3] */ virtual bool findNextFile(void) DUSK_OVERRIDE;
 
 private:
     /* 0x00 */  // JKRFileFinder_UnknownBase
@@ -63,7 +63,7 @@ public:
     virtual ~JKRDvdFinder();
 
 public:
-    /* vt[3] */ virtual bool findNextFile(void); /* override */
+    /* vt[3] */ virtual bool findNextFile(void) DUSK_OVERRIDE;
 
 private:
     /* 0x00 */  // JKRFileFinder_UnknownBase

--- a/libs/JSystem/include/JSystem/JKernel/JKRHeap.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRHeap.h
@@ -52,7 +52,7 @@ public:
 public:
     JKRHeap(u32 size, JKRHeap* parent, bool errorFlag);
     JKRHeap(void* data, u32 size, JKRHeap* parent, bool errorFlag);
-    virtual ~JKRHeap();
+    virtual ~JKRHeap() DUSK_OVERRIDE;
 
     JKRHeap* becomeSystemHeap();
     JKRHeap* becomeCurrentHeap();

--- a/libs/JSystem/include/JSystem/JKernel/JKRMemArchive.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRMemArchive.h
@@ -21,12 +21,12 @@ public:
     bool open(s32, JKRArchive::EMountDirection);
     bool open(void*, u32, JKRMemBreakFlag);
 
-    /* vt[09] */ void removeResourceAll(void); /* override */
-    /* vt[10] */ bool removeResource(void*);   /* override */
+    /* vt[09] */ void removeResourceAll(void) DUSK_OVERRIDE;
+    /* vt[10] */ bool removeResource(void*) DUSK_OVERRIDE;
 
-    /* vt[15] */ u32 getExpandedResSize(const void*) const;            /* override */
-    /* vt[16] */ void* fetchResource(SDIFileEntry*, u32*);             /* override */
-    /* vt[17] */ void* fetchResource(void*, u32, SDIFileEntry*, u32*); /* override */
+    /* vt[15] */ u32 getExpandedResSize(const void*) const DUSK_OVERRIDE;
+    /* vt[16] */ void* fetchResource(SDIFileEntry*, u32*) DUSK_OVERRIDE;
+    /* vt[17] */ void* fetchResource(void*, u32, SDIFileEntry*, u32*) DUSK_OVERRIDE;
 
 public:
     static u32 fetchResource_subroutine(u8*, u32, u8*, u32, JKRCompression);

--- a/libs/JSystem/include/JSystem/JKernel/JKRSolidHeap.h
+++ b/libs/JSystem/include/JSystem/JKernel/JKRSolidHeap.h
@@ -19,7 +19,7 @@ public:
 
 protected:
     JKRSolidHeap(void*, u32, JKRHeap*, bool);
-    virtual ~JKRSolidHeap();
+    virtual ~JKRSolidHeap() DUSK_OVERRIDE;
 
     void* allocFromHead(u32, int);
     void* allocFromTail(u32, int);
@@ -27,25 +27,25 @@ protected:
     static s32 getUsedSize(JKRSolidHeap* heap) { return heap->mSize - heap->getTotalFreeSize(); }
 
 public:
-    /* vt[04] */ virtual u32 getHeapType(void); /* override */
-    /* vt[05] */ virtual bool check(void);      /* override */
+    /* vt[04] */ virtual u32 getHeapType(void) DUSK_OVERRIDE;
+    /* vt[05] */ virtual bool check(void) DUSK_OVERRIDE;
 
-    /* vt[07] */ virtual bool dump(void);                /* override */
-    /* vt[08] */ virtual void do_destroy(void);          /* override */
-    /* vt[09] */ virtual void* do_alloc(u32, int);       /* override */
-    /* vt[10] */ virtual void do_free(void*);            /* override */
-    /* vt[11] */ virtual void do_freeAll(void);          /* override */
-    /* vt[12] */ virtual void do_freeTail(void);         /* override */
-    /* vt[13] */ virtual void do_fillFreeArea(void);     /* override */
-    /* vt[14] */ virtual s32 do_resize(void*, u32);      /* override */
-    /* vt[15] */ virtual s32 do_getSize(void*);          /* override */
-    /* vt[16] */ virtual s32 do_getFreeSize(void);       /* override */
-    /* vt[17] */ virtual void* do_getMaxFreeBlock(void); /* override */
-    /* vt[18] */ virtual s32 do_getTotalFreeSize(void);  /* override */
+    /* vt[07] */ virtual bool dump(void) DUSK_OVERRIDE;
+    /* vt[08] */ virtual void do_destroy(void) DUSK_OVERRIDE;
+    /* vt[09] */ virtual void* do_alloc(u32, int) DUSK_OVERRIDE;
+    /* vt[10] */ virtual void do_free(void*) DUSK_OVERRIDE;
+    /* vt[11] */ virtual void do_freeAll(void) DUSK_OVERRIDE;
+    /* vt[12] */ virtual void do_freeTail(void) DUSK_OVERRIDE;
+    /* vt[13] */ virtual void do_fillFreeArea(void) DUSK_OVERRIDE;
+    /* vt[14] */ virtual s32 do_resize(void*, u32) DUSK_OVERRIDE;
+    /* vt[15] */ virtual s32 do_getSize(void*) DUSK_OVERRIDE;
+    /* vt[16] */ virtual s32 do_getFreeSize(void) DUSK_OVERRIDE;
+    /* vt[17] */ virtual void* do_getMaxFreeBlock(void) DUSK_OVERRIDE;
+    /* vt[18] */ virtual s32 do_getTotalFreeSize(void) DUSK_OVERRIDE;
 
-    /* vt[21] */ virtual void state_register(JKRHeap::TState*, u32) const; /* override */
+    /* vt[21] */ virtual void state_register(JKRHeap::TState*, u32) const DUSK_OVERRIDE;
     /* vt[22] */ virtual bool state_compare(JKRHeap::TState const&,
-                                            JKRHeap::TState const&) const; /* override */
+                                            JKRHeap::TState const&) const DUSK_OVERRIDE;
 
 private:
     /* 0x00 */  // vtable

--- a/libs/JSystem/include/JSystem/JSupport/JSURandomInputStream.h
+++ b/libs/JSystem/include/JSystem/JSupport/JSURandomInputStream.h
@@ -12,11 +12,11 @@ public:
     JSURandomInputStream() {}
     virtual ~JSURandomInputStream() {}
 
-    /* vt[3] */ virtual s32 getAvailable() const /* override */ {
+    /* vt[3] */ virtual s32 getAvailable() const DUSK_OVERRIDE {
         return getLength() - getPosition();
     }
-    /* vt[4] */ virtual s32 skip(s32);            /* override */
-    /* vt[5] */ virtual u32 readData(void*, s32) = 0;
+    /* vt[4] */ virtual s32 skip(s32) DUSK_OVERRIDE;
+    /* vt[5] */ virtual u32 readData(void*, s32) DUSK_OVERRIDE = 0;
     /* vt[6] */ virtual s32 getLength() const = 0;
     /* vt[7] */ virtual s32 getPosition() const = 0;
     /* vt[8] */ virtual s32 seekPos(s32, JSUStreamSeekFrom) = 0;

--- a/libs/JSystem/include/JSystem/JUtility/JUTResFont.h
+++ b/libs/JSystem/include/JSystem/JUtility/JUTResFont.h
@@ -24,21 +24,21 @@ struct BlockHeader {
 */
 class JUTResFont : public JUTFont {
 public:
-    virtual ~JUTResFont();
-    virtual void setGX();
-    virtual void setGX(JUtility::TColor, JUtility::TColor);
-    virtual f32 drawChar_scale(f32, f32, f32, f32, int, bool FONT_DRAW_CTX);
-    virtual int getLeading() const;
-    virtual s32 getAscent() const;
-    virtual s32 getDescent() const;
-    virtual s32 getHeight() const;
-    virtual s32 getWidth() const;
-    virtual void getWidthEntry(int, JUTFont::TWidth*) const;
-    virtual s32 getCellWidth() const;
-    virtual s32 getCellHeight() const;
-    virtual int getFontType() const;
-    virtual ResFONT* getResFont() const;
-    virtual bool isLeadByte(int) const;
+    virtual ~JUTResFont() DUSK_OVERRIDE;
+    virtual void setGX() DUSK_OVERRIDE;
+    virtual void setGX(JUtility::TColor, JUtility::TColor) DUSK_OVERRIDE;
+    virtual f32 drawChar_scale(f32, f32, f32, f32, int, bool FONT_DRAW_CTX) DUSK_OVERRIDE;
+    virtual int getLeading() const DUSK_OVERRIDE;
+    virtual s32 getAscent() const DUSK_OVERRIDE;
+    virtual s32 getDescent() const DUSK_OVERRIDE;
+    virtual s32 getHeight() const DUSK_OVERRIDE;
+    virtual s32 getWidth() const DUSK_OVERRIDE;
+    virtual void getWidthEntry(int, JUTFont::TWidth*) const DUSK_OVERRIDE;
+    virtual s32 getCellWidth() const DUSK_OVERRIDE;
+    virtual s32 getCellHeight() const DUSK_OVERRIDE;
+    virtual int getFontType() const DUSK_OVERRIDE;
+    virtual ResFONT* getResFont() const DUSK_OVERRIDE;
+    virtual bool isLeadByte(int) const DUSK_OVERRIDE;
     virtual void loadImage(int, GXTexMapID FONT_DRAW_CTX);
     virtual void setBlock();
 


### PR DESCRIPTION
This is to mute compiler warnings and to avoid future mistakes like what previously happened with JUTResFont

These are behind a macro, DUSK_OVERRIDE, to make it clear they are Dusk modifications to the decomp. This is similar to DUSK_CONST etc.

This doesn't annotate even close to all the overrides but it's a start.