### PR TITLE
Android: allow overriding the application ID

### DIFF
--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -32,6 +32,13 @@ cd platforms/android
 ./gradlew :app:assembleDebug
 ```
 
+To install a development build alongside the official app, override its
+application ID:
+
+```bash
+DUSK_APPLICATION_ID=dev.twilitrealm.dusk.dev ./gradlew :app:assembleDebug
+```
+
 Output APK:
 
 - `app/build/outputs/apk/debug/app-arm64-v8a-debug.apk`

--- a/platforms/android/app/build.gradle
+++ b/platforms/android/app/build.gradle
@@ -9,7 +9,7 @@ ext.borealisAndroid = [
     borealisDir: borealisDir,
     propertiesFile: new File(duskRepoDir, 'build/android-arm64/borealis-android.properties'),
     namespace: 'dev.twilitrealm.dusk',
-    applicationId: 'dev.twilitrealm.dusk',
+    applicationId: System.getenv('DUSK_APPLICATION_ID') ?: 'dev.twilitrealm.dusk',
     abis: ['arm64-v8a'],
     assets: [
         [


### PR DESCRIPTION
## What changed

Allow Android builds to override the application ID with
`DUSK_APPLICATION_ID`. Builds without the variable keep the official
`dev.twilitrealm.dusk` ID.

## Why

This permits development and test builds to be installed beside an official
build instead of replacing it. The Java namespace and launcher class remain
unchanged, while the existing `${applicationId}.documents` manifest placeholder
keeps the DocumentsProvider authority aligned with the selected package.

## Validation

- `:app:processDebugMainManifest --offline` with no override produced
  `dev.twilitrealm.dusk` and `dev.twilitrealm.dusk.documents`.
- The same task with
  `DUSK_APPLICATION_ID=dev.twilitrealm.dusk.dev` produced
  `dev.twilitrealm.dusk.dev` and
  `dev.twilitrealm.dusk.dev.documents`.
- Both Gradle runs completed successfully.
