### PR TITLE
request presentation sync for pause and map captures

### DIFF
--- a/src/d/d_menu_window.cpp
+++ b/src/d/d_menu_window.cpp
@@ -123,7 +123,13 @@ public:
 #endif
     }
 
-    void setCaptureFlag() { mFlag = 1; }
+    void setCaptureFlag() {
+        mFlag = 1;
+    #ifdef TARGET_PC
+        dusk::frame_interp::request_presentation_sync();
+    #endif
+    }
+
     bool checkDraw() { return mFlag; }
     u8 getAlpha() { return mAlpha; }
     u8 getTopFlag() { return mTopFlag; }
@@ -1092,10 +1098,6 @@ void dMw_c::dMw_ring_create(u8 i_origin) {
     }
 
     mpCapture->setCaptureFlag();
-
-#ifdef TARGET_PC
-    dusk::frame_interp::request_presentation_sync();
-#endif
 }
 
 bool dMw_c::dMw_ring_delete() {


### PR DESCRIPTION
expands on #1447 so when interpolation is on, the pause screen, map and item wheel all show the correct freeze frame, helpful for alternate back in time methods that dont use item wheel