### PR TITLE
mods: add Android Keystore secret storage service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,9 @@ set(DUSK_COPYRIGHT "Copyright (C) Twilit Realm contributors")
 
 source_group("dolzel" FILES ${DOLZEL_FILES} ${Z2AUDIOLIB_FILES} ${REL_FILES})
 source_group("dusklight" FILES ${DUSK_FILES})
+if (ANDROID)
+    list(APPEND DUSK_FILES ${DUSK_SECRET_STORAGE_BACKEND_FILES})
+endif ()
 
 include(cmake/GameABIConfig.cmake)
 

--- a/docs/modding.md
+++ b/docs/modding.md
@@ -212,6 +212,46 @@ if (svc_resource->load(mod_ctx, "config.txt", &buf) == MOD_OK) {
 Missing files return `MOD_UNAVAILABLE`. Always `free` what you `load`. The bundle is read-only; use
 `HostService::data_dir` for persistent storage.
 
+### SecretStorageService (`mods/svc/secret_storage.h`)
+
+Small secret values bound to the caller's exact portable mod ID and a caller-chosen key, without exposing paths,
+aliases, enumeration, existence checks, or asynchronous work. The v1 table order is exactly `get`, owner-aware
+`free`, `put`, `remove`.
+
+```cpp
+IMPORT_SERVICE(SecretStorageService, svc_secret);
+
+const char token[] = "example";
+SecretStorageResult stored = svc_secret->put(mod_ctx, "token", token, sizeof(token) - 1);
+
+ResourceBuffer value = RESOURCE_BUFFER_INIT;
+if (svc_secret->get(mod_ctx, "token", &value) == SECRET_STORAGE_OK) {
+    // value.data is NULL and value.size is zero for a stored empty value.
+    svc_secret->free(mod_ctx, &value);
+}
+```
+
+Keys are 1 through 128 bytes of lowercase ASCII `[a-z0-9_.-]` and cannot start with a dot. Mod IDs must be portable
+lowercase dot-separated labels of `[a-z0-9_]`, at most 240 bytes total and 64 bytes per label; legacy uppercase IDs
+are rejected rather than normalized. Values are bounded to 65536 bytes. `put` deep-copies input before returning and
+the host wipes its temporary copies best effort.
+`get` always empties `out_buffer` on entry or failure but never frees a prior buffer, so callers must free it before
+reusing the struct. Returned buffers are owner-bound, wiped before release, and reclaimed/wiped on mod detach.
+
+Android derives a SHA-256 identity from the exact runtime application ID, mod ID and key using the fixed v1 domain and
+little-endian length prefixes. The digest drives a per-identity nonexportable AndroidKeyStore AES-256-GCM key and
+private no-backup metadata. The encrypted envelope authenticates its complete fixed header as AAD. Corrupt envelopes,
+identity mismatch, malformed lengths, trailing bytes and invalid tags return `SECRET_STORAGE_CORRUPT`; a committed
+record whose key was removed or permanently invalidated returns `SECRET_STORAGE_KEY_INVALIDATED`. A corrupt or
+key-invalidated committed record blocks `put` until an explicit `remove`.
+
+The record group is the base metadata file with `.new` and legacy `.bak` artifacts. Android's `AtomicFile.openRead`
+restores a legacy backup before the bounded read; base wins over stale `.new`, and `.new` alone is cleaned as
+uncommitted. Non-regular artifacts are rejected. `remove` deletes and verifies all metadata artifacts before deleting
+the Keystore alias; a failed metadata delete preserves the alias, while a failed alias delete leaves a harmless orphan
+for a later retry. On non-Android platforms every operation returns
+`SECRET_STORAGE_UNAVAILABLE`: there is deliberately no desktop secret-file fallback.
+
 ### HostService (`mods/svc/host.h`)
 
 Mod metadata and runtime interaction with the loader:

--- a/files.cmake
+++ b/files.cmake
@@ -1497,6 +1497,9 @@ set(DUSK_FILES
         src/dusk/mods/svc/save.hpp
         src/dusk/mods/svc/stage.cpp
         src/dusk/mods/svc/stage.hpp
+        src/dusk/mods/svc/secret_storage.cpp
+        src/dusk/mods/svc/secret_storage_core.cpp
+        src/dusk/mods/svc/secret_storage_core.hpp
         src/dusk/mouse.cpp
         src/dusk/presentation.cpp
         src/dusk/presentation.hpp
@@ -1581,4 +1584,9 @@ set(DUSK_FILES
         src/helpers/endian.cpp
         src/helpers/offset_ptr.cpp
         src/helpers/string.cpp
+)
+
+set(DUSK_SECRET_STORAGE_BACKEND_FILES
+        src/dusk/mods/svc/secret_storage_android.cpp
+        src/dusk/mods/svc/secret_storage_android.hpp
 )

--- a/platforms/android/app/proguard-rules.pro
+++ b/platforms/android/app/proguard-rules.pro
@@ -1,1 +1,3 @@
 -keep class dev.twilitrealm.dusk.DuskActivity { *; }
+-keep class dev.twilitrealm.dusk.DuskSecretStore { *; }
+-keep class dev.twilitrealm.dusk.DuskSecretStore$Result { *; }

--- a/platforms/android/app/src/main/java/com/twilitrealm/dusk/DuskSecretStore.java
+++ b/platforms/android/app/src/main/java/com/twilitrealm/dusk/DuskSecretStore.java
@@ -1,0 +1,284 @@
+package dev.twilitrealm.dusk;
+
+import android.content.Context;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyPermanentlyInvalidatedException;
+import android.security.keystore.KeyProperties;
+import android.util.AtomicFile;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.Arrays;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+/** Android facade. JNI loads this class through the Activity class loader. */
+public final class DuskSecretStore {
+    private static final Object LOCK = new Object();
+
+    static final class Result {
+        final int code;
+        final byte[] value;
+
+        Result(int code, byte[] value) {
+            this.code = code;
+            this.value = value;
+        }
+    }
+
+    private DuskSecretStore() {
+    }
+
+    static Result get(Context context, byte[] modId, byte[] key) {
+        byte[] plaintext = null;
+        try {
+            if (context == null) {
+                return new Result(DuskSecretStoreCore.UNAVAILABLE, null);
+            }
+            synchronized (LOCK) {
+                DuskSecretStoreCore.Result result = store(context).get(modId, key);
+                plaintext = result.value;
+                return new Result(result.code, plaintext == null ? null : plaintext.clone());
+            }
+        } catch (RuntimeException ignored) {
+            return new Result(DuskSecretStoreCore.UNAVAILABLE, null);
+        } finally {
+            DuskSecretStoreCore.wipe(modId);
+            DuskSecretStoreCore.wipe(key);
+            DuskSecretStoreCore.wipe(plaintext);
+        }
+    }
+
+    static int put(Context context, byte[] modId, byte[] key, byte[] value) {
+        try {
+            if (context == null) {
+                return DuskSecretStoreCore.UNAVAILABLE;
+            }
+            synchronized (LOCK) {
+                return store(context).put(modId, key, value);
+            }
+        } catch (RuntimeException ignored) {
+            return DuskSecretStoreCore.UNAVAILABLE;
+        } finally {
+            DuskSecretStoreCore.wipe(modId);
+            DuskSecretStoreCore.wipe(key);
+            DuskSecretStoreCore.wipe(value);
+        }
+    }
+
+    static int remove(Context context, byte[] modId, byte[] key) {
+        try {
+            if (context == null) {
+                return DuskSecretStoreCore.UNAVAILABLE;
+            }
+            synchronized (LOCK) {
+                return store(context).remove(modId, key);
+            }
+        } catch (RuntimeException ignored) {
+            return DuskSecretStoreCore.UNAVAILABLE;
+        } finally {
+            DuskSecretStoreCore.wipe(modId);
+            DuskSecretStoreCore.wipe(key);
+        }
+    }
+
+    private static DuskSecretStoreCore store(Context context) {
+        return new DuskSecretStoreCore(new AndroidKeyRepository(),
+            new AtomicMetadataRepository(new File(context.getNoBackupFilesDir(), "dusklight-secret-storage-v1")),
+            context.getPackageName());
+    }
+
+    private static final class AndroidKeyRepository implements DuskSecretStoreCore.KeyRepository {
+        @Override
+        public SecretKey find(String alias) throws DuskSecretStoreCore.MissingKeyException,
+            DuskSecretStoreCore.InvalidatedKeyException, DuskSecretStoreCore.UnavailableException {
+            try {
+                KeyStore keyStore = keyStore();
+                if (!keyStore.containsAlias(alias)) {
+                    throw new DuskSecretStoreCore.MissingKeyException();
+                }
+                SecretKey key = (SecretKey) keyStore.getKey(alias, null);
+                if (key == null) {
+                    throw new DuskSecretStoreCore.MissingKeyException();
+                }
+                return key;
+            } catch (KeyPermanentlyInvalidatedException invalidated) {
+                throw new DuskSecretStoreCore.InvalidatedKeyException();
+            } catch (DuskSecretStoreCore.MissingKeyException missing) {
+                throw missing;
+            } catch (GeneralSecurityException | IOException unavailable) {
+                throw new DuskSecretStoreCore.UnavailableException();
+            }
+        }
+
+        @Override
+        public SecretKey create(String alias) throws DuskSecretStoreCore.InvalidatedKeyException,
+            DuskSecretStoreCore.UnavailableException {
+            try {
+                KeyGenerator generator = KeyGenerator.getInstance("AES", "AndroidKeyStore");
+                generator.init(new KeyGenParameterSpec.Builder(alias,
+                    KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                    .setKeySize(256)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setRandomizedEncryptionRequired(true)
+                    .setUserAuthenticationRequired(false)
+                    .build());
+                return generator.generateKey();
+            } catch (GeneralSecurityException unavailable) {
+                throw new DuskSecretStoreCore.UnavailableException();
+            }
+        }
+
+        @Override
+        public boolean exists(String alias) throws DuskSecretStoreCore.UnavailableException {
+            try {
+                return keyStore().containsAlias(alias);
+            } catch (GeneralSecurityException | IOException unavailable) {
+                throw new DuskSecretStoreCore.UnavailableException();
+            }
+        }
+
+        @Override
+        public void delete(String alias) throws IOException, DuskSecretStoreCore.UnavailableException {
+            try {
+                KeyStore store = keyStore();
+                store.deleteEntry(alias);
+                if (store.containsAlias(alias)) {
+                    throw new IOException();
+                }
+            } catch (GeneralSecurityException unavailable) {
+                throw new DuskSecretStoreCore.UnavailableException();
+            }
+        }
+
+        private static KeyStore keyStore() throws GeneralSecurityException, IOException {
+            KeyStore result = KeyStore.getInstance("AndroidKeyStore");
+            result.load(null);
+            return result;
+        }
+    }
+
+    private static final class AtomicMetadataRepository implements DuskSecretStoreCore.MetadataRepository {
+        private static final int MAX_ENVELOPE = 8 + 4 + 4 + 4 + 4 + 32 + 12 + (64 * 1024) + 16;
+        private final File directory;
+
+        AtomicMetadataRepository(File directory) {
+            this.directory = directory;
+        }
+
+        @Override
+        public DuskSecretStoreCore.Metadata read(String filename) throws IOException {
+            File base = file(filename);
+            File pending = new File(base.getPath() + ".new");
+            File backup = new File(base.getPath() + ".bak");
+            requireRegularOrAbsent(base);
+            requireRegularOrAbsent(pending);
+            requireRegularOrAbsent(backup);
+            if (!base.exists() && !backup.exists()) {
+                if (!pending.exists()) {
+                    return DuskSecretStoreCore.Metadata.notFound();
+                }
+                if (!pending.delete() || pending.exists()) {
+                    throw new IOException();
+                }
+                return DuskSecretStoreCore.Metadata.notFound();
+            }
+            AtomicFile atomic = new AtomicFile(base);
+            try (FileInputStream input = atomic.openRead()) {
+                if (base.length() > MAX_ENVELOPE) {
+                    return DuskSecretStoreCore.Metadata.committed(new byte[0]);
+                }
+                return DuskSecretStoreCore.Metadata.committed(readBounded(input, base.length()));
+            }
+        }
+
+        @Override
+        public boolean hasArtifacts(String filename) throws IOException {
+            File base = file(filename);
+            File pending = new File(base.getPath() + ".new");
+            File backup = new File(base.getPath() + ".bak");
+            requireRegularOrAbsent(base);
+            requireRegularOrAbsent(pending);
+            requireRegularOrAbsent(backup);
+            return base.exists() || pending.exists() || backup.exists();
+        }
+
+        @Override
+        public void write(String filename, byte[] data) throws IOException {
+            if (!directory.isDirectory() && !directory.mkdirs()) {
+                throw new IOException();
+            }
+            AtomicFile output = new AtomicFile(file(filename));
+            FileOutputStream stream = null;
+            try {
+                stream = output.startWrite();
+                stream.write(data);
+                stream.flush();
+                output.finishWrite(stream);
+            } catch (IOException failure) {
+                if (stream != null) {
+                    output.failWrite(stream);
+                }
+                throw failure;
+            }
+        }
+
+        @Override
+        public void remove(String filename) throws IOException {
+            File base = file(filename);
+            requireRegularOrAbsent(base);
+            requireRegularOrAbsent(new File(base.getPath() + ".new"));
+            requireRegularOrAbsent(new File(base.getPath() + ".bak"));
+            deleteAndVerify(base);
+            deleteAndVerify(new File(base.getPath() + ".new"));
+            deleteAndVerify(new File(base.getPath() + ".bak"));
+        }
+
+        private File file(String filename) {
+            return new File(directory, filename);
+        }
+
+        private static void deleteAndVerify(File file) throws IOException {
+            if (file.exists() && !file.delete()) {
+                throw new IOException();
+            }
+            if (file.exists()) {
+                throw new IOException();
+            }
+        }
+
+        private static void requireRegularOrAbsent(File file) throws IOException {
+            if (file.exists() && !file.isFile()) {
+                throw new IOException();
+            }
+        }
+
+        private static byte[] readBounded(FileInputStream input, long length) throws IOException {
+            if (length < 0 || length > MAX_ENVELOPE) {
+                throw new IOException();
+            }
+            byte[] result = new byte[(int) length];
+            int offset = 0;
+            try {
+                while (offset < result.length) {
+                    int read = input.read(result, offset, result.length - offset);
+                    if (read < 0) {
+                        throw new IOException();
+                    }
+                    offset += read;
+                }
+                if (input.read() != -1) {
+                    throw new IOException();
+                }
+                return result;
+            } catch (IOException failure) {
+                Arrays.fill(result, (byte) 0);
+                throw failure;
+            }
+        }
+    }
+}

--- a/platforms/android/app/src/main/java/com/twilitrealm/dusk/DuskSecretStoreCore.java
+++ b/platforms/android/app/src/main/java/com/twilitrealm/dusk/DuskSecretStoreCore.java
@@ -1,0 +1,411 @@
+package dev.twilitrealm.dusk;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import javax.crypto.AEADBadTagException;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+/** Android-free envelope and state-machine core for SecretStorageService@1. */
+public final class DuskSecretStoreCore {
+    static final int OK = 0;
+    static final int NOT_FOUND = 1;
+    static final int INVALID_ARGUMENT = 2;
+    static final int TOO_LARGE = 3;
+    static final int UNAVAILABLE = 4;
+    static final int CORRUPT = 5;
+    static final int KEY_INVALIDATED = 6;
+    static final int IO_ERROR = 7;
+    static final int MAX_VALUE = 64 * 1024;
+    static final int MAX_KEY = 128;
+    static final int MAX_MOD_ID = 240;
+    static final int MAX_MOD_LABEL = 64;
+
+    private static final byte[] DOMAIN =
+        "dev.twilitrealm.dusklight.secret_storage.identity.v1".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] MAGIC = "DUSKSEC1".getBytes(StandardCharsets.US_ASCII);
+    private static final int VERSION = 1;
+    private static final int ALGORITHM_AES_256_GCM = 1;
+    private static final int IV_LENGTH = 12;
+    private static final int TAG_LENGTH = 16;
+    private static final int HEADER_LENGTH = 8 + 4 + 4 + 4 + 4 + 32 + IV_LENGTH;
+
+    public interface KeyRepository {
+        SecretKey find(String alias) throws MissingKeyException, InvalidatedKeyException, UnavailableException;
+        SecretKey create(String alias) throws InvalidatedKeyException, UnavailableException;
+        boolean exists(String alias) throws UnavailableException;
+        void delete(String alias) throws IOException, UnavailableException;
+    }
+
+    public interface MetadataRepository {
+        Metadata read(String filename) throws IOException;
+        boolean hasArtifacts(String filename) throws IOException;
+        void write(String filename, byte[] data) throws IOException;
+        void remove(String filename) throws IOException;
+    }
+
+    public static final class Metadata {
+        final boolean committed;
+        final byte[] data;
+
+        private Metadata(boolean committed, byte[] data) {
+            this.committed = committed;
+            this.data = data;
+        }
+
+        public static Metadata notFound() {
+            return new Metadata(false, null);
+        }
+
+        public static Metadata committed(byte[] data) {
+            return new Metadata(true, data);
+        }
+    }
+
+    public static final class MissingKeyException extends Exception {
+        private static final long serialVersionUID = 1L;
+    }
+
+    public static final class InvalidatedKeyException extends Exception {
+        private static final long serialVersionUID = 1L;
+    }
+
+    public static final class UnavailableException extends Exception {
+        private static final long serialVersionUID = 1L;
+    }
+
+    public static final class Result {
+        public final int code;
+        public final byte[] value;
+
+        Result(int code, byte[] value) {
+            this.code = code;
+            this.value = value;
+        }
+
+        static Result code(int code) {
+            return new Result(code, null);
+        }
+    }
+
+    static final class Identity {
+        final byte[] digest;
+        final String hex;
+        final String alias;
+        final String filename;
+
+        Identity(byte[] digest, String hex) {
+            this.digest = digest;
+            this.hex = hex;
+            this.alias = "dusk.secret.v1." + hex;
+            this.filename = hex + ".bin";
+        }
+    }
+
+    private final KeyRepository keys;
+    private final MetadataRepository metadata;
+    private final byte[] applicationId;
+
+    public DuskSecretStoreCore(KeyRepository keys, MetadataRepository metadata, String applicationId) {
+        this.keys = keys;
+        this.metadata = metadata;
+        this.applicationId = applicationId == null ? new byte[0] :
+            applicationId.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public synchronized Result get(byte[] modId, byte[] key) {
+        Identity identity = identityOrNull(modId, key);
+        if (identity == null) {
+            return Result.code(INVALID_ARGUMENT);
+        }
+        Metadata record;
+        try {
+            record = metadata.read(identity.filename);
+        } catch (IOException ignored) {
+            return Result.code(IO_ERROR);
+        }
+        if (!record.committed) {
+            return Result.code(NOT_FOUND);
+        }
+        return decryptRecord(identity, record.data);
+    }
+
+    public synchronized int put(byte[] modId, byte[] key, byte[] value) {
+        Identity identity = identityOrNull(modId, key);
+        if (identity == null || value == null) {
+            return INVALID_ARGUMENT;
+        }
+        if (value.length > MAX_VALUE) {
+            return TOO_LARGE;
+        }
+        Metadata existing;
+        try {
+            existing = metadata.read(identity.filename);
+        } catch (IOException ignored) {
+            return IO_ERROR;
+        }
+        if (existing.committed) {
+            Result checked = decryptRecord(identity, existing.data);
+            wipe(checked.value);
+            if (checked.code != OK) {
+                return checked.code;
+            }
+        }
+        SecretKey secretKey;
+        try {
+            secretKey = keys.find(identity.alias);
+        } catch (MissingKeyException ignored) {
+            try {
+                secretKey = keys.create(identity.alias);
+            } catch (InvalidatedKeyException invalidated) {
+                return KEY_INVALIDATED;
+            } catch (UnavailableException unavailable) {
+                return UNAVAILABLE;
+            }
+        } catch (InvalidatedKeyException invalidated) {
+            return KEY_INVALIDATED;
+        } catch (UnavailableException unavailable) {
+            return UNAVAILABLE;
+        }
+        byte[] envelope = null;
+        try {
+            envelope = encrypt(identity, secretKey, value);
+            metadata.write(identity.filename, envelope);
+            return OK;
+        } catch (InvalidKeyException invalidated) {
+            return KEY_INVALIDATED;
+        } catch (GeneralSecurityException unavailable) {
+            return UNAVAILABLE;
+        } catch (IOException io) {
+            return IO_ERROR;
+        } finally {
+            wipe(envelope);
+        }
+    }
+
+    public synchronized int remove(byte[] modId, byte[] key) {
+        Identity identity = identityOrNull(modId, key);
+        if (identity == null) {
+            return INVALID_ARGUMENT;
+        }
+        final boolean hasArtifacts;
+        final boolean hasKey;
+        try {
+            hasArtifacts = metadata.hasArtifacts(identity.filename);
+            hasKey = keys.exists(identity.alias);
+        } catch (IOException io) {
+            return IO_ERROR;
+        } catch (UnavailableException unavailable) {
+            return UNAVAILABLE;
+        }
+        if (!hasArtifacts && !hasKey) {
+            return NOT_FOUND;
+        }
+        if (hasArtifacts) {
+            try {
+                metadata.remove(identity.filename);
+            } catch (IOException io) {
+                return IO_ERROR;
+            }
+        }
+        if (!hasKey) {
+            return OK;
+        }
+        try {
+            keys.delete(identity.alias);
+            return OK;
+        } catch (IOException io) {
+            return IO_ERROR;
+        } catch (UnavailableException unavailable) {
+            return UNAVAILABLE;
+        }
+    }
+
+    static boolean validModId(byte[] value) {
+        if (value == null || value.length == 0 || value.length > MAX_MOD_ID || value[0] == '.' ||
+            value[value.length - 1] == '.') {
+            return false;
+        }
+        int labelLength = 0;
+        for (byte raw : value) {
+            int character = raw & 0xff;
+            if (character == '.') {
+                if (labelLength == 0 || labelLength > MAX_MOD_LABEL) {
+                    return false;
+                }
+                labelLength = 0;
+            } else if ((character >= 'a' && character <= 'z') ||
+                (character >= '0' && character <= '9') || character == '_') {
+                labelLength++;
+            } else {
+                return false;
+            }
+        }
+        return labelLength > 0 && labelLength <= MAX_MOD_LABEL;
+    }
+
+    static boolean validKey(byte[] value) {
+        if (value == null || value.length == 0 || value.length > MAX_KEY || value[0] == '.') {
+            return false;
+        }
+        for (byte raw : value) {
+            int character = raw & 0xff;
+            if (!((character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') ||
+                character == '_' || character == '.' || character == '-')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static Identity identity(byte[] applicationId, byte[] modId, byte[] key) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(DOMAIN);
+            updateLengthPrefixed(digest, applicationId);
+            updateLengthPrefixed(digest, modId);
+            updateLengthPrefixed(digest, key);
+            byte[] hash = digest.digest();
+            String hex = hex(hash);
+            return new Identity(hash, hex);
+        } catch (GeneralSecurityException impossible) {
+            throw new IllegalStateException(impossible);
+        }
+    }
+
+    private Identity identityOrNull(byte[] modId, byte[] key) {
+        return validModId(modId) && validKey(key) ? identity(applicationId, modId, key) : null;
+    }
+
+    private Result decryptRecord(Identity identity, byte[] envelope) {
+        if (envelope == null || envelope.length < HEADER_LENGTH + TAG_LENGTH) {
+            return Result.code(CORRUPT);
+        }
+        ByteBuffer input = ByteBuffer.wrap(envelope).order(ByteOrder.LITTLE_ENDIAN);
+        byte[] magic = new byte[8];
+        input.get(magic);
+        int version = input.getInt();
+        int algorithm = input.getInt();
+        int ivLength = input.getInt();
+        int cipherLength = input.getInt();
+        byte[] storedIdentity = new byte[32];
+        input.get(storedIdentity);
+        byte[] iv = new byte[IV_LENGTH];
+        input.get(iv);
+        if (!Arrays.equals(magic, MAGIC) || version != VERSION || algorithm != ALGORITHM_AES_256_GCM ||
+            ivLength != IV_LENGTH || cipherLength < 0 || cipherLength > MAX_VALUE ||
+            envelope.length != HEADER_LENGTH + cipherLength + TAG_LENGTH ||
+            !MessageDigest.isEqual(storedIdentity, identity.digest)) {
+            wipe(magic);
+            wipe(storedIdentity);
+            wipe(iv);
+            return Result.code(CORRUPT);
+        }
+        SecretKey secretKey;
+        try {
+            secretKey = keys.find(identity.alias);
+        } catch (MissingKeyException missing) {
+            wipe(magic);
+            wipe(storedIdentity);
+            wipe(iv);
+            return Result.code(KEY_INVALIDATED);
+        } catch (InvalidatedKeyException invalidated) {
+            wipe(magic);
+            wipe(storedIdentity);
+            wipe(iv);
+            return Result.code(KEY_INVALIDATED);
+        } catch (UnavailableException unavailable) {
+            wipe(magic);
+            wipe(storedIdentity);
+            wipe(iv);
+            return Result.code(UNAVAILABLE);
+        }
+        byte[] combined = new byte[cipherLength + TAG_LENGTH];
+        input.get(combined);
+        byte[] header = Arrays.copyOf(envelope, HEADER_LENGTH);
+        try {
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(128, iv));
+            cipher.updateAAD(header);
+            byte[] value = cipher.doFinal(combined);
+            if (value.length != cipherLength) {
+                wipe(value);
+                return Result.code(CORRUPT);
+            }
+            return new Result(OK, value);
+        } catch (AEADBadTagException tag) {
+            return Result.code(CORRUPT);
+        } catch (InvalidKeyException invalidated) {
+            return Result.code(KEY_INVALIDATED);
+        } catch (GeneralSecurityException unavailable) {
+            return Result.code(UNAVAILABLE);
+        } finally {
+            wipe(magic);
+            wipe(storedIdentity);
+            wipe(iv);
+            wipe(combined);
+            wipe(header);
+        }
+    }
+
+    private static byte[] encrypt(Identity identity, SecretKey secretKey, byte[] value)
+        throws GeneralSecurityException {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+        byte[] iv = cipher.getIV();
+        if (iv == null || iv.length != IV_LENGTH) {
+            wipe(iv);
+            throw new GeneralSecurityException();
+        }
+        byte[] header = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.LITTLE_ENDIAN)
+            .put(MAGIC).putInt(VERSION).putInt(ALGORITHM_AES_256_GCM).putInt(IV_LENGTH)
+            .putInt(value.length).put(identity.digest).put(iv).array();
+        try {
+            cipher.updateAAD(header);
+            byte[] encrypted = cipher.doFinal(value);
+            if (encrypted.length != value.length + TAG_LENGTH) {
+                wipe(encrypted);
+                throw new GeneralSecurityException();
+            }
+            byte[] result = new byte[HEADER_LENGTH + encrypted.length];
+            System.arraycopy(header, 0, result, 0, HEADER_LENGTH);
+            System.arraycopy(encrypted, 0, result, HEADER_LENGTH, encrypted.length);
+            wipe(encrypted);
+            return result;
+        } finally {
+            wipe(iv);
+            wipe(header);
+        }
+    }
+
+    private static void updateLengthPrefixed(MessageDigest digest, byte[] value) {
+        byte[] length = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(value.length).array();
+        digest.update(length);
+        digest.update(value);
+        wipe(length);
+    }
+
+    static String hex(byte[] data) {
+        char[] result = new char[data.length * 2];
+        final char[] digits = "0123456789abcdef".toCharArray();
+        for (int index = 0; index < data.length; index++) {
+            int value = data[index] & 0xff;
+            result[index * 2] = digits[value >>> 4];
+            result[index * 2 + 1] = digits[value & 15];
+        }
+        return new String(result);
+    }
+
+    static void wipe(byte[] value) {
+        if (value != null) {
+            Arrays.fill(value, (byte) 0);
+        }
+    }
+}

--- a/sdk/include/mods/svc/secret_storage.h
+++ b/sdk/include/mods/svc/secret_storage.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <mods/api.h>
+#include <mods/svc/resource.h>
+
+#ifdef __cplusplus
+#include <mods/service.hpp>
+#endif
+
+#define SECRET_STORAGE_SERVICE_ID "dev.twilitrealm.dusklight.secret_storage"
+#define SECRET_STORAGE_SERVICE_MAJOR 1u
+#define SECRET_STORAGE_SERVICE_MINOR 0u
+
+#define SECRET_STORAGE_KEY_MAX_SIZE 128u
+#define SECRET_STORAGE_MOD_ID_MAX_SIZE 240u
+#define SECRET_STORAGE_MOD_ID_LABEL_MAX_SIZE 64u
+#define SECRET_STORAGE_VALUE_MAX_SIZE (64u * 1024u)
+
+typedef enum SecretStorageResult {
+    SECRET_STORAGE_OK = 0,
+    SECRET_STORAGE_NOT_FOUND = 1,
+    SECRET_STORAGE_INVALID_ARGUMENT = 2,
+    SECRET_STORAGE_TOO_LARGE = 3,
+    SECRET_STORAGE_UNAVAILABLE = 4,
+    SECRET_STORAGE_CORRUPT = 5,
+    SECRET_STORAGE_KEY_INVALIDATED = 6,
+    SECRET_STORAGE_IO_ERROR = 7,
+} SecretStorageResult;
+
+#if defined(__cplusplus)
+static_assert(sizeof(SecretStorageResult) == sizeof(int));
+#else
+_Static_assert(sizeof(SecretStorageResult) == sizeof(int), "SecretStorageResult ABI size");
+#endif
+
+/*
+ * Private secret storage for the calling mod. Keys are 1..128 lowercase ASCII
+ * [a-z0-9_.-] with no leading dot; values are at most 65536 bytes.
+ *
+ * get overwrites out_buffer with an empty buffer on every entry/failure without
+ * freeing previous contents: callers must free a prior successful buffer first.
+ * Empty values return data == NULL and size == 0. free only releases buffers
+ * returned to the same ModContext; a wrong-owner free leaves the buffer intact.
+ */
+typedef struct SecretStorageService {
+    ServiceHeader header;
+
+    SecretStorageResult (*get)(ModContext* ctx, const char* key, ResourceBuffer* out_buffer);
+    void (*free)(ModContext* ctx, ResourceBuffer* buffer);
+    SecretStorageResult (*put)(ModContext* ctx, const char* key, const void* data, size_t size);
+    SecretStorageResult (*remove)(ModContext* ctx, const char* key);
+} SecretStorageService;
+
+MOD_DECLARE_SERVICE(SecretStorageService, svc_secret_storage, SECRET_STORAGE_SERVICE_ID,
+    SECRET_STORAGE_SERVICE_MAJOR, SECRET_STORAGE_SERVICE_MINOR);

--- a/src/dusk/mods/svc/registry.cpp
+++ b/src/dusk/mods/svc/registry.cpp
@@ -213,6 +213,7 @@ void ModLoader::init_services() {
             &svc::g_gfxModule,
             &svc::g_saveModule,
             &svc::g_stageModule,
+            &svc::g_secretStorageModule,
         })
     {
         svc::register_module(*module);

--- a/src/dusk/mods/svc/registry.hpp
+++ b/src/dusk/mods/svc/registry.hpp
@@ -75,5 +75,6 @@ extern const ServiceModule g_windowModule;
 extern const ServiceModule g_gfxModule;
 extern const ServiceModule g_saveModule;
 extern const ServiceModule g_stageModule;
+extern const ServiceModule g_secretStorageModule;
 
 }  // namespace dusk::mods::svc

--- a/src/dusk/mods/svc/secret_storage.cpp
+++ b/src/dusk/mods/svc/secret_storage.cpp
@@ -1,0 +1,91 @@
+#include "secret_storage_core.hpp"
+#include "registry.hpp"
+
+#include "dusk/mods/loader/loader.hpp"
+
+#include <memory>
+
+#if defined(__ANDROID__)
+#include "secret_storage_android.hpp"
+#endif
+
+namespace dusk::mods::svc {
+namespace {
+
+class UnavailableSecretStorageBackend final : public SecretStorageBackend {
+public:
+    SecretStorageResult get(std::string_view, std::string_view, std::vector<uint8_t>& value) override {
+        wipe_secret_bytes(value.data(), value.size());
+        value.clear();
+        return SECRET_STORAGE_UNAVAILABLE;
+    }
+    SecretStorageResult put(std::string_view, std::string_view, const uint8_t*, size_t) override {
+        return SECRET_STORAGE_UNAVAILABLE;
+    }
+    SecretStorageResult remove(std::string_view, std::string_view) override {
+        return SECRET_STORAGE_UNAVAILABLE;
+    }
+};
+
+std::unique_ptr<SecretStorageCore> s_core;
+
+SecretStorageResult secret_get(ModContext* context, const char* key, ResourceBuffer* outBuffer) {
+    return s_core != nullptr ? s_core->get(context, key, outBuffer) : SECRET_STORAGE_UNAVAILABLE;
+}
+
+void secret_free(ModContext* context, ResourceBuffer* buffer) {
+    if (s_core != nullptr) {
+        s_core->free(context, buffer);
+    }
+}
+
+SecretStorageResult secret_put(
+    ModContext* context, const char* key, const void* data, const size_t size) {
+    return s_core != nullptr ? s_core->put(context, key, data, size) : SECRET_STORAGE_UNAVAILABLE;
+}
+
+SecretStorageResult secret_remove(ModContext* context, const char* key) {
+    return s_core != nullptr ? s_core->remove(context, key) : SECRET_STORAGE_UNAVAILABLE;
+}
+
+constexpr SecretStorageService s_secretStorageService{
+    .header = SERVICE_HEADER(
+        SecretStorageService, SECRET_STORAGE_SERVICE_MAJOR, SECRET_STORAGE_SERVICE_MINOR),
+    .get = secret_get,
+    .free = secret_free,
+    .put = secret_put,
+    .remove = secret_remove,
+};
+
+std::unique_ptr<SecretStorageBackend> make_backend() {
+#if defined(__ANDROID__)
+    return make_android_secret_storage_backend();
+#else
+    return std::make_unique<UnavailableSecretStorageBackend>();
+#endif
+}
+
+}  // namespace
+
+constinit const ServiceModule g_secretStorageModule{
+    .id = SECRET_STORAGE_SERVICE_ID,
+    .majorVersion = SECRET_STORAGE_SERVICE_MAJOR,
+    .minorVersion = SECRET_STORAGE_SERVICE_MINOR,
+    .service = &s_secretStorageService,
+    .initialize = [] {
+        s_core = std::make_unique<SecretStorageCore>(
+            [](ModContext* context) -> std::string_view {
+                const auto* mod = mod_from_context(context);
+                return mod != nullptr ? std::string_view(mod->metadata.id) : std::string_view{};
+            },
+            make_backend());
+    },
+    .modDetached = [](LoadedMod& mod) {
+        if (s_core != nullptr) {
+            s_core->modDetached(mod.context.get());
+        }
+    },
+    .shutdown = [] { s_core.reset(); },
+};
+
+}  // namespace dusk::mods::svc

--- a/src/dusk/mods/svc/secret_storage_android.cpp
+++ b/src/dusk/mods/svc/secret_storage_android.cpp
@@ -1,0 +1,352 @@
+#include "secret_storage_android.hpp"
+
+#include <SDL3/SDL_system.h>
+#include <jni.h>
+
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace dusk::mods::svc {
+namespace {
+
+constexpr const char* kStoreClass = "dev.twilitrealm.dusk.DuskSecretStore";
+
+bool clear_exception(JNIEnv* env) {
+    if (env == nullptr || !env->ExceptionCheck()) {
+        return false;
+    }
+    env->ExceptionClear();
+    return true;
+}
+
+jclass load_dusk_class(JNIEnv* env, jobject activity, const char* name) {
+    if (env == nullptr || activity == nullptr) {
+        return nullptr;
+    }
+    jclass activityClass = env->GetObjectClass(activity);
+    const bool activityClassFailed = clear_exception(env);
+    if (activityClass == nullptr || activityClassFailed) {
+        return nullptr;
+    }
+    const jmethodID getClassLoader =
+        env->GetMethodID(activityClass, "getClassLoader", "()Ljava/lang/ClassLoader;");
+    const bool getClassLoaderFailed = clear_exception(env);
+    env->DeleteLocalRef(activityClass);
+    if (getClassLoader == nullptr || getClassLoaderFailed) {
+        return nullptr;
+    }
+    jobject loader = env->CallObjectMethod(activity, getClassLoader);
+    const bool loaderFailed = clear_exception(env);
+    if (loader == nullptr || loaderFailed) {
+        return nullptr;
+    }
+    jclass loaderClass = env->FindClass("java/lang/ClassLoader");
+    const bool loaderClassFailed = clear_exception(env);
+    if (loaderClass == nullptr || loaderClassFailed) {
+        env->DeleteLocalRef(loader);
+        return nullptr;
+    }
+    const jmethodID loadClass =
+        env->GetMethodID(loaderClass, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
+    const bool loadClassFailed = clear_exception(env);
+    env->DeleteLocalRef(loaderClass);
+    if (loadClass == nullptr || loadClassFailed) {
+        env->DeleteLocalRef(loader);
+        return nullptr;
+    }
+    jstring className = env->NewStringUTF(name);
+    const bool classNameFailed = clear_exception(env);
+    if (className == nullptr || classNameFailed) {
+        env->DeleteLocalRef(loader);
+        return nullptr;
+    }
+    auto* result = static_cast<jclass>(env->CallObjectMethod(loader, loadClass, className));
+    const bool resultFailed = clear_exception(env);
+    env->DeleteLocalRef(className);
+    env->DeleteLocalRef(loader);
+    if (result == nullptr || resultFailed) {
+        if (result != nullptr) {
+            env->DeleteLocalRef(result);
+        }
+        return nullptr;
+    }
+    return result;
+}
+
+void wipe_java_bytes(JNIEnv* env, jbyteArray value) {
+    if (env == nullptr || value == nullptr) {
+        return;
+    }
+    const jsize size = env->GetArrayLength(value);
+    const bool sizeFailed = clear_exception(env);
+    if (sizeFailed || size <= 0) {
+        return;
+    }
+    std::vector<jbyte> zeros(static_cast<size_t>(size), 0);
+    env->SetByteArrayRegion(value, 0, size, zeros.data());
+    static_cast<void>(clear_exception(env));
+}
+
+jbyteArray bytes(JNIEnv* env, const uint8_t* data, const size_t size) {
+    if (env == nullptr || (data == nullptr && size != 0) ||
+        size > static_cast<size_t>(std::numeric_limits<jsize>::max())) {
+        return nullptr;
+    }
+    auto* result = env->NewByteArray(static_cast<jsize>(size));
+    const bool allocationFailed = clear_exception(env);
+    if (result == nullptr || allocationFailed) {
+        return nullptr;
+    }
+    if (size != 0) {
+        env->SetByteArrayRegion(result, 0, static_cast<jsize>(size),
+            reinterpret_cast<const jbyte*>(data));
+        const bool copyFailed = clear_exception(env);
+        if (copyFailed) {
+            wipe_java_bytes(env, result);
+            env->DeleteLocalRef(result);
+            return nullptr;
+        }
+    }
+    return result;
+}
+
+SecretStorageResult result_code(const jint code) {
+    return code >= SECRET_STORAGE_OK && code <= SECRET_STORAGE_IO_ERROR
+        ? static_cast<SecretStorageResult>(code)
+        : SECRET_STORAGE_UNAVAILABLE;
+}
+
+class AndroidSecretStorageBackend final : public SecretStorageBackend {
+public:
+    SecretStorageResult get(
+        const std::string_view modId, const std::string_view key, std::vector<uint8_t>& value) override {
+        value.clear();
+        JNIEnv* env = static_cast<JNIEnv*>(SDL_GetAndroidJNIEnv());
+        if (env == nullptr) {
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        const bool environmentFailed = clear_exception(env);
+        if (environmentFailed) {
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        jobject activity = static_cast<jobject>(SDL_GetAndroidActivity());
+        const bool activityFailed = clear_exception(env);
+        if (activity == nullptr || activityFailed) {
+            if (activity != nullptr) env->DeleteLocalRef(activity);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        jclass store = load_dusk_class(env, activity, kStoreClass);
+        if (store == nullptr) {
+            env->DeleteLocalRef(activity);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        const jmethodID method = env->GetStaticMethodID(store, "get",
+            "(Landroid/content/Context;[B[B)Ldev/twilitrealm/dusk/DuskSecretStore$Result;");
+        const bool methodFailed = clear_exception(env);
+        jbyteArray mod = bytes(env, reinterpret_cast<const uint8_t*>(modId.data()), modId.size());
+        jbyteArray keyBytes = bytes(env, reinterpret_cast<const uint8_t*>(key.data()), key.size());
+        if (method == nullptr || methodFailed || mod == nullptr || keyBytes == nullptr) {
+            if (mod != nullptr) env->DeleteLocalRef(mod);
+            if (keyBytes != nullptr) env->DeleteLocalRef(keyBytes);
+            env->DeleteLocalRef(store);
+            env->DeleteLocalRef(activity);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        jobject result = env->CallStaticObjectMethod(store, method, activity, mod, keyBytes);
+        const bool callFailed = clear_exception(env);
+        env->DeleteLocalRef(mod);
+        env->DeleteLocalRef(keyBytes);
+        env->DeleteLocalRef(store);
+        env->DeleteLocalRef(activity);
+        if (result == nullptr || callFailed) {
+            if (result != nullptr) env->DeleteLocalRef(result);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        jclass resultClass = env->GetObjectClass(result);
+        const bool resultClassFailed = clear_exception(env);
+        if (resultClass == nullptr || resultClassFailed) {
+            env->DeleteLocalRef(result);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        const jfieldID codeField = env->GetFieldID(resultClass, "code", "I");
+        const bool codeFieldFailed = clear_exception(env);
+        const jfieldID valueField = env->GetFieldID(resultClass, "value", "[B");
+        const bool valueFieldFailed = clear_exception(env);
+        if (codeField == nullptr || codeFieldFailed || valueField == nullptr || valueFieldFailed) {
+            env->DeleteLocalRef(resultClass);
+            env->DeleteLocalRef(result);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        const jint rawCode = env->GetIntField(result, codeField);
+        const bool codeFailed = clear_exception(env);
+        if (codeFailed) {
+            env->DeleteLocalRef(resultClass);
+            env->DeleteLocalRef(result);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        const SecretStorageResult code = result_code(rawCode);
+        auto* payload = static_cast<jbyteArray>(env->GetObjectField(result, valueField));
+        const bool payloadFailed = clear_exception(env);
+        if (payloadFailed) {
+            if (payload != nullptr) {
+                wipe_java_bytes(env, payload);
+                env->DeleteLocalRef(payload);
+            }
+            env->DeleteLocalRef(resultClass);
+            env->DeleteLocalRef(result);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        if (code == SECRET_STORAGE_OK && payload == nullptr) {
+            env->DeleteLocalRef(resultClass);
+            env->DeleteLocalRef(result);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        if (code != SECRET_STORAGE_OK && payload != nullptr) {
+            wipe_java_bytes(env, payload);
+            env->DeleteLocalRef(payload);
+            env->DeleteLocalRef(resultClass);
+            env->DeleteLocalRef(result);
+            return code;
+        }
+        if (code == SECRET_STORAGE_OK && payload != nullptr) {
+            const jsize size = env->GetArrayLength(payload);
+            const bool sizeFailed = clear_exception(env);
+            if (sizeFailed || size < 0 || static_cast<size_t>(size) > SECRET_STORAGE_VALUE_MAX_SIZE) {
+                wipe_java_bytes(env, payload);
+                env->DeleteLocalRef(payload);
+                env->DeleteLocalRef(resultClass);
+                env->DeleteLocalRef(result);
+                return SECRET_STORAGE_CORRUPT;
+            }
+            value.resize(static_cast<size_t>(size));
+            if (size != 0) {
+                env->GetByteArrayRegion(payload, 0, size, reinterpret_cast<jbyte*>(value.data()));
+            }
+            const bool copyFailed = clear_exception(env);
+            if (copyFailed) {
+                wipe_secret_bytes(value.data(), value.size());
+                value.clear();
+                wipe_java_bytes(env, payload);
+                env->DeleteLocalRef(payload);
+                env->DeleteLocalRef(resultClass);
+                env->DeleteLocalRef(result);
+                return SECRET_STORAGE_UNAVAILABLE;
+            }
+            wipe_java_bytes(env, payload);
+            env->DeleteLocalRef(payload);
+        }
+        env->DeleteLocalRef(resultClass);
+        env->DeleteLocalRef(result);
+        return code;
+    }
+
+    SecretStorageResult put(
+        const std::string_view modId, const std::string_view key, const uint8_t* data, const size_t size) override {
+        return call_put(modId, key, data, size);
+    }
+
+    SecretStorageResult remove(const std::string_view modId, const std::string_view key) override {
+        return call_remove(modId, key);
+    }
+
+private:
+    SecretStorageResult call_put(const std::string_view modId, const std::string_view key,
+        const uint8_t* value, const size_t size) {
+        JNIEnv* env = static_cast<JNIEnv*>(SDL_GetAndroidJNIEnv());
+        if (env == nullptr) {
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        const bool environmentFailed = clear_exception(env);
+        if (environmentFailed) {
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        jobject activity = static_cast<jobject>(SDL_GetAndroidActivity());
+        const bool activityFailed = clear_exception(env);
+        if (activity == nullptr || activityFailed) {
+            if (activity != nullptr) env->DeleteLocalRef(activity);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        jclass store = load_dusk_class(env, activity, kStoreClass);
+        jbyteArray mod = bytes(env, reinterpret_cast<const uint8_t*>(modId.data()), modId.size());
+        jbyteArray keyBytes = bytes(env, reinterpret_cast<const uint8_t*>(key.data()), key.size());
+        jbyteArray bytesValue = bytes(env, value, size);
+        jmethodID method = nullptr;
+        bool methodFailed = false;
+        if (store != nullptr) {
+            method = env->GetStaticMethodID(store, "put", "(Landroid/content/Context;[B[B[B)I");
+            methodFailed = clear_exception(env);
+        }
+        if (store == nullptr || mod == nullptr || keyBytes == nullptr ||
+            bytesValue == nullptr || method == nullptr || methodFailed)
+        {
+            if (bytesValue != nullptr) {
+                wipe_java_bytes(env, bytesValue);
+                env->DeleteLocalRef(bytesValue);
+            }
+            if (keyBytes != nullptr) env->DeleteLocalRef(keyBytes);
+            if (mod != nullptr) env->DeleteLocalRef(mod);
+            if (store != nullptr) env->DeleteLocalRef(store);
+            env->DeleteLocalRef(activity);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        const jint code = env->CallStaticIntMethod(store, method, activity, mod, keyBytes, bytesValue);
+        const bool callFailed = clear_exception(env);
+        wipe_java_bytes(env, bytesValue);
+        if (bytesValue != nullptr) env->DeleteLocalRef(bytesValue);
+        env->DeleteLocalRef(keyBytes);
+        env->DeleteLocalRef(mod);
+        env->DeleteLocalRef(store);
+        env->DeleteLocalRef(activity);
+        return callFailed ? SECRET_STORAGE_UNAVAILABLE : result_code(code);
+    }
+
+    SecretStorageResult call_remove(const std::string_view modId, const std::string_view key) {
+        JNIEnv* env = static_cast<JNIEnv*>(SDL_GetAndroidJNIEnv());
+        if (env == nullptr) {
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        const bool environmentFailed = clear_exception(env);
+        if (environmentFailed) {
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        jobject activity = static_cast<jobject>(SDL_GetAndroidActivity());
+        const bool activityFailed = clear_exception(env);
+        if (activity == nullptr || activityFailed) {
+            if (activity != nullptr) env->DeleteLocalRef(activity);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        jclass store = load_dusk_class(env, activity, kStoreClass);
+        jbyteArray mod = bytes(env, reinterpret_cast<const uint8_t*>(modId.data()), modId.size());
+        jbyteArray keyBytes = bytes(env, reinterpret_cast<const uint8_t*>(key.data()), key.size());
+        jmethodID method = nullptr;
+        bool methodFailed = false;
+        if (store != nullptr) {
+            method = env->GetStaticMethodID(store, "remove", "(Landroid/content/Context;[B[B)I");
+            methodFailed = clear_exception(env);
+        }
+        if (store == nullptr || mod == nullptr || keyBytes == nullptr || method == nullptr || methodFailed)
+        {
+            if (keyBytes != nullptr) env->DeleteLocalRef(keyBytes);
+            if (mod != nullptr) env->DeleteLocalRef(mod);
+            if (store != nullptr) env->DeleteLocalRef(store);
+            env->DeleteLocalRef(activity);
+            return SECRET_STORAGE_UNAVAILABLE;
+        }
+        const jint code = env->CallStaticIntMethod(store, method, activity, mod, keyBytes);
+        const bool callFailed = clear_exception(env);
+        env->DeleteLocalRef(keyBytes);
+        env->DeleteLocalRef(mod);
+        env->DeleteLocalRef(store);
+        env->DeleteLocalRef(activity);
+        return callFailed ? SECRET_STORAGE_UNAVAILABLE : result_code(code);
+    }
+};
+
+}  // namespace
+
+std::unique_ptr<SecretStorageBackend> make_android_secret_storage_backend() {
+    return std::make_unique<AndroidSecretStorageBackend>();
+}
+
+}  // namespace dusk::mods::svc

--- a/src/dusk/mods/svc/secret_storage_android.hpp
+++ b/src/dusk/mods/svc/secret_storage_android.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "secret_storage_core.hpp"
+
+#include <memory>
+
+namespace dusk::mods::svc {
+
+std::unique_ptr<SecretStorageBackend> make_android_secret_storage_backend();
+
+}  // namespace dusk::mods::svc

--- a/src/dusk/mods/svc/secret_storage_core.cpp
+++ b/src/dusk/mods/svc/secret_storage_core.cpp
@@ -1,0 +1,218 @@
+#include "secret_storage_core.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+
+namespace dusk::mods::svc {
+namespace {
+
+std::mutex s_secretStorageMutex;
+
+bool valid_label(const std::string_view label) {
+    if (label.empty() || label.size() > SECRET_STORAGE_MOD_ID_LABEL_MAX_SIZE) {
+        return false;
+    }
+    for (const unsigned char character : label) {
+        if (!((character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') ||
+                character == '_'))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool bounded_c_string(const char* text, const size_t maximum, std::string_view& result) {
+    if (text == nullptr) {
+        return false;
+    }
+    const void* terminator = std::memchr(text, '\0', maximum + 1);
+    if (terminator == nullptr) {
+        return false;
+    }
+    result = std::string_view(text, static_cast<const char*>(terminator) - text);
+    return true;
+}
+
+SecretStorageResult validate(
+    ModContext* context, const SecretStorageCore::ModIdResolver& modIdResolver, const char* key,
+    const void* data, const size_t size, std::string_view& modId, std::string_view& keyText) {
+    if (size > SECRET_STORAGE_VALUE_MAX_SIZE) {
+        return SECRET_STORAGE_TOO_LARGE;
+    }
+    if (context == nullptr || (data == nullptr && size != 0) ||
+        !bounded_c_string(key, SECRET_STORAGE_KEY_MAX_SIZE, keyText) ||
+        !valid_secret_storage_key(keyText))
+    {
+        return SECRET_STORAGE_INVALID_ARGUMENT;
+    }
+    modId = modIdResolver(context);
+    return valid_secret_storage_mod_id(modId) ? SECRET_STORAGE_OK : SECRET_STORAGE_INVALID_ARGUMENT;
+}
+
+}  // namespace
+
+void wipe_secret_bytes(void* data, size_t size) {
+    volatile auto* bytes = static_cast<volatile uint8_t*>(data);
+    while (bytes != nullptr && size != 0) {
+        *bytes++ = 0;
+        --size;
+    }
+}
+
+bool valid_secret_storage_key(const std::string_view key) {
+    if (key.empty() || key.size() > SECRET_STORAGE_KEY_MAX_SIZE || key.front() == '.') {
+        return false;
+    }
+    for (const unsigned char character : key) {
+        if (!((character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') ||
+                character == '_' || character == '.' || character == '-'))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool valid_secret_storage_mod_id(const std::string_view modId) {
+    if (modId.empty() || modId.size() > SECRET_STORAGE_MOD_ID_MAX_SIZE || modId.front() == '.' ||
+        modId.back() == '.')
+    {
+        return false;
+    }
+    size_t start = 0;
+    while (start < modId.size()) {
+        const size_t end = modId.find('.', start);
+        if (!valid_label(modId.substr(start, end == std::string_view::npos ? end : end - start))) {
+            return false;
+        }
+        if (end == std::string_view::npos) {
+            return true;
+        }
+        start = end + 1;
+    }
+    return false;
+}
+
+SecretStorageCore::SecretStorageCore(
+    ModIdResolver modId, std::unique_ptr<SecretStorageBackend> backend)
+    : m_modId(std::move(modId)), m_backend(std::move(backend)) {}
+
+SecretStorageCore::~SecretStorageCore() {
+    std::lock_guard lock(s_secretStorageMutex);
+    for (const auto& [data, owner] : m_buffers) {
+        wipe_secret_bytes(data, owner.size);
+        std::free(data);
+    }
+    m_buffers.clear();
+}
+
+SecretStorageResult SecretStorageCore::get(
+    ModContext* context, const char* key, ResourceBuffer* outBuffer) {
+    if (outBuffer == nullptr || outBuffer->struct_size < sizeof(ResourceBuffer)) {
+        return SECRET_STORAGE_INVALID_ARGUMENT;
+    }
+    outBuffer->data = nullptr;
+    outBuffer->size = 0;
+
+    std::string_view modId;
+    std::string_view keyText;
+    if (const auto result = validate(context, m_modId, key, nullptr, 0, modId, keyText);
+        result != SECRET_STORAGE_OK)
+    {
+        return result;
+    }
+
+    std::vector<uint8_t> value;
+    std::lock_guard lock(s_secretStorageMutex);
+    if (m_backend == nullptr) {
+        return SECRET_STORAGE_UNAVAILABLE;
+    }
+    const SecretStorageResult result = m_backend->get(modId, keyText, value);
+    if (result != SECRET_STORAGE_OK) {
+        wipe_secret_bytes(value.data(), value.size());
+        return result;
+    }
+    if (value.size() > SECRET_STORAGE_VALUE_MAX_SIZE) {
+        wipe_secret_bytes(value.data(), value.size());
+        return SECRET_STORAGE_CORRUPT;
+    }
+    if (!value.empty()) {
+        void* allocation = std::malloc(value.size());
+        if (allocation == nullptr) {
+            wipe_secret_bytes(value.data(), value.size());
+            return SECRET_STORAGE_IO_ERROR;
+        }
+        std::memcpy(allocation, value.data(), value.size());
+        m_buffers.emplace(allocation, BufferOwner{.context = context, .size = value.size()});
+        outBuffer->data = allocation;
+        outBuffer->size = value.size();
+    }
+    wipe_secret_bytes(value.data(), value.size());
+    return SECRET_STORAGE_OK;
+}
+
+void SecretStorageCore::free(ModContext* context, ResourceBuffer* buffer) {
+    if (buffer == nullptr || buffer->struct_size < sizeof(ResourceBuffer) || buffer->data == nullptr) {
+        return;
+    }
+    std::lock_guard lock(s_secretStorageMutex);
+    const auto found = m_buffers.find(buffer->data);
+    if (found == m_buffers.end() || found->second.context != context) {
+        return;
+    }
+    wipe_secret_bytes(buffer->data, found->second.size);
+    std::free(buffer->data);
+    m_buffers.erase(found);
+    buffer->data = nullptr;
+    buffer->size = 0;
+}
+
+SecretStorageResult SecretStorageCore::put(
+    ModContext* context, const char* key, const void* data, const size_t size) {
+    std::string_view modId;
+    std::string_view keyText;
+    if (const auto result = validate(context, m_modId, key, data, size, modId, keyText);
+        result != SECRET_STORAGE_OK)
+    {
+        return result;
+    }
+    std::vector<uint8_t> copy(size);
+    if (size != 0) {
+        std::memcpy(copy.data(), data, size);
+    }
+    std::lock_guard lock(s_secretStorageMutex);
+    const SecretStorageResult result =
+        m_backend == nullptr ? SECRET_STORAGE_UNAVAILABLE : m_backend->put(modId, keyText, copy.data(), size);
+    wipe_secret_bytes(copy.data(), copy.size());
+    return result;
+}
+
+SecretStorageResult SecretStorageCore::remove(ModContext* context, const char* key) {
+    std::string_view modId;
+    std::string_view keyText;
+    if (const auto result = validate(context, m_modId, key, nullptr, 0, modId, keyText);
+        result != SECRET_STORAGE_OK)
+    {
+        return result;
+    }
+    std::lock_guard lock(s_secretStorageMutex);
+    return m_backend == nullptr ? SECRET_STORAGE_UNAVAILABLE : m_backend->remove(modId, keyText);
+}
+
+void SecretStorageCore::modDetached(ModContext* context) {
+    std::lock_guard lock(s_secretStorageMutex);
+    for (auto it = m_buffers.begin(); it != m_buffers.end();) {
+        if (it->second.context == context) {
+            wipe_secret_bytes(it->first, it->second.size);
+            std::free(it->first);
+            it = m_buffers.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+}  // namespace dusk::mods::svc

--- a/src/dusk/mods/svc/secret_storage_core.hpp
+++ b/src/dusk/mods/svc/secret_storage_core.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "mods/svc/secret_storage.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace dusk::mods::svc {
+
+class SecretStorageBackend {
+public:
+    virtual ~SecretStorageBackend() = default;
+    virtual SecretStorageResult get(
+        std::string_view modId, std::string_view key, std::vector<uint8_t>& value) = 0;
+    virtual SecretStorageResult put(
+        std::string_view modId, std::string_view key, const uint8_t* data, size_t size) = 0;
+    virtual SecretStorageResult remove(std::string_view modId, std::string_view key) = 0;
+};
+
+class SecretStorageCore {
+public:
+    using ModIdResolver = std::function<std::string_view(ModContext*)>;
+
+    SecretStorageCore(ModIdResolver modId, std::unique_ptr<SecretStorageBackend> backend);
+    ~SecretStorageCore();
+
+    SecretStorageCore(const SecretStorageCore&) = delete;
+    SecretStorageCore& operator=(const SecretStorageCore&) = delete;
+
+    SecretStorageResult get(ModContext* context, const char* key, ResourceBuffer* outBuffer);
+    void free(ModContext* context, ResourceBuffer* buffer);
+    SecretStorageResult put(ModContext* context, const char* key, const void* data, size_t size);
+    SecretStorageResult remove(ModContext* context, const char* key);
+    void modDetached(ModContext* context);
+
+private:
+    struct BufferOwner {
+        const ModContext* context = nullptr;
+        size_t size = 0;
+    };
+
+    ModIdResolver m_modId;
+    std::unique_ptr<SecretStorageBackend> m_backend;
+    std::unordered_map<void*, BufferOwner> m_buffers;
+};
+
+bool valid_secret_storage_key(std::string_view key);
+bool valid_secret_storage_mod_id(std::string_view modId);
+void wipe_secret_bytes(void* data, size_t size);
+
+}  // namespace dusk::mods::svc

--- a/tests/hostservices/java/DuskSecretStoreCoreTest.java
+++ b/tests/hostservices/java/DuskSecretStoreCoreTest.java
@@ -1,0 +1,249 @@
+package dev.twilitrealm.dusk;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+public final class DuskSecretStoreCoreTest {
+    private static final byte[] MOD = "com.example_mod".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] KEY = "token".getBytes(StandardCharsets.US_ASCII);
+
+    private static final class Keys implements DuskSecretStoreCore.KeyRepository {
+        final Map<String, SecretKey> values = new HashMap<>();
+        boolean invalidated;
+        boolean unavailable;
+        boolean deleteFails;
+
+        public SecretKey find(String alias) throws DuskSecretStoreCore.MissingKeyException,
+            DuskSecretStoreCore.InvalidatedKeyException, DuskSecretStoreCore.UnavailableException {
+            if (unavailable) throw new DuskSecretStoreCore.UnavailableException();
+            if (invalidated) throw new DuskSecretStoreCore.InvalidatedKeyException();
+            SecretKey key = values.get(alias);
+            if (key == null) throw new DuskSecretStoreCore.MissingKeyException();
+            return key;
+        }
+        public SecretKey create(String alias) throws DuskSecretStoreCore.UnavailableException {
+            if (unavailable) throw new DuskSecretStoreCore.UnavailableException();
+            try {
+                KeyGenerator generator = KeyGenerator.getInstance("AES");
+                generator.init(256);
+                SecretKey key = generator.generateKey();
+                values.put(alias, key);
+                return key;
+            } catch (Exception failure) {
+                throw new DuskSecretStoreCore.UnavailableException();
+            }
+        }
+        public boolean exists(String alias) throws DuskSecretStoreCore.UnavailableException {
+            if (unavailable) throw new DuskSecretStoreCore.UnavailableException();
+            return values.containsKey(alias);
+        }
+        public void delete(String alias) throws IOException, DuskSecretStoreCore.UnavailableException {
+            if (unavailable) throw new DuskSecretStoreCore.UnavailableException();
+            if (deleteFails) throw new IOException();
+            values.remove(alias);
+        }
+    }
+
+    private static final class Metadata implements DuskSecretStoreCore.MetadataRepository {
+        final Map<String, byte[]> values = new HashMap<>();
+        boolean newOnly;
+        boolean cleanupFails;
+        boolean removeFails;
+        boolean writeFails;
+
+        public DuskSecretStoreCore.Metadata read(String filename) throws IOException {
+            if (newOnly) {
+                if (cleanupFails) throw new IOException();
+                newOnly = false;
+            }
+            byte[] bytes = values.get(filename);
+            return bytes == null ? DuskSecretStoreCore.Metadata.notFound() :
+                DuskSecretStoreCore.Metadata.committed(bytes);
+        }
+        public boolean hasArtifacts(String filename) {
+            return newOnly || values.containsKey(filename);
+        }
+        public void write(String filename, byte[] data) throws IOException {
+            if (writeFails) throw new IOException();
+            values.put(filename, Arrays.copyOf(data, data.length));
+        }
+        public void remove(String filename) throws IOException {
+            if (removeFails) throw new IOException();
+            values.remove(filename);
+            newOnly = false;
+        }
+    }
+
+    private static final class InvalidAesKey implements SecretKey {
+        public String getAlgorithm() { return "AES"; }
+        public String getFormat() { return "RAW"; }
+        public byte[] getEncoded() { return new byte[] {1}; }
+    }
+
+    private static DuskSecretStoreCore store(Keys keys, Metadata metadata) {
+        return new DuskSecretStoreCore(keys, metadata, "dev.twilitrealm.dusk");
+    }
+
+    private static void assertCode(int expected, int actual) {
+        assert expected == actual : expected + " != " + actual;
+    }
+
+    private static String filename() {
+        return DuskSecretStoreCore.identity("dev.twilitrealm.dusk".getBytes(StandardCharsets.UTF_8), MOD, KEY).filename;
+    }
+
+    private static void testIdentity() {
+        DuskSecretStoreCore.Identity identity = DuskSecretStoreCore.identity(
+            "dev.twilitrealm.dusk".getBytes(StandardCharsets.UTF_8), MOD, KEY);
+        assert "4657e16d2c559494f24ca4cc9b183d33e01905ecfca085275a2848674296ec5b".equals(identity.hex);
+        assert !DuskSecretStoreCore.identity("a".getBytes(StandardCharsets.UTF_8),
+            "a".getBytes(StandardCharsets.US_ASCII), "bc".getBytes(StandardCharsets.US_ASCII)).hex.equals(
+            DuskSecretStoreCore.identity("a".getBytes(StandardCharsets.UTF_8),
+                "ab".getBytes(StandardCharsets.US_ASCII), "c".getBytes(StandardCharsets.US_ASCII)).hex);
+    }
+
+    private static void testCryptoRestartAndCorruption() {
+        Keys keys = new Keys();
+        Metadata metadata = new Metadata();
+        DuskSecretStoreCore first = store(keys, metadata);
+        byte[] one = "secret-one".getBytes(StandardCharsets.US_ASCII);
+        assertCode(DuskSecretStoreCore.OK, first.put(MOD, KEY, one));
+        byte[] initial = Arrays.copyOf(metadata.values.get(filename()), metadata.values.get(filename()).length);
+        assertCode(DuskSecretStoreCore.OK, first.put(MOD, KEY, one));
+        byte[] second = metadata.values.get(filename());
+        assert !Arrays.equals(initial, second);
+        DuskSecretStoreCore restarted = store(keys, metadata);
+        DuskSecretStoreCore.Result read = restarted.get(MOD, KEY);
+        assertCode(DuskSecretStoreCore.OK, read.code);
+        assert Arrays.equals(one, read.value);
+        DuskSecretStoreCore.wipe(read.value);
+
+        byte[] valid = Arrays.copyOf(second, second.length);
+        int[] corruptOffsets = {0, 24, 40, valid.length - 1};
+        for (int offset : corruptOffsets) {
+            byte[] corrupted = Arrays.copyOf(valid, valid.length);
+            corrupted[offset] ^= 1;
+            metadata.values.put(filename(), corrupted);
+            assertCode(DuskSecretStoreCore.CORRUPT, restarted.get(MOD, KEY).code);
+        }
+        byte[] impossibleLength = Arrays.copyOf(valid, valid.length);
+        ByteBuffer.wrap(impossibleLength).order(ByteOrder.LITTLE_ENDIAN).putInt(20, 65537);
+        metadata.values.put(filename(), impossibleLength);
+        assertCode(DuskSecretStoreCore.CORRUPT, restarted.get(MOD, KEY).code);
+        metadata.values.put(filename(), Arrays.copyOf(valid, valid.length + 1));
+        assertCode(DuskSecretStoreCore.CORRUPT, restarted.get(MOD, KEY).code);
+        DuskSecretStoreCore.wipe(initial);
+        DuskSecretStoreCore.wipe(valid);
+    }
+
+    private static void testInvalidationPutAndRemove() {
+        Keys keys = new Keys();
+        Metadata metadata = new Metadata();
+        DuskSecretStoreCore secret = store(keys, metadata);
+        assertCode(DuskSecretStoreCore.OK, secret.put(MOD, KEY, new byte[] {1}));
+        String alias = DuskSecretStoreCore.identity(
+            "dev.twilitrealm.dusk".getBytes(StandardCharsets.UTF_8), MOD, KEY).alias;
+        keys.values.remove(alias);
+        assertCode(DuskSecretStoreCore.KEY_INVALIDATED, secret.get(MOD, KEY).code);
+        assertCode(DuskSecretStoreCore.KEY_INVALIDATED, secret.put(MOD, KEY, new byte[] {2}));
+        metadata.values.put(filename(), new byte[] {1, 2, 3});
+        assertCode(DuskSecretStoreCore.CORRUPT, secret.put(MOD, KEY, new byte[] {2}));
+
+        metadata.values.clear();
+        metadata.newOnly = true;
+        assertCode(DuskSecretStoreCore.NOT_FOUND, secret.get(MOD, KEY).code);
+        metadata.newOnly = true;
+        metadata.cleanupFails = true;
+        assertCode(DuskSecretStoreCore.IO_ERROR, secret.get(MOD, KEY).code);
+        metadata.cleanupFails = false;
+        metadata.newOnly = false;
+        assertCode(DuskSecretStoreCore.OK, secret.put(MOD, KEY, new byte[] {3}));
+        metadata.removeFails = true;
+        keys.deleteFails = false;
+        assertCode(DuskSecretStoreCore.IO_ERROR, secret.remove(MOD, KEY));
+        assert keys.values.containsKey(alias);
+        metadata.removeFails = false;
+        keys.deleteFails = true;
+        assertCode(DuskSecretStoreCore.IO_ERROR, secret.remove(MOD, KEY));
+        assert keys.values.containsKey(alias);
+        keys.deleteFails = false;
+        assertCode(DuskSecretStoreCore.OK, secret.remove(MOD, KEY));
+        assertCode(DuskSecretStoreCore.NOT_FOUND, secret.remove(MOD, KEY));
+        keys.values.put(alias, newKey());
+        assertCode(DuskSecretStoreCore.OK, secret.remove(MOD, KEY));
+    }
+
+    private static SecretKey newKey() {
+        try {
+            KeyGenerator generator = KeyGenerator.getInstance("AES");
+            generator.init(256);
+            return generator.generateKey();
+        } catch (Exception failure) {
+            throw new AssertionError(failure);
+        }
+    }
+
+    private static void testBoundsAndConcurrency() throws InterruptedException {
+        Keys keys = new Keys();
+        Metadata metadata = new Metadata();
+        DuskSecretStoreCore secret = store(keys, metadata);
+        assertCode(DuskSecretStoreCore.INVALID_ARGUMENT, secret.put(
+            "Com.example".getBytes(StandardCharsets.US_ASCII), KEY, new byte[0]));
+        assertCode(DuskSecretStoreCore.INVALID_ARGUMENT, secret.put(
+            MOD, "Upper".getBytes(StandardCharsets.US_ASCII), new byte[0]));
+        assertCode(DuskSecretStoreCore.TOO_LARGE, secret.put(MOD, KEY, new byte[65537]));
+        byte[] maxMod = (new String(new char[64]).replace('\0', 'a') + "." +
+            new String(new char[64]).replace('\0', 'b') + "." +
+            new String(new char[64]).replace('\0', 'c') + "." +
+            new String(new char[45]).replace('\0', 'd')).getBytes(StandardCharsets.US_ASCII);
+        assert maxMod.length == DuskSecretStoreCore.MAX_MOD_ID;
+        assert DuskSecretStoreCore.validModId(maxMod);
+        byte[] tooLongMod = Arrays.copyOf(maxMod, maxMod.length + 1);
+        tooLongMod[tooLongMod.length - 1] = 'e';
+        assert !DuskSecretStoreCore.validModId(tooLongMod);
+        assert !DuskSecretStoreCore.validModId(
+            new String(new char[65]).replace('\0', 'a').getBytes(StandardCharsets.US_ASCII));
+        metadata.writeFails = true;
+        assertCode(DuskSecretStoreCore.IO_ERROR, secret.put(MOD, KEY, new byte[0]));
+        metadata.writeFails = false;
+        Thread first = new Thread(() -> assertCode(DuskSecretStoreCore.OK,
+            secret.put(MOD, KEY, new byte[] {1})));
+        Thread second = new Thread(() -> assertCode(DuskSecretStoreCore.OK,
+            secret.put(MOD, KEY, new byte[] {2})));
+        first.start();
+        second.start();
+        first.join();
+        second.join();
+        assertCode(DuskSecretStoreCore.OK, secret.get(MOD, KEY).code);
+    }
+
+    private static void testInvalidAesKey() {
+        Keys keys = new Keys();
+        Metadata metadata = new Metadata();
+        DuskSecretStoreCore secret = store(keys, metadata);
+        String alias = DuskSecretStoreCore.identity(
+            "dev.twilitrealm.dusk".getBytes(StandardCharsets.UTF_8), MOD, KEY).alias;
+        keys.values.put(alias, new InvalidAesKey());
+        assertCode(DuskSecretStoreCore.KEY_INVALIDATED, secret.put(MOD, KEY, new byte[] {1}));
+        keys.values.remove(alias);
+        assertCode(DuskSecretStoreCore.OK, secret.put(MOD, KEY, new byte[] {1}));
+        keys.values.put(alias, new InvalidAesKey());
+        assertCode(DuskSecretStoreCore.KEY_INVALIDATED, secret.get(MOD, KEY).code);
+    }
+
+    public static void main(String[] args) throws Exception {
+        testIdentity();
+        testCryptoRestartAndCorruption();
+        testInvalidationPutAndRemove();
+        testBoundsAndConcurrency();
+        testInvalidAesKey();
+    }
+}

--- a/tests/hostservices/secret_storage_c_testmod.c
+++ b/tests/hostservices/secret_storage_c_testmod.c
@@ -1,0 +1,16 @@
+#include "mods/svc/secret_storage.h"
+
+SecretStorageResult secret_storage_c_testmod_roundtrip(
+    const SecretStorageService* service, ModContext* context, const char* key) {
+    static const char value[] = "c-table";
+    ResourceBuffer buffer = RESOURCE_BUFFER_INIT;
+    if (service == 0 || service->header.major_version != SECRET_STORAGE_SERVICE_MAJOR ||
+        service->put(context, key, value, sizeof(value) - 1) != SECRET_STORAGE_OK ||
+        service->get(context, key, &buffer) != SECRET_STORAGE_OK ||
+        buffer.size != sizeof(value) - 1)
+    {
+        return SECRET_STORAGE_IO_ERROR;
+    }
+    service->free(context, &buffer);
+    return service->remove(context, key);
+}

--- a/tests/hostservices/secret_storage_core_test.cpp
+++ b/tests/hostservices/secret_storage_core_test.cpp
@@ -1,0 +1,205 @@
+#include "dusk/mods/svc/secret_storage_core.hpp"
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using dusk::mods::svc::SecretStorageBackend;
+using dusk::mods::svc::SecretStorageCore;
+
+struct TestMod { std::string id; };
+struct ModContext { TestMod* mod; };
+
+extern "C" SecretStorageResult secret_storage_c_testmod_roundtrip(
+    const SecretStorageService*, ModContext*, const char*);
+
+namespace {
+
+class FakeBackend final : public SecretStorageBackend {
+public:
+    SecretStorageResult nextGet = SECRET_STORAGE_OK;
+    std::vector<uint8_t> errorPayload;
+    std::unordered_map<std::string, std::vector<uint8_t>> values;
+
+    SecretStorageResult get(
+        std::string_view modId, std::string_view key, std::vector<uint8_t>& value) override {
+        if (nextGet != SECRET_STORAGE_OK) {
+            value = errorPayload;
+            return nextGet;
+        }
+        auto found = values.find(std::string(modId) + "/" + std::string(key));
+        if (found == values.end()) return SECRET_STORAGE_NOT_FOUND;
+        value = found->second;
+        return SECRET_STORAGE_OK;
+    }
+    SecretStorageResult put(
+        std::string_view modId, std::string_view key, const uint8_t* data, size_t size) override {
+        values[std::string(modId) + "/" + std::string(key)] = {data, data + size};
+        return SECRET_STORAGE_OK;
+    }
+    SecretStorageResult remove(std::string_view modId, std::string_view key) override {
+        return values.erase(std::string(modId) + "/" + std::string(key)) == 0 ?
+            SECRET_STORAGE_NOT_FOUND : SECRET_STORAGE_OK;
+    }
+};
+
+SecretStorageCore* core = nullptr;
+SecretStorageResult tableGet(ModContext* context, const char* key, ResourceBuffer* out) {
+    return core->get(context, key, out);
+}
+void tableFree(ModContext* context, ResourceBuffer* buffer) { core->free(context, buffer); }
+SecretStorageResult tablePut(ModContext* context, const char* key, const void* data, size_t size) {
+    return core->put(context, key, data, size);
+}
+SecretStorageResult tableRemove(ModContext* context, const char* key) {
+    return core->remove(context, key);
+}
+constexpr SecretStorageService service{
+    .header = SERVICE_HEADER(SecretStorageService, SECRET_STORAGE_SERVICE_MAJOR, SECRET_STORAGE_SERVICE_MINOR),
+    .get = tableGet,
+    .free = tableFree,
+    .put = tablePut,
+    .remove = tableRemove,
+};
+
+struct Fixture {
+    TestMod first{"com.example_first"};
+    TestMod second{"com.example_second"};
+    ModContext firstContext{&first};
+    ModContext secondContext{&second};
+    FakeBackend* backend;
+    SecretStorageCore storage;
+
+    Fixture() : backend(new FakeBackend()),
+        storage([](ModContext* context) -> std::string_view {
+            return context == nullptr || context->mod == nullptr ? std::string_view{} :
+                std::string_view(context->mod->id);
+        }, std::unique_ptr<SecretStorageBackend>(backend)) {
+        core = &storage;
+    }
+    ~Fixture() { core = nullptr; }
+};
+
+void test_abi_table_and_validation() {
+    static_assert(SECRET_STORAGE_OK == 0 && SECRET_STORAGE_NOT_FOUND == 1 &&
+        SECRET_STORAGE_INVALID_ARGUMENT == 2 && SECRET_STORAGE_TOO_LARGE == 3 &&
+        SECRET_STORAGE_UNAVAILABLE == 4 && SECRET_STORAGE_CORRUPT == 5 &&
+        SECRET_STORAGE_KEY_INVALIDATED == 6 && SECRET_STORAGE_IO_ERROR == 7);
+    static_assert(sizeof(SecretStorageResult) == sizeof(int));
+    static_assert(offsetof(SecretStorageService, get) < offsetof(SecretStorageService, free));
+    static_assert(offsetof(SecretStorageService, free) < offsetof(SecretStorageService, put));
+    static_assert(offsetof(SecretStorageService, put) < offsetof(SecretStorageService, remove));
+    Fixture fixture;
+    assert(secret_storage_c_testmod_roundtrip(&service, &fixture.firstContext, "c.roundtrip") ==
+        SECRET_STORAGE_OK);
+    const char value[] = "x";
+    const char* invalid[] = {"", ".x", "Upper", "x/y", "x ", "x\xc3\xa9"};
+    for (const char* key : invalid) {
+        assert(fixture.storage.put(&fixture.firstContext, key, value, 1) ==
+            SECRET_STORAGE_INVALID_ARGUMENT);
+    }
+    fixture.first.id = "Com.example";
+    assert(fixture.storage.put(&fixture.firstContext, "ok", value, 1) ==
+        SECRET_STORAGE_INVALID_ARGUMENT);
+    fixture.first.id = std::string(64, 'a') + "." + std::string(64, 'b') + "." +
+        std::string(64, 'c') + "." + std::string(45, 'd');
+    assert(fixture.first.id.size() == SECRET_STORAGE_MOD_ID_MAX_SIZE);
+    assert(fixture.storage.put(&fixture.firstContext, "ok", value, 1) == SECRET_STORAGE_OK);
+    fixture.first.id += "e";
+    assert(fixture.storage.put(&fixture.firstContext, "ok", value, 1) ==
+        SECRET_STORAGE_INVALID_ARGUMENT);
+    fixture.first.id = std::string(65, 'a');
+    assert(fixture.storage.put(&fixture.firstContext, "ok", value, 1) ==
+        SECRET_STORAGE_INVALID_ARGUMENT);
+}
+
+void test_bounds_empty_and_copy() {
+    Fixture fixture;
+    assert(fixture.storage.put(&fixture.firstContext, "empty", nullptr, 0) == SECRET_STORAGE_OK);
+    ResourceBuffer empty = RESOURCE_BUFFER_INIT;
+    assert(fixture.storage.get(&fixture.firstContext, "empty", &empty) == SECRET_STORAGE_OK);
+    assert(empty.data == nullptr && empty.size == 0);
+    std::vector<uint8_t> max(SECRET_STORAGE_VALUE_MAX_SIZE, 7);
+    assert(fixture.storage.put(&fixture.firstContext, "max", max.data(), max.size()) == SECRET_STORAGE_OK);
+    max[0] = 9;
+    assert(fixture.backend->values["com.example_first/max"][0] == 7);
+    max.push_back(1);
+    assert(fixture.storage.put(&fixture.firstContext, "large", max.data(), max.size()) ==
+        SECRET_STORAGE_TOO_LARGE);
+    ResourceBuffer result = RESOURCE_BUFFER_INIT;
+    assert(fixture.storage.get(&fixture.firstContext, "max", &result) == SECRET_STORAGE_OK);
+    assert(result.size == SECRET_STORAGE_VALUE_MAX_SIZE);
+    fixture.storage.free(&fixture.firstContext, &result);
+}
+
+void test_fail_closed_owner_and_detach() {
+    Fixture fixture;
+    const char value[] = "owned";
+    assert(fixture.storage.put(&fixture.firstContext, "owner", value, 5) == SECRET_STORAGE_OK);
+    ResourceBuffer buffer = RESOURCE_BUFFER_INIT;
+    assert(fixture.storage.get(&fixture.firstContext, "owner", &buffer) == SECRET_STORAGE_OK);
+    void* allocation = buffer.data;
+    fixture.storage.free(&fixture.secondContext, &buffer);
+    assert(buffer.data == allocation && buffer.size == 5);
+    buffer.size = 0;
+    fixture.storage.free(&fixture.firstContext, &buffer);
+    assert(buffer.data == nullptr && buffer.size == 0);
+
+    assert(fixture.storage.get(&fixture.firstContext, "owner", &buffer) == SECRET_STORAGE_OK);
+    buffer.size = SECRET_STORAGE_VALUE_MAX_SIZE + 1;
+    fixture.storage.free(&fixture.firstContext, &buffer);
+    assert(buffer.data == nullptr && buffer.size == 0);
+
+    assert(fixture.storage.get(&fixture.firstContext, "owner", &buffer) == SECRET_STORAGE_OK);
+    allocation = buffer.data;
+    fixture.storage.modDetached(&fixture.firstContext);
+    assert(buffer.data == allocation);  // Detach reclaimed and wiped the owned allocation.
+    fixture.storage.free(&fixture.firstContext, &buffer);
+    assert(buffer.data == allocation);  // It is no longer an owned buffer.
+
+    ResourceBuffer failed = {.struct_size = sizeof(ResourceBuffer), .data = allocation, .size = 5};
+    fixture.backend->nextGet = SECRET_STORAGE_IO_ERROR;
+    fixture.backend->errorPayload = {1, 2, 3};
+    assert(fixture.storage.get(&fixture.firstContext, "owner", &failed) == SECRET_STORAGE_IO_ERROR);
+    assert(failed.data == nullptr && failed.size == 0);
+}
+
+class UnavailableBackend final : public SecretStorageBackend {
+public:
+    SecretStorageResult get(std::string_view, std::string_view, std::vector<uint8_t>&) override {
+        return SECRET_STORAGE_UNAVAILABLE;
+    }
+    SecretStorageResult put(std::string_view, std::string_view, const uint8_t*, size_t) override {
+        return SECRET_STORAGE_UNAVAILABLE;
+    }
+    SecretStorageResult remove(std::string_view, std::string_view) override {
+        return SECRET_STORAGE_UNAVAILABLE;
+    }
+};
+
+void test_unavailable_backend() {
+    TestMod mod{"com.example"};
+    ModContext context{&mod};
+    SecretStorageCore storage([](ModContext* item) { return std::string_view(item->mod->id); },
+        std::make_unique<UnavailableBackend>());
+    ResourceBuffer out = RESOURCE_BUFFER_INIT;
+    assert(storage.get(&context, "key", &out) == SECRET_STORAGE_UNAVAILABLE);
+    assert(storage.put(&context, "key", nullptr, 0) == SECRET_STORAGE_UNAVAILABLE);
+    assert(storage.remove(&context, "key") == SECRET_STORAGE_UNAVAILABLE);
+}
+
+}  // namespace
+
+int main() {
+    test_abi_table_and_validation();
+    test_bounds_empty_and_copy();
+    test_fail_closed_owner_and_detach();
+    test_unavailable_backend();
+    return 0;
+}

--- a/tests/hostservices/test_secret_storage_android_source.py
+++ b/tests/hostservices/test_secret_storage_android_source.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Offline source audit for Android-only storage and JNI fail-closed boundaries."""
+
+import pathlib
+
+
+def main() -> int:
+    root = pathlib.Path(__file__).parents[2]
+    source = (root / "platforms/android/app/src/main/java/com/twilitrealm/dusk/DuskSecretStore.java").read_text(
+            encoding="utf-8")
+    required = (
+        "new AtomicFile(base)",
+        "atomic.openRead()",
+        "requireRegularOrAbsent(backup)",
+        "if (!base.exists() && !backup.exists())",
+        "store.deleteEntry(alias)",
+        "store.containsAlias(alias)",
+    )
+    assert all(marker in source for marker in required)
+    native = (root / "src/dusk/mods/svc/secret_storage_android.cpp").read_text(encoding="utf-8")
+    assert "== nullptr || clear_exception(env)" not in native
+    assert "!= nullptr && clear_exception(env)" not in native
+    assert "const bool allocationFailed = clear_exception(env);" in native
+    assert "const bool callFailed = clear_exception(env);" in native
+    assert "wipe_java_bytes(env, payload);" in native
+    assert """if (copyFailed) {
+            wipe_java_bytes(env, result);
+            env->DeleteLocalRef(result);""" in native
+    assert """if (bytesValue != nullptr) {
+                wipe_java_bytes(env, bytesValue);
+                env->DeleteLocalRef(bytesValue);""" in native
+    assert """if (payloadFailed) {
+            if (payload != nullptr) {
+                wipe_java_bytes(env, payload);
+                env->DeleteLocalRef(payload);
+            }
+            env->DeleteLocalRef(resultClass);
+            env->DeleteLocalRef(result);
+            return SECRET_STORAGE_UNAVAILABLE;""" in native
+    assert """if (code != SECRET_STORAGE_OK && payload != nullptr) {
+            wipe_java_bytes(env, payload);
+            env->DeleteLocalRef(payload);
+            env->DeleteLocalRef(resultClass);
+            env->DeleteLocalRef(result);
+            return code;""" in native
+    assert '"put", "(Landroid/content/Context;[B[B[B)I"' in native
+    assert "activity, mod, keyBytes, bytesValue" in native
+    assert '"remove", "(Landroid/content/Context;[B[B)I"' in native
+    assert "activity, mod, keyBytes);" in native
+    assert not list((root / "platforms/android/app/src/debug").rglob("*Bootstrap*"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a generic per-mod secret-storage service ABI
- use Android Keystore AES-256-GCM with authenticated, atomically persisted metadata
- isolate records by application ID, mod ID, and key
- wipe native and Java byte buffers across success, failure, free, and mod detach
- return `UNAVAILABLE` on platforms without a secure backend

## API

`SecretStorageService@1.0` provides `get`, `put`, `remove`, and owner-checked
`free`. Keys are limited to 128 bytes and values to 64 KiB. The host derives
the namespace from the calling `ModContext`; mods cannot choose another mod's
namespace.

## Validation

- focused C ABI and linked C++ core tests: passed
- Java crypto/state-machine assertion tests: passed
- Android source-contract scan: passed
- AddressSanitizer + UndefinedBehaviorSanitizer: passed
- ThreadSanitizer: passed
- official `android-arm64` CMake/Ninja preset: passed, including final `libmain.so`
- Gradle `:app:compileDebugJavaWithJavac`: passed
- `git diff --check`
- independent Luna Max review: PASS
