### PR TITLE
Add Aiming Reticle for Bow and Slingshot

### DIFF
--- a/src/d/actor/d_a_alink_bow.inc
+++ b/src/d/actor/d_a_alink_bow.inc
@@ -551,7 +551,7 @@ void daAlink_c::setBowSight() {
         getArrowFlyData(&dist, &speed, TRUE);
         checkSightLine(dist, &sight_pos);
         mSight.setPos(&sight_pos);
-        mSight.offDrawFlg();
+        mSight.onDrawFlg();
     } else {
         mSight.offDrawFlg();
     }

--- a/src/d/actor/d_a_alink_bow.inc
+++ b/src/d/actor/d_a_alink_bow.inc
@@ -543,18 +543,7 @@ void daAlink_c::setBowNormalAnime() {
 }
 
 void daAlink_c::setBowSight() {
-#if TARGET_PC
-    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000) && dusk::getSettings().game.aimingReticle) {
-        cXyz sight_pos;
-        f32 dist;
-        f32 speed;
-
-        getArrowFlyData(&dist, &speed, TRUE);
-        checkSightLine(dist, &sight_pos);
-        mSight.setPos(&sight_pos);
-        mSight.onDrawFlg();
-#else
-    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000)) {
+    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000) IF_DUSK(&& dusk::getSettings().game.aimingReticle)) {
         cXyz sight_pos;
         f32 dist;
         f32 speed;
@@ -563,7 +552,7 @@ void daAlink_c::setBowSight() {
         checkSightLine(dist, &sight_pos);
         mSight.setPos(&sight_pos);
         mSight.offDrawFlg();
-#endif
+        IF_DUSK(mSight.onDrawFlg());
     } else {
         mSight.offDrawFlg();
     }

--- a/src/d/actor/d_a_alink_bow.inc
+++ b/src/d/actor/d_a_alink_bow.inc
@@ -553,16 +553,6 @@ void daAlink_c::setBowSight() {
         checkSightLine(dist, &sight_pos);
         mSight.setPos(&sight_pos);
         mSight.onDrawFlg();
-    }
-    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000) && !dusk::getSettings().game.aimingReticle) {
-        cXyz sight_pos;
-        f32 dist;
-        f32 speed;
-
-        getArrowFlyData(&dist, &speed, TRUE);
-        checkSightLine(dist, &sight_pos);
-        mSight.setPos(&sight_pos);
-        mSight.offDrawFlg();
 #else
     if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000)) {
         cXyz sight_pos;

--- a/src/d/actor/d_a_alink_bow.inc
+++ b/src/d/actor/d_a_alink_bow.inc
@@ -543,7 +543,7 @@ void daAlink_c::setBowNormalAnime() {
 }
 
 void daAlink_c::setBowSight() {
-    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000) IF_DUSK(&& dusk::getSettings().game.aimingReticle)) {
+    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000)) {
         cXyz sight_pos;
         f32 dist;
         f32 speed;
@@ -552,7 +552,7 @@ void daAlink_c::setBowSight() {
         checkSightLine(dist, &sight_pos);
         mSight.setPos(&sight_pos);
         mSight.offDrawFlg();
-        IF_DUSK(mSight.onDrawFlg());
+        DUSK_IF_ELSE(dusk::getSettings().game.aimingReticle ? mSight.onDrawFlg() : mSight.offDrawFlg(), mSight.offDrawFlg());
     } else {
         mSight.offDrawFlg();
     }

--- a/src/d/actor/d_a_alink_bow.inc
+++ b/src/d/actor/d_a_alink_bow.inc
@@ -543,7 +543,8 @@ void daAlink_c::setBowNormalAnime() {
 }
 
 void daAlink_c::setBowSight() {
-    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000)) {
+#if TARGET_PC
+    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000) && dusk::getSettings().game.aimingReticle) {
         cXyz sight_pos;
         f32 dist;
         f32 speed;
@@ -552,6 +553,27 @@ void daAlink_c::setBowSight() {
         checkSightLine(dist, &sight_pos);
         mSight.setPos(&sight_pos);
         mSight.onDrawFlg();
+    } 
+    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000)) {
+        cXyz sight_pos;
+        f32 dist;
+        f32 speed;
+
+        getArrowFlyData(&dist, &speed, TRUE);
+        checkSightLine(dist, &sight_pos);
+        mSight.setPos(&sight_pos);
+        mSight.offDrawFlg();
+#else
+    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000)) {
+        cXyz sight_pos;
+        f32 dist;
+        f32 speed;
+
+        getArrowFlyData(&dist, &speed, TRUE);
+        checkSightLine(dist, &sight_pos);
+        mSight.setPos(&sight_pos);
+        mSight.offDrawFlg();
+#endif
     } else {
         mSight.offDrawFlg();
     }

--- a/src/d/actor/d_a_alink_bow.inc
+++ b/src/d/actor/d_a_alink_bow.inc
@@ -551,7 +551,6 @@ void daAlink_c::setBowSight() {
         getArrowFlyData(&dist, &speed, TRUE);
         checkSightLine(dist, &sight_pos);
         mSight.setPos(&sight_pos);
-        mSight.offDrawFlg();
         DUSK_IF_ELSE(dusk::getSettings().game.aimingReticle ? mSight.onDrawFlg() : mSight.offDrawFlg(), mSight.offDrawFlg());
     } else {
         mSight.offDrawFlg();

--- a/src/d/actor/d_a_alink_bow.inc
+++ b/src/d/actor/d_a_alink_bow.inc
@@ -553,8 +553,8 @@ void daAlink_c::setBowSight() {
         checkSightLine(dist, &sight_pos);
         mSight.setPos(&sight_pos);
         mSight.onDrawFlg();
-    } 
-    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000)) {
+    }
+    if (checkBowChargeWaitAnime() && !dComIfGp_checkPlayerStatus0(0, 0x200000) && !dusk::getSettings().game.aimingReticle) {
         cXyz sight_pos;
         f32 dist;
         f32 speed;

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -51,6 +51,7 @@ UserSettings g_userSettings = {
         .sunsSong {"game.sunsSong", false},
         .autoSave {"game.autoSave", false},
         .enhancedMapMenus {"game.enhancedMapMenus", false},
+        .aimingReticle {"game.aimingReticle", false},
 
         // Preferences
         .enableMirrorMode {"game.enableMirrorMode", false},

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -256,6 +256,7 @@ void registerSettings() {
     Register(g_userSettings.game.sunsSong);
     Register(g_userSettings.game.autoSave);
     Register(g_userSettings.game.enhancedMapMenus);
+    Register(g_userSettings.game.aimingReticle);
     Register(g_userSettings.game.enableMirrorMode);
     Register(g_userSettings.game.invertCameraXAxis);
     Register(g_userSettings.game.invertCameraYAxis);

--- a/src/dusk/settings.h
+++ b/src/dusk/settings.h
@@ -183,6 +183,7 @@ struct UserSettings {
         ConfigVar<bool> sunsSong;
         ConfigVar<bool> autoSave;
         ConfigVar<bool> enhancedMapMenus;
+        ConfigVar<bool> aimingReticle;
 
         // Preferences
         ConfigVar<bool> enableMirrorMode;

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1225,6 +1225,8 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             "Allows Wolf Link to howl and change the time of day.");
         addOption("Quick Transform (R+Y)", getSettings().game.enableQuickTransform,
             "Transform instantly by pressing R and Y simultaneously.");
+        addOption("Aiming Reticle", getSettings().game.aimingReticle,
+            "Shows an aiming reticle for bow and slingshot."
 
         leftPane.add_section("Speedrunning");
         config_bool_select(leftPane, rightPane, getSettings().game.speedrunMode,

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1226,7 +1226,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
         addOption("Quick Transform (R+Y)", getSettings().game.enableQuickTransform,
             "Transform instantly by pressing R and Y simultaneously.");
         addOption("Aiming Reticle", getSettings().game.aimingReticle,
-            "Shows an aiming reticle for bow and slingshot."
+            "Shows an aiming reticle for bow and slingshot.");
 
         leftPane.add_section("Speedrunning");
         config_bool_select(leftPane, rightPane, getSettings().game.speedrunMode,

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1226,7 +1226,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
         addOption("Quick Transform (R+Y)", getSettings().game.enableQuickTransform,
             "Transform instantly by pressing R and Y simultaneously.");
         addOption("Aiming Reticle", getSettings().game.aimingReticle,
-            "Shows an aiming reticle for bow and slingshot.");
+            "Shows the aiming reticle for bow and slingshot.");
 
         leftPane.add_section("Speedrunning");
         config_bool_select(leftPane, rightPane, getSettings().game.speedrunMode,


### PR DESCRIPTION
Adds an aiming reticle to first-person for bow and slingshot. Utilizes code that was already present, just disabled.

Closes #2186.