### PR TITLE
Make JASCalc memory helpers just use memcpy/memset

### DIFF
--- a/libs/JSystem/include/JSystem/JAudio2/JASCalc.h
+++ b/libs/JSystem/include/JSystem/JAudio2/JASCalc.h
@@ -2,6 +2,7 @@
 #define JASCALC_H
 
 #include <types.h>
+#include <cstring>
 #include <limits>
 
 /**
@@ -12,24 +13,24 @@ struct JASCalc {
     static void imixcopy(const s16*, const s16*, s16*, u32);
 #if TARGET_PC
     static void bcopyfast(const void* src, void* dest, u32 size) {
-        memcpy(dest, src, size);
+        std::memcpy(dest, src, size);
     }
 #if TARGET_ANDROID
     static void _bcopy(const void* src, void* dest, u32 size) {
 #else
     static void bcopy(const void* src, void* dest, u32 size) {
 #endif
-        memcpy(dest, src, size);
+        std::memcpy(dest, src, size);
     }
     static void bzerofast(void* dest, u32 size) {
-        memset(dest, 0, size);
+        std::memset(dest, 0, size);
     }
 #if TARGET_ANDROID
     static void _bzero(void* dest, u32 size) {
 #else
     static void bzero(void* dest, u32 size) {
 #endif
-        memset(dest, 0, size);
+        std::memset(dest, 0, size);
     }
 #else
     static void bcopyfast(const void* src, void* dest, u32 size);

--- a/libs/JSystem/include/JSystem/JAudio2/JASCalc.h
+++ b/libs/JSystem/include/JSystem/JAudio2/JASCalc.h
@@ -10,16 +10,31 @@
  */
 struct JASCalc {
     static void imixcopy(const s16*, const s16*, s16*, u32);
-    static void bcopyfast(const void* src, void* dest, u32 size);
+#if TARGET_PC
+    static void bcopyfast(const void* src, void* dest, u32 size) {
+        memcpy(dest, src, size);
+    }
 #if TARGET_ANDROID
-    static void _bcopy(const void* src, void* dest, u32 size);
+    static void _bcopy(const void* src, void* dest, u32 size) {
 #else
-    static void bcopy(const void* src, void* dest, u32 size);
+    static void bcopy(const void* src, void* dest, u32 size) {
 #endif
-    static void bzerofast(void* dest, u32 size);
+        memcpy(dest, src, size);
+    }
+    static void bzerofast(void* dest, u32 size) {
+        memset(dest, 0, size);
+    }
 #if TARGET_ANDROID
-    static void _bzero(void* dest, u32 size);
+    static void _bzero(void* dest, u32 size) {
 #else
+    static void bzero(void* dest, u32 size) {
+#endif
+        memset(dest, 0, size);
+    }
+#else
+    static void bcopyfast(const void* src, void* dest, u32 size);
+    static void bcopy(const void* src, void* dest, u32 size);
+    static void bzerofast(void* dest, u32 size);
     static void bzero(void* dest, u32 size);
 #endif
     static f32 pow2(f32);

--- a/libs/JSystem/src/JAudio2/JASCalc.cpp
+++ b/libs/JSystem/src/JAudio2/JASCalc.cpp
@@ -11,6 +11,7 @@ void JASCalc::imixcopy(const s16* s1, const s16* s2, s16* dst, u32 n) {
     }
 }
 
+#if !TARGET_PC
 void JASCalc::bcopyfast(const void* src, void* dest, u32 size) {
     JUT_ASSERT(226, (reinterpret_cast<uintptr_t>(src) & 0x03) == 0);
     JUT_ASSERT(227, (reinterpret_cast<uintptr_t>(dest) & 0x03) == 0);
@@ -33,11 +34,7 @@ void JASCalc::bcopyfast(const void* src, void* dest, u32 size) {
     }
 }
 
-#if TARGET_ANDROID
-void JASCalc::_bcopy(const void* src, void* dest, u32 size) {
-#else
 void JASCalc::bcopy(const void* src, void* dest, u32 size) {
-#endif
     u32* usrc;
     u32* udest;
 
@@ -94,11 +91,7 @@ void JASCalc::bzerofast(void* dest, u32 size) {
     }
 }
 
-#if TARGET_ANDROID
-void JASCalc::_bzero(void* dest, u32 size) {
-#else
 void JASCalc::bzero(void* dest, u32 size) {
-#endif
     u32* udest;
     u8* bdest = (u8*)dest;
     if ((size & 0x1f) == 0 && (reinterpret_cast<uintptr_t>(dest) & 0x1f) == 0) {
@@ -139,6 +132,7 @@ void JASCalc::bzero(void* dest, u32 size) {
         }
     }
 }
+#endif
 
 #if AVOID_UB
 DUSK_GAME_DATA s16 const JASCalc::CUTOFF_TO_IIR_TABLE[129][4] = {


### PR DESCRIPTION
A ton of code that we don't need in 2026