### PR TITLE
Mods: add a write-only secret input control

### DIFF
--- a/docs/modding.md
+++ b/docs/modding.md
@@ -469,8 +469,8 @@ per-window RCSS. A non-`MOD_OK` result from `build`/`update` fails your mod, as 
 callback.
 
 **Controls:** `pane_add_control` adds an input row described by a `UiControlDesc`: `UI_CONTROL_BUTTON`,
-`UI_CONTROL_TOGGLE`, `UI_CONTROL_NUMBER`, `UI_CONTROL_STRING`, or `UI_CONTROL_SELECT`. Values bind with callbacks or
-directly to a config var.
+`UI_CONTROL_TOGGLE`, `UI_CONTROL_NUMBER`, `UI_CONTROL_STRING`, `UI_CONTROL_SECRET`, or
+`UI_CONTROL_SELECT`. Values bind with callbacks or directly to a config var.
 
 ```cpp
 UiControlDesc control = UI_CONTROL_DESC_INIT;
@@ -485,7 +485,8 @@ svc_ui->pane_add_control(mod_ctx, leftPane, &control, nullptr);
 `UI_BINDING_CONFIG_VAR` wires persistence, change notifications, and the modified indicator automatically. The var
 type must match the control: `TOGGLE` = bool, `NUMBER` and `SELECT` = int, `STRING` = string. Float vars are not
 bindable; use callbacks and convert. `help_rml` and `SELECT` option lists render in a help pane, so `SELECT` controls
-are only available inside window tabs.
+are only available inside window tabs. `SECRET` requires callback binding, never invokes a getter, masks input, and
+clears the host's temporary input after invoking the setter.
 
 **Windows:** `window_push` pushes a tabbed two-pane window onto the document stack and shows it. Each tab's `build`
 receives the window handle plus fresh left and right pane handles on every activation. The optional per-tab `update`

--- a/sdk/include/mods/svc/ui.h
+++ b/sdk/include/mods/svc/ui.h
@@ -9,7 +9,7 @@
 
 #define UI_SERVICE_ID "dev.twilitrealm.dusklight.ui"
 #define UI_SERVICE_MAJOR 1u
-#define UI_SERVICE_MINOR 1u
+#define UI_SERVICE_MINOR 2u
 
 /*
  * UI primitives: a panel inside the host Mods window, mod-owned windows, dialogs, toasts,
@@ -51,11 +51,12 @@ typedef enum UiControlKind {
     UI_CONTROL_NUMBER = 2, /* integer stepper with min/max/step */
     UI_CONTROL_STRING = 3, /* text input */
     UI_CONTROL_SELECT = 4, /* one of `options`; the value is the option index */
+    UI_CONTROL_SECRET = 5, /* write-only password input; callback binding only */
 } UiControlKind;
 
 typedef enum UiControlBinding {
     /* Values flow through the `get`/`set` callbacks. Getters are polled every frame while the
-       control is visible and must be cheap. */
+       control is visible and must be cheap. SECRET is write-only and uses only `set`. */
     UI_BINDING_CALLBACKS = 0,
     /* The control reads and writes `config_var` (a ConfigService handle owned by the calling mod)
      * directly: persistence, change notifications and the modified indicator (value != default) are
@@ -64,10 +65,11 @@ typedef enum UiControlBinding {
     UI_BINDING_CONFIG_VAR = 1,
 } UiControlBinding;
 
-/* Tagged by the control's kind: TOGGLE reads bool_value, NUMBER and SELECT read int_value, STRING
- * reads string_value. string_value passed to a setter is only valid during the call; a getter
- * should point it at storage owned by the mod (e.g. a static buffer) that stays valid until the
- * next call into the mod — the host copies it right after the getter returns. */
+/* Tagged by the control's kind: TOGGLE reads bool_value, NUMBER and SELECT read int_value, and
+ * STRING/SECRET read string_value. string_value passed to a setter is only valid during the call;
+ * a STRING getter should point it at storage owned by the mod (e.g. a static buffer) that stays
+ * valid until the next call into the mod — the host copies it right after the getter returns.
+ * SECRET ignores `get` and never prefills or displays a value. */
 typedef struct UiControlValue {
     uint32_t struct_size;
     bool bool_value;
@@ -93,7 +95,7 @@ typedef struct UiControlDesc {
     const char* help_rml;
     UiControlBinding binding;   /* ignored for BUTTON */
     ConfigVarHandle config_var; /* UI_BINDING_CONFIG_VAR */
-    UiControlGetFn get;         /* UI_BINDING_CALLBACKS (all kinds but BUTTON) */
+    UiControlGetFn get;         /* UI_BINDING_CALLBACKS (ignored for BUTTON/SECRET) */
     UiControlSetFn set;         /* UI_BINDING_CALLBACKS (all kinds but BUTTON) */
     UiPressedFn on_pressed;     /* BUTTON only. Required for BUTTON. */
     UiPredicateFn is_disabled;  /* optional */
@@ -114,7 +116,7 @@ typedef struct UiControlDesc {
      * one exists (mod window tabs); MOD_UNSUPPORTED elsewhere. */
     const char* const* options;
     size_t option_count;
-    int32_t max_length; /* STRING: maximum input length; < 1 means unlimited */
+    int32_t max_length; /* STRING/SECRET: maximum input length; < 1 means unlimited */
 } UiControlDesc;
 
 #define UI_CONTROL_DESC_INIT                                                                       \

--- a/src/dusk/mods/svc/ui.cpp
+++ b/src/dusk/mods/svc/ui.cpp
@@ -288,6 +288,20 @@ void wire_callback_binding(
             setValue(raw);
         };
         break;
+    case UI_CONTROL_SECRET:
+        spec.setString = [modPtr, set, userData, guardHandle](Rml::String value) {
+            if (!slot_live(guardHandle)) {
+                std::fill(value.begin(), value.end(), '\0');
+                return;
+            }
+            UiControlValue raw = UI_CONTROL_VALUE_INIT;
+            raw.string_value = value.c_str();
+            guarded_call(*modPtr, "secret control setter", [&] {
+                set(modPtr->context.get(), userData, &raw);
+            });
+            std::fill(value.begin(), value.end(), '\0');
+        };
+        break;
     default:
         break;
     }
@@ -384,6 +398,8 @@ bool wire_config_var_binding(LoadedMod& mod, const UiControlDesc& desc, ui::ModC
         }
         return true;
     }
+    case UI_CONTROL_SECRET:
+        return false;
     default:
         return false;
     }
@@ -596,6 +612,13 @@ ModResult ui_pane_add_control(
         break;
     case UI_CONTROL_STRING:
         spec.kind = ui::ModControlSpec::Kind::String;
+        spec.maxLength = desc.max_length < 1 ? -1 : desc.max_length;
+        break;
+    case UI_CONTROL_SECRET:
+        if (desc.binding != UI_BINDING_CALLBACKS) {
+            return MOD_INVALID_ARGUMENT;
+        }
+        spec.kind = ui::ModControlSpec::Kind::Secret;
         spec.maxLength = desc.max_length < 1 ? -1 : desc.max_length;
         break;
     case UI_CONTROL_SELECT:
@@ -1055,6 +1078,7 @@ bool valid_control_desc(const UiControlDesc& desc) {
     case UI_CONTROL_NUMBER:
     case UI_CONTROL_STRING:
     case UI_CONTROL_SELECT:
+    case UI_CONTROL_SECRET:
         break;
     default:
         return false;
@@ -1071,9 +1095,9 @@ bool valid_control_desc(const UiControlDesc& desc) {
     }
     switch (desc.binding) {
     case UI_BINDING_CALLBACKS:
-        return desc.get != nullptr && desc.set != nullptr;
+        return desc.set != nullptr && (desc.kind == UI_CONTROL_SECRET || desc.get != nullptr);
     case UI_BINDING_CONFIG_VAR:
-        return desc.config_var != 0;
+        return desc.kind != UI_CONTROL_SECRET && desc.config_var != 0;
     default:
         return false;
     }

--- a/src/dusk/ui/mod_window.cpp
+++ b/src/dusk/ui/mod_window.cpp
@@ -48,6 +48,7 @@ Component* build_mod_control(Pane& pane, Pane* helpPane, ModControlSpec spec) {
         });
         break;
     case ModControlSpec::Kind::String:
+    case ModControlSpec::Kind::Secret:
         control = &pane.add_child<StringButton>(StringButton::Props{
             .key = s.label,
             .getValue = s.getString,
@@ -55,6 +56,7 @@ Component* build_mod_control(Pane& pane, Pane* helpPane, ModControlSpec spec) {
             .isDisabled = s.isDisabled,
             .isModified = s.isModified,
             .maxLength = s.maxLength,
+            .secret = s.kind == ModControlSpec::Kind::Secret,
         });
         break;
     case ModControlSpec::Kind::Select:

--- a/src/dusk/ui/mod_window.hpp
+++ b/src/dusk/ui/mod_window.hpp
@@ -14,6 +14,7 @@ struct ModControlSpec {
         Number,
         String,
         Select,
+        Secret,
     };
 
     Kind kind = Kind::Button;

--- a/src/dusk/ui/string_button.cpp
+++ b/src/dusk/ui/string_button.cpp
@@ -126,6 +126,9 @@ void BaseStringButton::stop_editing(bool commit, bool refocusRoot) {
     if (commit) {
         set_value(mInputElem->GetValue());
     }
+    if (mType == "password") {
+        mInputElem->SetValue("");
+    }
     mInputListeners.clear();
     mRoot->RemoveChild(mInputElem);
     mInputElem = nullptr;
@@ -140,9 +143,12 @@ void BaseStringButton::stop_editing(bool commit, bool refocusRoot) {
 }
 
 StringButton::StringButton(Rml::Element* parent, Props props)
-    : BaseStringButton(parent, {.key = std::move(props.key), .maxLength = props.maxLength}),
+    : BaseStringButton(parent,
+          {.key = std::move(props.key), .type = props.secret ? "password" : "text",
+              .maxLength = props.maxLength}),
       mGetValue(std::move(props.getValue)), mSetValue(std::move(props.setValue)),
-      mIsDisabled(std::move(props.isDisabled)), mIsModified(std::move(props.isModified)) {}
+      mIsDisabled(std::move(props.isDisabled)), mIsModified(std::move(props.isModified)),
+      mSecret(props.secret) {}
 
 bool StringButton::modified() const {
     if (mIsModified) {

--- a/src/dusk/ui/string_button.hpp
+++ b/src/dusk/ui/string_button.hpp
@@ -48,6 +48,7 @@ public:
         std::function<bool()> isDisabled;
         std::function<bool()> isModified;
         int maxLength = -1;
+        bool secret = false;
     };
 
     StringButton(Rml::Element* parent, Props props);
@@ -55,7 +56,7 @@ public:
     bool disabled() const override;
 
 protected:
-    Rml::String format_value() override { return mGetValue(); }
+    Rml::String format_value() override { return mSecret ? "" : mGetValue(); }
     void set_value(Rml::String value) override {
         if (mSetValue) {
             mSetValue(std::move(value));
@@ -67,6 +68,7 @@ private:
     std::function<void(Rml::String)> mSetValue;
     std::function<bool()> mIsDisabled;
     std::function<bool()> mIsModified;
+    bool mSecret = false;
 };
 
 }  // namespace dusk::ui


### PR DESCRIPTION
## Summary

- add `UI_CONTROL_SECRET` as a write-only mod UI control
- mask input with a password field and never poll, prefill, or render an existing value
- allow callback binding only and clear host-side temporary input after the setter returns
- bump `UiService` from 1.1 to 1.2

## Validation

- C and C++ SDK syntax compilation passed
- full macOS Dusklight compile and link passed
- copied app bundle codesigned and verified successfully
- fresh Luna Max review passed
- `git diff --check`

The public descriptor layout is unchanged; the new control kind is appended.
