### PR TITLE
Fix for Linux distributions that use lib64: force libturbojpeg to use 'lib'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ if (DUSK_MOVIE_SUPPORT)
             -DENABLE_SHARED=OFF
             -DWITH_TURBOJPEG=ON
             -DWITH_JAVA=OFF
+            -DCMAKE_INSTALL_LIBDIR=lib
         )
         if (CMAKE_TOOLCHAIN_FILE)
             get_filename_component(_jpeg_toolchain_file "${CMAKE_TOOLCHAIN_FILE}" ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")


### PR DESCRIPTION
After switching to Fedora (and installing the relevant dependencies) I get the following compile error when building (linux-default-relwithdebinfo):

```/usr/bin/ld.bfd: cannot find libjpeg-turbo-install/lib/libturbojpeg.a: No such file or directory```

Looking at the build log, I see the following:

```-- Up-to-date: /home/pwootage/projects/dusklight/build/linux-default-relwithdebinfo/libjpeg-turbo-install/lib64/libturbojpeg.a```

So it appears there is some issue here with 'lib' vs 'lib64'.  This seems to be the simplest solution.