### PR TITLE
Set gamepad's LED color based on player's HP

### DIFF
--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -396,6 +396,7 @@ template class ConfigImpl<MenuScaling>;
 template class ConfigImpl<Resampler>;
 template class ConfigImpl<MagicArmorMode>;
 template class ConfigImpl<ui::ControlLayout>;
+template class ConfigImpl<LedStatusMode>;
 
 void Register(ConfigVarBase& configVar) {
     const std::string_view name = configVar.getName();

--- a/src/dusk/gamepad_color.cpp
+++ b/src/dusk/gamepad_color.cpp
@@ -114,8 +114,8 @@ namespace {
         float t = static_cast<float>(currentHp) / static_cast<float>(maxHp);
         t = std::clamp(t, 0.0f, 1.0f);
 
-        const cXyz kRed = kColorTable[RED].color;  // 0% HP
-        const cXyz  kGreen = kColorTable[GREEN].color; // 100% HP
+        const cXyz kRed = kColorTable[RED].color;     // 0% HP
+        const cXyz kGreen = kColorTable[GREEN].color; // 100% HP
 
         // Interpolate between red and green based on HP percentage
         const cXyz hpColor = LerpColor(kRed, kGreen, t);
@@ -145,8 +145,7 @@ void handleGamepadColor() {
             }
             continue;
         case LedStatusMode::PLAYER_HP: {
-            auto color = getColorSettingFromHP();
-            finalColor = color;
+            finalColor = getColorSettingFromHP();
             lerpSpeed = 1.0f;
             break;
         }

--- a/src/dusk/gamepad_color.cpp
+++ b/src/dusk/gamepad_color.cpp
@@ -148,16 +148,18 @@ void handleGamepadColor() {
                 PADSetColor(port, 0, 0, 0);
             }
             continue;
-        case LedStatusMode::PLAYER_HP:
+        case LedStatusMode::PLAYER_HP: {
             auto [color, speed] = getColorSettingFromHP();
             finalColor = color;
             lerpSpeed = speed * speedFactor;
             break;
-        case LedStatusMode::GAME_STATE:
+        }
+        case LedStatusMode::GAME_STATE: {
             auto [color, speed] = getColorSetting();
             finalColor = color + additionalColor;
             lerpSpeed = speed * speedFactor;
             break;
+        }
         default:
             continue;
         }

--- a/src/dusk/gamepad_color.cpp
+++ b/src/dusk/gamepad_color.cpp
@@ -99,10 +99,10 @@ namespace {
         return kColorTable[NO_COLOR].color;
     }
 
-    cXyz getColorSettingFromHP() {
+    ColorSetting getColorSettingFromHP() {
         Z2CreatureLink* link = Z2GetLink();
         if (link == nullptr)
-            return kColorTable[DUSK_COLOR].color;
+            return kColorTable[DUSK_COLOR];
 
         // Current HP in quarter-heart units (pieces)
         const int currentHp = link->getLinkHp();
@@ -120,7 +120,7 @@ namespace {
         // Interpolate between red and green based on HP percentage
         const cXyz hpColor = LerpColor(kRed, kGreen, t);
 
-        return hpColor;
+        return {hpColor, 30.0f};
     }
 }  // namespace
 
@@ -134,28 +134,30 @@ bool pad_has_led(const int port) noexcept {
 void handleGamepadColor() {
     cXyz finalColor = {0, 0, 0};
     float lerpSpeed = 0.0f;
+    const cXyz additionalColor = getAdditionalColor();
+    const auto& settings = getSettings();
+    constexpr float speedFactor = 1.0f / 30.0f;
 
     for (int port = 0; port < PAD_MAX_CONTROLLERS; ++port) {
-        const auto ledMode = getSettings().game.ledStatusMode[port].getValue();
+        const bool hasLed = pad_has_led(port);
+        const auto ledMode = settings.game.ledStatusMode[port].getValue();
 
         switch (ledMode) {
         case LedStatusMode::OFF:
-            if (pad_has_led(port)) {
+            if (hasLed) {
                 PADSetColor(port, 0, 0, 0);
             }
             continue;
-        case LedStatusMode::PLAYER_HP: {
-            finalColor = getColorSettingFromHP();
-            lerpSpeed = 1.0f;
+        case LedStatusMode::PLAYER_HP:
+            auto [color, speed] = getColorSettingFromHP();
+            finalColor = color;
+            lerpSpeed = speed * speedFactor;
             break;
-        }
-        case LedStatusMode::GAME_STATE: {
+        case LedStatusMode::GAME_STATE:
             auto [color, speed] = getColorSetting();
-            const cXyz additionalColor = getAdditionalColor();
             finalColor = color + additionalColor;
-            lerpSpeed = speed / 30.0f;
+            lerpSpeed = speed * speedFactor;
             break;
-        }
         default:
             continue;
         }
@@ -163,7 +165,7 @@ void handleGamepadColor() {
         clamp(finalColor);
         currentColor = LerpColor(currentColor, finalColor, lerpSpeed);
 
-        if (pad_has_led(port)) {
+        if (hasLed) {
             PADSetColor(
                 port,
                 static_cast<u8>(currentColor.x),

--- a/src/dusk/gamepad_color.cpp
+++ b/src/dusk/gamepad_color.cpp
@@ -5,8 +5,6 @@
 #include <d/actor/d_a_alink.h>
 #include <dusk/gamepad_color.h>
 
-#include "aurora/lib/logging.hpp"
-
 #include "ui/controller_config.hpp"
 
 #include <pad.h>
@@ -15,10 +13,7 @@ namespace dusk::input {
 
 namespace {
 
-    aurora::Module Log("dusk::input::gamepad_color");
-
     cXyz currentColor = {0, 0, 0};
-    float lerpSpeed = 0.0f;
 
     enum ColorVariations : u8 {
         NO_COLOR = 0,
@@ -30,6 +25,8 @@ namespace {
         LINK_ZORA = 6,
         LINK_MAGIC = 7,
         LINK_MAGIC_HEAVY = 8,
+        RED = 9,
+        GREEN = 10,
     };
 
     struct ColorSetting {
@@ -47,6 +44,8 @@ namespace {
         /* 6: LINK_ZORA        */ { {0, 0, 100},     5.0f },
         /* 7: LINK_MAGIC       */ { {100, 0, 5},     5.0f },
         /* 8: LINK_MAGIC_HEAVY */ { {5, 100, 100},   5.0f },
+        /* 9: RED              */ { {255, 0, 0},     2.0f },
+        /* 10: GREEN           */ { {0, 255, 0},     2.0f },
     };
 
     cXyz LerpColor(const cXyz a, const cXyz b, const float t) {
@@ -100,10 +99,10 @@ namespace {
         return kColorTable[NO_COLOR].color;
     }
 
-    ColorSetting getColorSettingFromHP() {
+    cXyz getColorSettingFromHP() {
         Z2CreatureLink* link = Z2GetLink();
         if (link == nullptr)
-            return kColorTable[NO_COLOR];
+            return kColorTable[DUSK_COLOR].color;
 
         // Current HP in quarter-heart units (pieces)
         const int currentHp = link->getLinkHp();
@@ -115,38 +114,59 @@ namespace {
         float t = static_cast<float>(currentHp) / static_cast<float>(maxHp);
         t = std::clamp(t, 0.0f, 1.0f);
 
-        Log.info("Current HP: {}, Max HP: {}, Normalized: {}", currentHp, maxHp, t);
+        const cXyz kRed = kColorTable[RED].color;  // 0% HP
+        const cXyz  kGreen = kColorTable[GREEN].color; // 100% HP
 
-        constexpr cXyz kRed = {255.0f, 0.0f, 0.0f};    // 0% HP
-        constexpr cXyz kGreen = {0.0f, 255.0f, 0.0f};  // 100% HP
-
+        // Interpolate between red and green based on HP percentage
         const cXyz hpColor = LerpColor(kRed, kGreen, t);
-        const float speed = 2.0f; // Speed of color transition
 
-        return {hpColor, speed};
+        return hpColor;
     }
 }  // namespace
 
 bool pad_has_led(const int port) noexcept {
-    if (port > PAD_MAX_CONTROLLERS || port < 0)
+    if (port >= PAD_MAX_CONTROLLERS || port < 0)
         return false;
 
     return PADHasLED(port);
 }
 
 void handleGamepadColor() {
-    auto [color, speed] = getColorSettingFromHP();
-    const cXyz additionalColor = getAdditionalColor();
-    cXyz finalColor = color; // + additionalColor;
-    lerpSpeed = speed / 30.0f;
+    cXyz finalColor = {0, 0, 0};
+    float lerpSpeed = 0.0f;
 
-    clamp(finalColor);
-    currentColor = LerpColor(currentColor, finalColor, lerpSpeed);
+    for (int port = 0; port < PAD_MAX_CONTROLLERS; ++port) {
+        const auto LedMode = getSettings().game.LedStatusMode[port].getValue();
 
-    for (int i = 0; i < 4; i++) {
-        if (pad_has_led(i) && getSettings().game.enableLED[i]) {
+        switch (LedMode) {
+        case LedStatusMode::OFF:
+            if (pad_has_led(port)) {
+                PADSetColor(port, 0, 0, 0);
+            }
+            continue;
+        case LedStatusMode::PLAYER_HP: {
+            auto color = getColorSettingFromHP();
+            finalColor = color;
+            lerpSpeed = 1.0f;
+            break;
+        }
+        case LedStatusMode::GAME_STATE: {
+            auto [color, speed] = getColorSetting();
+            const cXyz additionalColor = getAdditionalColor();
+            finalColor = color + additionalColor;
+            lerpSpeed = speed / 30.0f;
+            break;
+        }
+        default:
+            continue;
+        }
+
+        clamp(finalColor);
+        currentColor = LerpColor(currentColor, finalColor, lerpSpeed);
+
+        if (pad_has_led(port)) {
             PADSetColor(
-                i,
+                port,
                 static_cast<u8>(currentColor.x),
                 static_cast<u8>(currentColor.y),
                 static_cast<u8>(currentColor.z)

--- a/src/dusk/gamepad_color.cpp
+++ b/src/dusk/gamepad_color.cpp
@@ -136,9 +136,9 @@ void handleGamepadColor() {
     float lerpSpeed = 0.0f;
 
     for (int port = 0; port < PAD_MAX_CONTROLLERS; ++port) {
-        const auto LedMode = getSettings().game.LedStatusMode[port].getValue();
+        const auto ledMode = getSettings().game.ledStatusMode[port].getValue();
 
-        switch (LedMode) {
+        switch (ledMode) {
         case LedStatusMode::OFF:
             if (pad_has_led(port)) {
                 PADSetColor(port, 0, 0, 0);

--- a/src/dusk/gamepad_color.cpp
+++ b/src/dusk/gamepad_color.cpp
@@ -5,6 +5,8 @@
 #include <d/actor/d_a_alink.h>
 #include <dusk/gamepad_color.h>
 
+#include "aurora/lib/logging.hpp"
+
 #include "ui/controller_config.hpp"
 
 #include <pad.h>
@@ -12,6 +14,9 @@
 namespace dusk::input {
 
 namespace {
+
+    aurora::Module Log("dusk::input::gamepad_color");
+
     cXyz currentColor = {0, 0, 0};
     float lerpSpeed = 0.0f;
 
@@ -95,6 +100,31 @@ namespace {
         return kColorTable[NO_COLOR].color;
     }
 
+    ColorSetting getColorSettingFromHP() {
+        Z2CreatureLink* link = Z2GetLink();
+        if (link == nullptr)
+            return kColorTable[NO_COLOR];
+
+        // Current HP in quarter-heart units (pieces)
+        const int currentHp = link->getLinkHp();
+
+        // Max HP in quarter-heart units
+        const int maxHp = dComIfGs_getMaxLifeGauge();
+
+        // Normalize to [0, 1]
+        float t = static_cast<float>(currentHp) / static_cast<float>(maxHp);
+        t = std::clamp(t, 0.0f, 1.0f);
+
+        Log.info("Current HP: {}, Max HP: {}, Normalized: {}", currentHp, maxHp, t);
+
+        constexpr cXyz kRed = {255.0f, 0.0f, 0.0f};    // 0% HP
+        constexpr cXyz kGreen = {0.0f, 255.0f, 0.0f};  // 100% HP
+
+        const cXyz hpColor = LerpColor(kRed, kGreen, t);
+        const float speed = 2.0f; // Speed of color transition
+
+        return {hpColor, speed};
+    }
 }  // namespace
 
 bool pad_has_led(const int port) noexcept {
@@ -105,9 +135,9 @@ bool pad_has_led(const int port) noexcept {
 }
 
 void handleGamepadColor() {
-    auto [color, speed] = getColorSetting();
+    auto [color, speed] = getColorSettingFromHP();
     const cXyz additionalColor = getAdditionalColor();
-    cXyz finalColor = color + additionalColor;
+    cXyz finalColor = color; // + additionalColor;
     lerpSpeed = speed / 30.0f;
 
     clamp(finalColor);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -119,11 +119,11 @@ UserSettings g_userSettings = {
             ConfigVar<bool>{"game.enableLED_port2", true},
             ConfigVar<bool>{"game.enableLED_port3", true},
         },
-        .LedStatusMode {
-            ConfigVar<LedStatusMode>{"game.LedStatusMode_port0", LedStatusMode::GAME_STATE},
-            ConfigVar<LedStatusMode>{"game.LedStatusMode_port1", LedStatusMode::GAME_STATE},
-            ConfigVar<LedStatusMode>{"game.LedStatusMode_port2", LedStatusMode::GAME_STATE},
-            ConfigVar<LedStatusMode>{"game.LedStatusMode_port3", LedStatusMode::GAME_STATE},
+        .ledStatusMode {
+            ConfigVar<LedStatusMode>{"game.ledStatusMode_port0", LedStatusMode::GAME_STATE},
+            ConfigVar<LedStatusMode>{"game.ledStatusMode_port1", LedStatusMode::GAME_STATE},
+            ConfigVar<LedStatusMode>{"game.ledStatusMode_port2", LedStatusMode::GAME_STATE},
+            ConfigVar<LedStatusMode>{"game.ledStatusMode_port3", LedStatusMode::GAME_STATE},
         },
         .swapDirectSelect {"game.swapDirectSelect", false},
 
@@ -349,10 +349,10 @@ void registerSettings() {
     Register(g_userSettings.game.enableLED[1]);
     Register(g_userSettings.game.enableLED[2]);
     Register(g_userSettings.game.enableLED[3]);
-    Register(g_userSettings.game.LedStatusMode[0]);
-    Register(g_userSettings.game.LedStatusMode[1]);
-    Register(g_userSettings.game.LedStatusMode[2]);
-    Register(g_userSettings.game.LedStatusMode[3]);
+    Register(g_userSettings.game.ledStatusMode[0]);
+    Register(g_userSettings.game.ledStatusMode[1]);
+    Register(g_userSettings.game.ledStatusMode[2]);
+    Register(g_userSettings.game.ledStatusMode[3]);
     Register(g_userSettings.game.swapDirectSelect);
 
     Register(g_userSettings.backend.isoPath);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -113,12 +113,6 @@ UserSettings g_userSettings = {
         .debugFlyCam {"game.debugFlyCam", false},
         .debugFlyCamLockEvents {"game.debugFlyCamLockEvents", true},
         .allowBackgroundInput {"game.allowBackgroundInput", true},
-        .enableLED {
-            ConfigVar<bool>{"game.enableLED_port0", true},
-            ConfigVar<bool>{"game.enableLED_port1", true},
-            ConfigVar<bool>{"game.enableLED_port2", true},
-            ConfigVar<bool>{"game.enableLED_port3", true},
-        },
         .ledStatusMode {
             ConfigVar<LedStatusMode>{"game.ledStatusMode_port0", LedStatusMode::GAME_STATE},
             ConfigVar<LedStatusMode>{"game.ledStatusMode_port1", LedStatusMode::GAME_STATE},
@@ -345,10 +339,6 @@ void registerSettings() {
     Register(g_userSettings.game.debugFlyCam);
     Register(g_userSettings.game.debugFlyCamLockEvents);
     Register(g_userSettings.game.allowBackgroundInput);
-    Register(g_userSettings.game.enableLED[0]);
-    Register(g_userSettings.game.enableLED[1]);
-    Register(g_userSettings.game.enableLED[2]);
-    Register(g_userSettings.game.enableLED[3]);
     Register(g_userSettings.game.ledStatusMode[0]);
     Register(g_userSettings.game.ledStatusMode[1]);
     Register(g_userSettings.game.ledStatusMode[2]);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -119,6 +119,12 @@ UserSettings g_userSettings = {
             ConfigVar<bool>{"game.enableLED_port2", true},
             ConfigVar<bool>{"game.enableLED_port3", true},
         },
+        .LedStatusMode {
+            ConfigVar<LedStatusMode>{"game.LedStatusMode_port0", LedStatusMode::GAME_STATE},
+            ConfigVar<LedStatusMode>{"game.LedStatusMode_port1", LedStatusMode::GAME_STATE},
+            ConfigVar<LedStatusMode>{"game.LedStatusMode_port2", LedStatusMode::GAME_STATE},
+            ConfigVar<LedStatusMode>{"game.LedStatusMode_port3", LedStatusMode::GAME_STATE},
+        },
         .swapDirectSelect {"game.swapDirectSelect", false},
 
         // Cheats
@@ -316,6 +322,7 @@ void registerSettings() {
     Register(g_userSettings.game.alwaysGreatspin);
     Register(g_userSettings.game.invincibleEnemies);
     Register(g_userSettings.game.enableFrameInterpolation);
+    // Input
     Register(g_userSettings.game.enableGyroAim);
     Register(g_userSettings.game.enableGyroRollgoal);
     Register(g_userSettings.game.gyroSensitivityX);
@@ -342,6 +349,10 @@ void registerSettings() {
     Register(g_userSettings.game.enableLED[1]);
     Register(g_userSettings.game.enableLED[2]);
     Register(g_userSettings.game.enableLED[3]);
+    Register(g_userSettings.game.LedStatusMode[0]);
+    Register(g_userSettings.game.LedStatusMode[1]);
+    Register(g_userSettings.game.LedStatusMode[2]);
+    Register(g_userSettings.game.LedStatusMode[3]);
     Register(g_userSettings.game.swapDirectSelect);
 
     Register(g_userSettings.backend.isoPath);

--- a/src/dusk/settings.h
+++ b/src/dusk/settings.h
@@ -258,7 +258,7 @@ struct UserSettings {
         ConfigVar<bool> debugFlyCamLockEvents;
         ConfigVar<bool> allowBackgroundInput;
         std::array<ConfigVar<bool>, 4> enableLED;
-        std::array<ConfigVar<LedStatusMode>, 4> LedStatusMode;
+        std::array<ConfigVar<LedStatusMode>, 4> ledStatusMode;
         ConfigVar<bool> swapDirectSelect;
 
         // Cheats

--- a/src/dusk/settings.h
+++ b/src/dusk/settings.h
@@ -67,6 +67,12 @@ enum class MagicArmorMode : u8 {
     COSMETIC = 4,
 };
 
+enum class LedStatusMode : u8 {
+    OFF = 0,
+    GAME_STATE = 1,
+    PLAYER_HP = 2,
+};
+
 namespace config {
 template <>
 struct ConfigEnumRange<BloomMode> {
@@ -120,6 +126,12 @@ template <>
 struct ConfigEnumRange<MagicArmorMode> {
     static constexpr auto min = MagicArmorMode::NORMAL;
     static constexpr auto max = MagicArmorMode::COSMETIC;
+};
+
+template <>
+struct ConfigEnumRange<LedStatusMode> {
+    static constexpr auto min = LedStatusMode::OFF;
+    static constexpr auto max = LedStatusMode::PLAYER_HP;
 };
 
 template <>
@@ -246,6 +258,7 @@ struct UserSettings {
         ConfigVar<bool> debugFlyCamLockEvents;
         ConfigVar<bool> allowBackgroundInput;
         std::array<ConfigVar<bool>, 4> enableLED;
+        std::array<ConfigVar<LedStatusMode>, 4> LedStatusMode;
         ConfigVar<bool> swapDirectSelect;
 
         // Cheats

--- a/src/dusk/settings.h
+++ b/src/dusk/settings.h
@@ -257,7 +257,6 @@ struct UserSettings {
         ConfigVar<bool> debugFlyCam;
         ConfigVar<bool> debugFlyCamLockEvents;
         ConfigVar<bool> allowBackgroundInput;
-        std::array<ConfigVar<bool>, 4> enableLED;
         std::array<ConfigVar<LedStatusMode>, 4> ledStatusMode;
         ConfigVar<bool> swapDirectSelect;
 

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -311,27 +311,60 @@ void ControllerConfigWindow::build_port_tab(Rml::Element* content, int port) {
     addPageButton(Page::Actions, "Custom Action Bindings", [] {return Rml::String(">"); }, [] { return false; });
 
     leftPane.add_section("Options");
-    leftPane.register_control(leftPane.add_child<BoolButton>(BoolButton::Props{
-                                  .key = "Enable LED Status",
-                                  .getValue =
-                                      [port] {
-                                          return getSettings().game.enableLED[port].getValue();
-                                      },
-                                  .setValue =
-                                      [port](const bool value) {
-                                          getSettings().game.enableLED[port].setValue(value);
-                                      },
-                                  .isDisabled = [port] {
-                                      return !input::pad_has_led(port);
-                                  },
-                                  .valueOverride = [port] {
-                                      if (!input::pad_has_led(port))
-                                          return "Not Supported";
+    leftPane.register_control(
+        leftPane.add_select_button({
+            .key = "LED Status Mode",
+            .getValue =
+                [port] {
+                    if (getSettings().game.LedStatusMode[port].getValue() == LedStatusMode::GAME_STATE) {
+                        return "Game's state";
+                    }
+                    else if (getSettings().game.LedStatusMode[port].getValue() == LedStatusMode::PLAYER_HP) {
+                        return "Player's HP";
+                    } else {
+                        return "Off";
+                    }
+                },
+            .isDisabled = [port] {
+                return !input::pad_has_led(port);
+            },
+        }),
+        rightPane, [this, port](Pane& pane) {
+            pane.add_button({
+                .text = "Off",
+                .isSelected = [port] {
+                    return getSettings().game.LedStatusMode[port].getValue() == LedStatusMode::OFF;
+                },
+            })
+            .on_pressed([this, port] {
+                mDoAud_seStartMenu(kSoundClick);
+                getSettings().game.LedStatusMode[port].setValue(LedStatusMode::OFF);
+            });
 
-                                      return "";
-                                  }}),
-        rightPane, [](Pane& pane) {
-            pane.add_text("Sets the controller's lighting color based on the game's state.");
+            pane.add_button({
+                .text = "Game's state",
+                .isSelected = [port] {
+                    return getSettings().game.LedStatusMode[port].getValue() ==
+                           LedStatusMode::GAME_STATE;
+                },
+            })
+            .on_pressed([this, port] {
+                mDoAud_seStartMenu(kSoundClick);
+                getSettings().game.LedStatusMode[port].setValue(LedStatusMode::GAME_STATE);
+            });
+
+            pane.add_button({
+                .text = "Player's HP",
+                .isSelected = [port] {
+                    return getSettings().game.LedStatusMode[port].getValue() ==
+                           LedStatusMode::PLAYER_HP;
+                },
+            })
+            .on_pressed([this, port] {
+                mDoAud_seStartMenu(kSoundClick);
+                getSettings().game.LedStatusMode[port].setValue(LedStatusMode::PLAYER_HP);
+            });
+            pane.add_text("Sets the controller's lighting color based on the game's state (such as the current outfit) or the player's HP.");
         });
     leftPane.register_control(leftPane.add_child<BoolButton>(BoolButton::Props{
                                   .key = "Enable Dead Zones",

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -344,8 +344,7 @@ void ControllerConfigWindow::build_port_tab(Rml::Element* content, int port) {
             pane.add_button({
                 .text = "Game's state",
                 .isSelected = [port] {
-                    return getSettings().game.ledStatusMode[port].getValue() ==
-                           LedStatusMode::GAME_STATE;
+                    return getSettings().game.ledStatusMode[port].getValue() == LedStatusMode::GAME_STATE;
                 },
             })
             .on_pressed([this, port] {
@@ -356,15 +355,14 @@ void ControllerConfigWindow::build_port_tab(Rml::Element* content, int port) {
             pane.add_button({
                 .text = "Player's HP",
                 .isSelected = [port] {
-                    return getSettings().game.ledStatusMode[port].getValue() ==
-                           LedStatusMode::PLAYER_HP;
+                    return getSettings().game.ledStatusMode[port].getValue() == LedStatusMode::PLAYER_HP;
                 },
             })
             .on_pressed([this, port] {
                 mDoAud_seStartMenu(kSoundClick);
                 getSettings().game.ledStatusMode[port].setValue(LedStatusMode::PLAYER_HP);
             });
-            pane.add_text("Sets the controller's lighting color based on the game's state (such as the current outfit) or the player's HP.");
+            pane.add_text("Sets the controller's lighting color based on the game's state (such as the current outfit) or the current player's HP.");
         });
     leftPane.register_control(leftPane.add_child<BoolButton>(BoolButton::Props{
                                   .key = "Enable Dead Zones",

--- a/src/dusk/ui/controller_config.cpp
+++ b/src/dusk/ui/controller_config.cpp
@@ -316,10 +316,10 @@ void ControllerConfigWindow::build_port_tab(Rml::Element* content, int port) {
             .key = "LED Status Mode",
             .getValue =
                 [port] {
-                    if (getSettings().game.LedStatusMode[port].getValue() == LedStatusMode::GAME_STATE) {
+                    if (getSettings().game.ledStatusMode[port].getValue() == LedStatusMode::GAME_STATE) {
                         return "Game's state";
                     }
-                    else if (getSettings().game.LedStatusMode[port].getValue() == LedStatusMode::PLAYER_HP) {
+                    else if (getSettings().game.ledStatusMode[port].getValue() == LedStatusMode::PLAYER_HP) {
                         return "Player's HP";
                     } else {
                         return "Off";
@@ -333,36 +333,36 @@ void ControllerConfigWindow::build_port_tab(Rml::Element* content, int port) {
             pane.add_button({
                 .text = "Off",
                 .isSelected = [port] {
-                    return getSettings().game.LedStatusMode[port].getValue() == LedStatusMode::OFF;
+                    return getSettings().game.ledStatusMode[port].getValue() == LedStatusMode::OFF;
                 },
             })
             .on_pressed([this, port] {
                 mDoAud_seStartMenu(kSoundClick);
-                getSettings().game.LedStatusMode[port].setValue(LedStatusMode::OFF);
+                getSettings().game.ledStatusMode[port].setValue(LedStatusMode::OFF);
             });
 
             pane.add_button({
                 .text = "Game's state",
                 .isSelected = [port] {
-                    return getSettings().game.LedStatusMode[port].getValue() ==
+                    return getSettings().game.ledStatusMode[port].getValue() ==
                            LedStatusMode::GAME_STATE;
                 },
             })
             .on_pressed([this, port] {
                 mDoAud_seStartMenu(kSoundClick);
-                getSettings().game.LedStatusMode[port].setValue(LedStatusMode::GAME_STATE);
+                getSettings().game.ledStatusMode[port].setValue(LedStatusMode::GAME_STATE);
             });
 
             pane.add_button({
                 .text = "Player's HP",
                 .isSelected = [port] {
-                    return getSettings().game.LedStatusMode[port].getValue() ==
+                    return getSettings().game.ledStatusMode[port].getValue() ==
                            LedStatusMode::PLAYER_HP;
                 },
             })
             .on_pressed([this, port] {
                 mDoAud_seStartMenu(kSoundClick);
-                getSettings().game.LedStatusMode[port].setValue(LedStatusMode::PLAYER_HP);
+                getSettings().game.ledStatusMode[port].setValue(LedStatusMode::PLAYER_HP);
             });
             pane.add_text("Sets the controller's lighting color based on the game's state (such as the current outfit) or the player's HP.");
         });


### PR DESCRIPTION
Adds an option to change the color of the gamepad's LED to reflect the current player's HP, from fully red (0 hearts) to fully green (all available hearts)

https://github.com/user-attachments/assets/2e40ffc3-c530-47ff-be31-53119fb3f27e

<img width="1216" height="928" alt="Screenshot 2026-08-03 at 16 30 27" src="https://github.com/user-attachments/assets/b0c84106-aa65-47e3-a768-8ea223b1e38f" />

Feedback is welcome