### PR TITLE
Enable color diagnostics for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # Folder-based instead of target-based organization
 # in Visual Studio and Xcode generators


### PR DESCRIPTION
Enable color diagnostics for CMake output, useful for reading build logs to quickly identify warnings and errors

<img width="907" height="569" alt="Screenshot 2026-08-05 at 16 15 15" src="https://github.com/user-attachments/assets/17c06de1-8de3-427d-a368-06ea91b7d029" />
