### PR TITLE
Add support for playing Dusklight using Wii disc images

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -68,13 +68,18 @@ body:
     required: true
 
 - type: dropdown
-  id: game-region
+  id: game-disc
   attributes:
-    label: Game Region
-    description: The game region you are playing on
+    label: Game Disc
+    description: The game disc you are playing on
     options:
-    - NTSC-U (North America)
-    - PAL (Europe)
+    - GameCube NTSC-U (North America)
+    - GameCube PAL (Europe)
+    - GameCube NTSC-J (Japan)
+    - Wii NTSC-U (North America) Revision 0
+    - Wii NTSC-U (North America) Revision 2
+    - Wii PAL (Europe)
+    - Wii NTSC-J (Japan)
   validations:
     required: true
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ It aims to be as accurate as possible to the original while also providing new o
 
 You must dump your own copy of the game. Please see [this article](https://wiki.dolphin-emu.org/index.php?title=Ripping_Games) for instructions. After dumping, you can use a program like [Dolphin](https://dolphin-emu.org/) or [nodtool](https://github.com/encounter/nod/releases) to convert the `.iso` to `.rvz` to save space.
 
-Currently, only the GameCube releases are supported. Support for other versions of the game is planned in the future.
+Dusklight currently supports all commercial discs except for Wii's Korean release.
+
+> [!NOTE]
+> Dusklight is based on the [Twilight Princess decompilation](https://github.com/zeldaret/tp), which is currently only matching for GameCube. As a result, even when playing Dusklight with a Wii disc, you will be presented with the GameCube version's HUD and certain other specificities.
 
 ### 2. Install Dusklight
 

--- a/docs/ios-install-altstore.md
+++ b/docs/ios-install-altstore.md
@@ -5,7 +5,13 @@
 - A Windows, Linux, or macOS device 
 - iOS device connected to computer via USB 
 - Dusklight IPA file (download the latest `Dusklight-vX.X.X-ios-arm64.ipa` from the [releases page](https://github.com/TwilitRealm/dusklight/releases))
-- Legally acquired game disc - `GZ2E01` (Gamecube USA) or `GZ2PE01` (Gamecube PAL)
+- Legally acquired game disc:
+  - `GZ2E01` (GameCube USA)
+  - `GZ2P01` (GameCube PAL)
+  - `GZ2J01` (GameCube JPN)
+  - `RZDE01` (Wii USA Rev. 0 *or* Rev. 2)
+  - `RZDP01` (Wii PAL)
+  - `RZDJ01` (Wii JPN)
 
 ## 1. Install iloader
 

--- a/files.cmake
+++ b/files.cmake
@@ -1457,6 +1457,8 @@ set(DUSK_FILES
         src/dusk/imgui/ImGuiStubLog.cpp
         src/dusk/io.cpp
         src/dusk/iso_validate.cpp
+        src/dusk/language.cpp
+        src/dusk/language.hpp
         src/dusk/layout.cpp
         src/dusk/livesplit.cpp
         src/dusk/logging.cpp

--- a/libs/JSystem/src/JUtility/JUTResFont.cpp
+++ b/libs/JSystem/src/JUtility/JUTResFont.cpp
@@ -71,7 +71,7 @@ void JUTResFont::initJoinedTexture() {
     int pageCount = 0;
     u32 pageNumCells = block.numRows * block.numColumns;
 
-    if (dusk::version::getGameVersion() == dusk::version::GameVersion::GcnJpn) {
+    if (dusk::version::isRegionJpn()) {
         pageCount = 1;
         if (pageNumCells > 0 && block.endCode > block.startCode) {
             pageCount = (block.endCode - block.startCode + pageNumCells - 1) / pageNumCells;

--- a/src/Z2AudioLib/Z2SeqMgr.cpp
+++ b/src/Z2AudioLib/Z2SeqMgr.cpp
@@ -11,7 +11,10 @@
 #include "Z2AudioLib/SpotName.h"
 #include "os_report.h"
 
+#if TARGET_PC
 #include "dusk/audio.h"
+#include "dusk/version.hpp"
+#endif
 
 Z2SeqMgr::Z2SeqMgr() : JASGlobalInstance<Z2SeqMgr>(true) {
     mMainBgmMaster.forceIn();
@@ -584,7 +587,7 @@ void Z2SeqMgr::bgmStreamPlay() {
     }
 
     #if !PLATFORM_SHIELD
-    else if (getStreamBgmID() == 0x2000000) {
+    else if (getStreamBgmID() == 0x2000000 IF_DUSK(&& dusk::version::isGcn())) {
         if (mStreamBgmHandle) {
             mStreamBgmHandle->stop();
         }

--- a/src/d/actor/d_a_mant.cpp
+++ b/src/d/actor/d_a_mant.cpp
@@ -15,12 +15,77 @@
 #include "dusk/dvd_asset.hpp"
 #include "dusk/frame_interpolation.h"
 
-using GameVersion = dusk::version::GameVersion;
+using namespace dusk::version;
+
+#define MANT_REL_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/rel/Final/Release/d_a_mant.rel"}, {GameVersion::GcnPal, "/rel/Final/Release/d_a_mant.rel"}, {GameVersion::GcnJpn, "/rel/Final/Release/d_a_mant.rel"}}, "/rel/Rfinal/Release/d_a_mant.rel")
 
 // keep the original version of the cape texture const so we don't need to reload the file
-static u8 const * l_Egnd_mantTEX_get()   { alignas(32) static u8 buf[0x4000]; static bool _ = (dusk::LoadRelAsset(buf, "/rel/Final/Release/d_a_mant.rel", {{GameVersion::GcnUsa, 0x1C00}, {GameVersion::GcnPal, 0x1C00}, {GameVersion::GcnJpn, 0x1C00}}, 0x4000), true); return buf; }
-static u8* l_Egnd_mantTEX_U_get() { alignas(32) static u8 buf[0x4000]; static bool _ = (dusk::LoadRelAsset(buf, "/rel/Final/Release/d_a_mant.rel", {{GameVersion::GcnUsa, 0x5C00}, {GameVersion::GcnPal, 0x5C00}, {GameVersion::GcnJpn, 0x5C00}}, 0x4000), true); return buf; }
-static u8* l_Egnd_mantPAL_get()   { alignas(32) static u8 buf[0x60];   static bool _ = (dusk::LoadRelAsset(buf, "/rel/Final/Release/d_a_mant.rel", {{GameVersion::GcnUsa, 0x9C00}, {GameVersion::GcnPal, 0x9C00}, {GameVersion::GcnJpn, 0x9C00}}, 0x60),   true); return buf; }
+static u8 const* l_Egnd_mantTEX_get() {
+    alignas(32) static u8 buf[0x4000];
+    static bool _ = (
+        dusk::LoadRelAsset(
+            buf,
+            MANT_REL_PATH,
+            {
+            {GameVersion::GcnUsa,     0x1C00},
+            {GameVersion::GcnPal,     0x1C00},
+            {GameVersion::GcnJpn,     0x1C00},
+            {GameVersion::WiiUsaRev0, 0x1B00},
+            {GameVersion::WiiUsa,     0x1900},
+            {GameVersion::WiiPal,     0x1900},
+            {GameVersion::WiiJpn,     0x1900}
+            },
+            0x4000
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_Egnd_mantTEX_U_get() {
+    alignas(32) static u8 buf[0x4000];
+    static bool _ = (
+        dusk::LoadRelAsset(
+            buf,
+            MANT_REL_PATH,
+            {
+            {GameVersion::GcnUsa,     0x5C00},
+            {GameVersion::GcnPal,     0x5C00},
+            {GameVersion::GcnJpn,     0x5C00},
+            {GameVersion::WiiUsaRev0, 0x5B00},
+            {GameVersion::WiiUsa,     0x5900},
+            {GameVersion::WiiPal,     0x5900},
+            {GameVersion::WiiJpn,     0x5900}
+            },
+            0x4000
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_Egnd_mantPAL_get() {
+    alignas(32) static u8 buf[0x60];
+    static bool _ = (
+        dusk::LoadRelAsset(
+            buf,
+            MANT_REL_PATH,
+            {
+            {GameVersion::GcnUsa,     0x9C00},
+            {GameVersion::GcnPal,     0x9C00},
+            {GameVersion::GcnJpn,     0x9C00},
+            {GameVersion::WiiUsaRev0, 0x9B00},
+            {GameVersion::WiiUsa,     0x9900},
+            {GameVersion::WiiPal,     0x9900},
+            {GameVersion::WiiJpn,     0x9900}
+            },
+            0x60
+        ),
+        true
+    );
+    return buf;
+}
+
 #define l_Egnd_mantTEX   (l_Egnd_mantTEX_get())
 #define l_Egnd_mantTEX_U (l_Egnd_mantTEX_U_get())
 #define l_Egnd_mantPAL   (l_Egnd_mantPAL_get())
@@ -35,9 +100,64 @@ static TGXTexObj mainTexObj;
 static TGXTexObj undersideTexObj;
 
 // l_pos is unused
-//static f32* l_pos_get()      { alignas(32) static f32 buf[507];   static bool _ = (dusk::LoadRelAsset(buf, "/rel/Final/Release/d_a_mant.rel", {{GameVersion::GcnUsa, 0xA44C}, {GameVersion::GcnPal, 0xA44C}}, sizeof(buf)),   true); return buf; }
-static f32* l_normal_get()   { alignas(32) static f32 buf[3];   static bool _ = (dusk::LoadRelAsset(buf, "/rel/Final/Release/d_a_mant.rel", {{GameVersion::GcnUsa, 0x9C60}, {GameVersion::GcnPal, 0x9C60}, {GameVersion::GcnJpn, 0x9C60}}, sizeof(buf)),   true); return buf; }
-static f32* l_texCoord_get() { alignas(32) static f32 buf[338];   static bool _ = (dusk::LoadRelAsset(buf, "/rel/Final/Release/d_a_mant.rel", {{GameVersion::GcnUsa, 0xA458}, {GameVersion::GcnPal, 0xA458}, {GameVersion::GcnJpn, 0xA458}}, sizeof(buf)),   true); return buf; }
+// static f32* l_pos_get() {
+//     alignas(32) static f32 buf[507];
+//     static bool _ = (
+//         dusk::LoadRelAsset(
+//             buf,
+//             MANT_REL_PATH,
+//             {
+//             {GameVersion::GcnUsa, 0x9C60},
+//             {GameVersion::GcnPal, 0x9C60}
+//             },
+//             sizeof(buf)
+//         ),
+//         true
+//     );
+//     return buf;
+// }
+
+// I think l_normal doesn't exist on Wii
+static f32* l_normal_get() {
+    alignas(32) static f32 buf[3];
+    static bool _ = (
+        dusk::LoadRelAsset(
+            buf,
+            MANT_REL_PATH,
+            {
+            {GameVersion::GcnUsa, 0xA44C},
+            {GameVersion::GcnPal, 0xA44C},
+            {GameVersion::GcnJpn, 0xA44C}
+            },
+            sizeof(buf)
+        ),
+        true
+    );
+    return buf;
+}
+
+static f32* l_texCoord_get() {
+    alignas(32) static f32 buf[338];
+    static bool _ = (
+        dusk::LoadRelAsset(
+            buf,
+            MANT_REL_PATH,
+            {
+            {GameVersion::GcnUsa,     0xA458},
+            {GameVersion::GcnPal,     0xA458},
+            {GameVersion::GcnJpn,     0xA458},
+            {GameVersion::WiiUsaRev0, 0x9B60},
+            {GameVersion::WiiUsa,     0x9960},
+            {GameVersion::WiiPal,     0x9960},
+            {GameVersion::WiiJpn,     0x9960}
+            },
+            sizeof(buf)
+        ),
+        true
+    );
+    return buf;
+}
+
 //#define l_pos      (l_pos_get())
 #define l_normal   (l_normal_get())
 #define l_texCoord (l_texCoord_get())
@@ -55,7 +175,28 @@ static bool l_Egnd_mantTEX_hasReplacement = false;
 #if TARGET_PC
 using GameVersion = dusk::version::GameVersion;
 
-static u8* l_Egnd_mantDL_get() { alignas(32) static u8 buf[0x3EC]; static bool _ = (dusk::LoadRelAsset(buf, "/rel/Final/Release/d_a_mant.rel", {{GameVersion::GcnUsa, 0xA9A0}, {GameVersion::GcnPal, 0xA9A0}, {GameVersion::GcnJpn, 0xA9A0}}, 0x3EC), true); return buf; }
+static u8* l_Egnd_mantDL_get() {
+    alignas(32) static u8 buf[0x3EC];
+    static bool _ = (
+        dusk::LoadRelAsset(
+            buf,
+            MANT_REL_PATH,
+            {
+            {GameVersion::GcnUsa,     0xA9A0},
+            {GameVersion::GcnPal,     0xA9A0},
+            {GameVersion::GcnJpn,     0xA9A0},
+            {GameVersion::WiiUsaRev0, 0xA0C0},
+            {GameVersion::WiiUsa,     0x9EC0},
+            {GameVersion::WiiPal,     0x9EC0},
+            {GameVersion::WiiJpn,     0x9EC0}
+            },
+            0x3EC
+        ),
+        true
+    );
+    return buf;
+}
+
 #define l_Egnd_mantDL (l_Egnd_mantDL_get())
 #else
 #include "assets/l_Egnd_mantDL.h"

--- a/src/d/actor/d_a_mant.cpp
+++ b/src/d/actor/d_a_mant.cpp
@@ -15,76 +15,49 @@
 #include "dusk/dvd_asset.hpp"
 #include "dusk/frame_interpolation.h"
 
+#include <type_traits>
+
 using namespace dusk::version;
 
 #define MANT_REL_PATH platformSelect<const char*>("/rel/Final/Release/d_a_mant.rel", "/rel/Rfinal/Release/d_a_mant.rel")
 
+#define DEFINE_MANT_ASSET(name, type, count, ...)                                                  \
+    static type* name##_get() {                                                                    \
+        alignas(32) static std::remove_cv_t<type> buf[count];                                      \
+        static bool _ = (dusk::LoadRelAsset(buf, MANT_REL_PATH, __VA_ARGS__), true);               \
+        return buf;                                                                                \
+    }
+
 // keep the original version of the cape texture const so we don't need to reload the file
-static u8 const* l_Egnd_mantTEX_get() {
-    alignas(32) static u8 buf[0x4000];
-    static bool _ = (
-        dusk::LoadRelAsset(
-            buf,
-            MANT_REL_PATH,
-            {
-            {GameVersion::GcnUsa,     0x1C00},
-            {GameVersion::GcnPal,     0x1C00},
-            {GameVersion::GcnJpn,     0x1C00},
-            {GameVersion::WiiUsaRev0, 0x1B00},
-            {GameVersion::WiiUsa,     0x1900},
-            {GameVersion::WiiPal,     0x1900},
-            {GameVersion::WiiJpn,     0x1900}
-            },
-            0x4000
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_MANT_ASSET(l_Egnd_mantTEX, u8 const, 0x4000, {
+    {GameVersion::GcnUsa,     0x1C00},
+    {GameVersion::GcnPal,     0x1C00},
+    {GameVersion::GcnJpn,     0x1C00},
+    {GameVersion::WiiUsaRev0, 0x1B00},
+    {GameVersion::WiiUsa,     0x1900},
+    {GameVersion::WiiPal,     0x1900},
+    {GameVersion::WiiJpn,     0x1900},
+});
 
-static u8* l_Egnd_mantTEX_U_get() {
-    alignas(32) static u8 buf[0x4000];
-    static bool _ = (
-        dusk::LoadRelAsset(
-            buf,
-            MANT_REL_PATH,
-            {
-            {GameVersion::GcnUsa,     0x5C00},
-            {GameVersion::GcnPal,     0x5C00},
-            {GameVersion::GcnJpn,     0x5C00},
-            {GameVersion::WiiUsaRev0, 0x5B00},
-            {GameVersion::WiiUsa,     0x5900},
-            {GameVersion::WiiPal,     0x5900},
-            {GameVersion::WiiJpn,     0x5900}
-            },
-            0x4000
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_MANT_ASSET(l_Egnd_mantTEX_U, u8, 0x4000, {
+    {GameVersion::GcnUsa,     0x5C00},
+    {GameVersion::GcnPal,     0x5C00},
+    {GameVersion::GcnJpn,     0x5C00},
+    {GameVersion::WiiUsaRev0, 0x5B00},
+    {GameVersion::WiiUsa,     0x5900},
+    {GameVersion::WiiPal,     0x5900},
+    {GameVersion::WiiJpn,     0x5900},
+});
 
-static u8* l_Egnd_mantPAL_get() {
-    alignas(32) static u8 buf[0x60];
-    static bool _ = (
-        dusk::LoadRelAsset(
-            buf,
-            MANT_REL_PATH,
-            {
-            {GameVersion::GcnUsa,     0x9C00},
-            {GameVersion::GcnPal,     0x9C00},
-            {GameVersion::GcnJpn,     0x9C00},
-            {GameVersion::WiiUsaRev0, 0x9B00},
-            {GameVersion::WiiUsa,     0x9900},
-            {GameVersion::WiiPal,     0x9900},
-            {GameVersion::WiiJpn,     0x9900}
-            },
-            0x60
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_MANT_ASSET(l_Egnd_mantPAL, u8, 0x60, {
+    {GameVersion::GcnUsa,     0x9C00},
+    {GameVersion::GcnPal,     0x9C00},
+    {GameVersion::GcnJpn,     0x9C00},
+    {GameVersion::WiiUsaRev0, 0x9B00},
+    {GameVersion::WiiUsa,     0x9900},
+    {GameVersion::WiiPal,     0x9900},
+    {GameVersion::WiiJpn,     0x9900},
+});
 
 #define l_Egnd_mantTEX   (l_Egnd_mantTEX_get())
 #define l_Egnd_mantTEX_U (l_Egnd_mantTEX_U_get())
@@ -100,69 +73,45 @@ static TGXTexObj mainTexObj;
 static TGXTexObj undersideTexObj;
 
 // l_pos is unused
-// static f32* l_pos_get() {
-//     alignas(32) static f32 buf[507];
-//     static bool _ = (
-//         dusk::LoadRelAsset(
-//             buf,
-//             MANT_REL_PATH,
-//             {
-//             {GameVersion::GcnUsa, 0x9C60},
-//             {GameVersion::GcnPal, 0x9C60}
-//             },
-//             sizeof(buf)
-//         ),
-//         true
-//     );
-//     return buf;
-// }
+// DEFINE_MANT_ASSET(l_pos, f32, 507, {
+//     {GameVersion::GcnUsa, 0x9C60},
+//     {GameVersion::GcnPal, 0x9C60},
+// });
 
 // I think l_normal doesn't exist on Wii
-static f32* l_normal_get() {
-    alignas(32) static f32 buf[3];
-    static bool _ = (
-        dusk::LoadRelAsset(
-            buf,
-            MANT_REL_PATH,
-            {
-            {GameVersion::GcnUsa, 0xA44C},
-            {GameVersion::GcnPal, 0xA44C},
-            {GameVersion::GcnJpn, 0xA44C}
-            },
-            sizeof(buf)
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_MANT_ASSET(l_normal, f32, 3, {
+    {GameVersion::GcnUsa, 0xA44C},
+    {GameVersion::GcnPal, 0xA44C},
+    {GameVersion::GcnJpn, 0xA44C},
+});
 
-static f32* l_texCoord_get() {
-    alignas(32) static f32 buf[338];
-    static bool _ = (
-        dusk::LoadRelAsset(
-            buf,
-            MANT_REL_PATH,
-            {
-            {GameVersion::GcnUsa,     0xA458},
-            {GameVersion::GcnPal,     0xA458},
-            {GameVersion::GcnJpn,     0xA458},
-            {GameVersion::WiiUsaRev0, 0x9B60},
-            {GameVersion::WiiUsa,     0x9960},
-            {GameVersion::WiiPal,     0x9960},
-            {GameVersion::WiiJpn,     0x9960}
-            },
-            sizeof(buf)
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_MANT_ASSET(l_texCoord, f32, 338, {
+    {GameVersion::GcnUsa,     0xA458},
+    {GameVersion::GcnPal,     0xA458},
+    {GameVersion::GcnJpn,     0xA458},
+    {GameVersion::WiiUsaRev0, 0x9B60},
+    {GameVersion::WiiUsa,     0x9960},
+    {GameVersion::WiiPal,     0x9960},
+    {GameVersion::WiiJpn,     0x9960},
+});
 
 //#define l_pos      (l_pos_get())
 #define l_normal   (l_normal_get())
 #define l_texCoord (l_texCoord_get())
 
 static bool l_Egnd_mantTEX_hasReplacement = false;
+
+DEFINE_MANT_ASSET(l_Egnd_mantDL, u8, 0x3EC, {
+    {GameVersion::GcnUsa,     0xA9A0},
+    {GameVersion::GcnPal,     0xA9A0},
+    {GameVersion::GcnJpn,     0xA9A0},
+    {GameVersion::WiiUsaRev0, 0xA0C0},
+    {GameVersion::WiiUsa,     0x9EC0},
+    {GameVersion::WiiPal,     0x9EC0},
+    {GameVersion::WiiJpn,     0x9EC0},
+});
+
+#define l_Egnd_mantDL (l_Egnd_mantDL_get())
 #else
 #include "assets/l_Egnd_mantTEX.h"
 
@@ -172,37 +121,9 @@ static bool l_Egnd_mantTEX_hasReplacement = false;
 #endif
 #include "d/d_s_play.h"
 
-#if TARGET_PC
-using GameVersion = dusk::version::GameVersion;
-
-static u8* l_Egnd_mantDL_get() {
-    alignas(32) static u8 buf[0x3EC];
-    static bool _ = (
-        dusk::LoadRelAsset(
-            buf,
-            MANT_REL_PATH,
-            {
-            {GameVersion::GcnUsa,     0xA9A0},
-            {GameVersion::GcnPal,     0xA9A0},
-            {GameVersion::GcnJpn,     0xA9A0},
-            {GameVersion::WiiUsaRev0, 0xA0C0},
-            {GameVersion::WiiUsa,     0x9EC0},
-            {GameVersion::WiiPal,     0x9EC0},
-            {GameVersion::WiiJpn,     0x9EC0}
-            },
-            0x3EC
-        ),
-        true
-    );
-    return buf;
-}
-
-#define l_Egnd_mantDL (l_Egnd_mantDL_get())
-#else
-#include "assets/l_Egnd_mantDL.h"
-#endif
-
 #if !TARGET_PC
+#include "assets/l_Egnd_mantDL.h"
+
 static void* pal_d = (void*)&l_Egnd_mantPAL;
 
 static void* tex_d[2] = {

--- a/src/d/actor/d_a_mant.cpp
+++ b/src/d/actor/d_a_mant.cpp
@@ -78,12 +78,7 @@ static TGXTexObj undersideTexObj;
 //     {GameVersion::GcnPal, 0x9C60},
 // });
 
-// I think l_normal doesn't exist on Wii
-DEFINE_MANT_ASSET(l_normal, f32, 3, {
-    {GameVersion::GcnUsa, 0xA44C},
-    {GameVersion::GcnPal, 0xA44C},
-    {GameVersion::GcnJpn, 0xA44C},
-});
+alignas(32) static f32 const l_normal[3] = {0.0f, 1.0f, 0.0f};
 
 DEFINE_MANT_ASSET(l_texCoord, f32, 338, {
     {GameVersion::GcnUsa,     0xA458},
@@ -95,8 +90,7 @@ DEFINE_MANT_ASSET(l_texCoord, f32, 338, {
     {GameVersion::WiiJpn,     0x9960},
 });
 
-//#define l_pos      (l_pos_get())
-#define l_normal   (l_normal_get())
+// #define l_pos      (l_pos_get())
 #define l_texCoord (l_texCoord_get())
 
 static bool l_Egnd_mantTEX_hasReplacement = false;

--- a/src/d/actor/d_a_mant.cpp
+++ b/src/d/actor/d_a_mant.cpp
@@ -17,7 +17,7 @@
 
 using namespace dusk::version;
 
-#define MANT_REL_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/rel/Final/Release/d_a_mant.rel"}, {GameVersion::GcnPal, "/rel/Final/Release/d_a_mant.rel"}, {GameVersion::GcnJpn, "/rel/Final/Release/d_a_mant.rel"}}, "/rel/Rfinal/Release/d_a_mant.rel")
+#define MANT_REL_PATH platformSelect<const char*>("/rel/Final/Release/d_a_mant.rel", "/rel/Rfinal/Release/d_a_mant.rel")
 
 // keep the original version of the cape texture const so we don't need to reload the file
 static u8 const* l_Egnd_mantTEX_get() {

--- a/src/d/actor/d_a_player.cpp
+++ b/src/d/actor/d_a_player.cpp
@@ -375,10 +375,14 @@ static const u8* l_sightDL_get() {
     static bool _ = (
         dusk::LoadDolAsset(
             buf,
-{
-            {GameVersion::GcnUsa, 0x803BA0C0},
-            {GameVersion::GcnPal, 0x803BBDA0},
-            {GameVersion::GcnJpn, 0x803B4220}
+            {
+            {GameVersion::GcnUsa,     0x803BA0C0},
+            {GameVersion::GcnPal,     0x803BBDA0},
+            {GameVersion::GcnJpn,     0x803B4220},
+            {GameVersion::WiiUsaRev0, 0x803F63C0},
+            {GameVersion::WiiUsa,     0x803E1640},
+            {GameVersion::WiiPal,     0x803E23A0},
+            {GameVersion::WiiJpn,     0x803DF600}
             },
             0x89
         ),

--- a/src/d/actor/d_a_title.cpp
+++ b/src/d/actor/d_a_title.cpp
@@ -52,7 +52,7 @@ static u8 const lit_3772[12] = {
 
 #if TARGET_PC
 using namespace dusk::version;
-#define l_arcName versionSelect<const char*>({{GameVersion::GcnPal, "TitlePal"}}, "Title")
+#define l_arcName regionSelect<const char*>("Title", "TitlePal", "Title")
 #elif VERSION == VERSION_GCN_PAL
 static char const l_arcName[] = "TitlePal";
 #else

--- a/src/d/actor/d_flower.inc
+++ b/src/d/actor/d_flower.inc
@@ -11,31 +11,15 @@ const u16 l_J_Ohana00_64TEX__width = 63;
 const u16 l_J_Ohana00_64TEX__height = 63;
 
 #if TARGET_PC
-#include "dusk/dvd_asset.hpp"
-using GameVersion = dusk::version::GameVersion;
-
-static u8* l_J_Ohana00_64TEX_get() {
-    static u8 buf[0x800];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x9060},
-            {GameVersion::GcnPal,     0x9060},
-            {GameVersion::GcnJpn,     0x9060},
-            {GameVersion::WiiUsaRev0, 0x7B60},
-            {GameVersion::WiiUsa,     0x7BC0},
-            {GameVersion::WiiPal,     0x7BC0},
-            {GameVersion::WiiJpn,     0x7BC0}
-            },
-            0x800
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_J_Ohana00_64TEX, u8, 0x800, {
+    {GameVersion::GcnUsa,     0x9060},
+    {GameVersion::GcnPal,     0x9060},
+    {GameVersion::GcnJpn,     0x9060},
+    {GameVersion::WiiUsaRev0, 0x7B60},
+    {GameVersion::WiiUsa,     0x7BC0},
+    {GameVersion::WiiPal,     0x7BC0},
+    {GameVersion::WiiJpn,     0x7BC0},
+});
 
 #define l_J_Ohana00_64TEX (l_J_Ohana00_64TEX_get())
 
@@ -138,99 +122,45 @@ static u8 l_flowerTexCoord[] = {
     0x3E, 0xA7, 0x72, 0xD6, 0xBD, 0x2F, 0x46, 0xAA};
 
 #if TARGET_PC
-using GameVersion = dusk::version::GameVersion;
+DEFINE_GRASS_ASSET(l_J_hana00DL, u8, 0x150, {
+    {GameVersion::GcnUsa,     0x9D20},
+    {GameVersion::GcnPal,     0x9D20},
+    {GameVersion::GcnJpn,     0x9D20},
+    {GameVersion::WiiUsaRev0, 0x8820},
+    {GameVersion::WiiUsa,     0x8880},
+    {GameVersion::WiiPal,     0x8880},
+    {GameVersion::WiiJpn,     0x8880},
+});
 
-static u8* l_J_hana00DL_get() {
-    static u8 buf[0x150];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x9D20},
-            {GameVersion::GcnPal,     0x9D20},
-            {GameVersion::GcnJpn,     0x9D20},
-            {GameVersion::WiiUsaRev0, 0x8820},
-            {GameVersion::WiiUsa,     0x8880},
-            {GameVersion::WiiPal,     0x8880},
-            {GameVersion::WiiJpn,     0x8880}
-            },
-            0x150
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_J_hana00_cDL, u8, 0xDE, {
+    {GameVersion::GcnUsa,     0x9E80},
+    {GameVersion::GcnPal,     0x9E80},
+    {GameVersion::GcnJpn,     0x9E80},
+    {GameVersion::WiiUsaRev0, 0x8980},
+    {GameVersion::WiiUsa,     0x89E0},
+    {GameVersion::WiiPal,     0x89E0},
+    {GameVersion::WiiJpn,     0x89E0},
+});
 
-static u8* l_J_hana00_cDL_get() {
-    static u8 buf[0xDE];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x9E80},
-            {GameVersion::GcnPal,     0x9E80},
-            {GameVersion::GcnJpn,     0x9E80},
-            {GameVersion::WiiUsaRev0, 0x8980},
-            {GameVersion::WiiUsa,     0x89E0},
-            {GameVersion::WiiPal,     0x89E0},
-            {GameVersion::WiiJpn,     0x89E0}
-            },
-            0xDE
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_matDL, u8, 0x99, {
+    {GameVersion::GcnUsa,     0x9F60},
+    {GameVersion::GcnPal,     0x9F60},
+    {GameVersion::GcnJpn,     0x9F60},
+    {GameVersion::WiiUsaRev0, 0x8A60},
+    {GameVersion::WiiUsa,     0x8AC0},
+    {GameVersion::WiiPal,     0x8AC0},
+    {GameVersion::WiiJpn,     0x8AC0},
+});
 
-static u8* l_matDL_get() {
-    static u8 buf[0x99];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x9F60},
-            {GameVersion::GcnPal,     0x9F60},
-            {GameVersion::GcnJpn,     0x9F60},
-            {GameVersion::WiiUsaRev0, 0x8A60},
-            {GameVersion::WiiUsa,     0x8AC0},
-            {GameVersion::WiiPal,     0x8AC0},
-            {GameVersion::WiiJpn,     0x8AC0}
-            },
-            0x99
-        ),
-        true
-    );
-    return buf;
-}
-
-static u8* l_matLight4DL_get() {
-    static u8 buf[0x99];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0xA000},
-            {GameVersion::GcnPal,     0xA000},
-            {GameVersion::GcnJpn,     0xA000},
-            {GameVersion::WiiUsaRev0, 0x8B00},
-            {GameVersion::WiiUsa,     0x8B60},
-            {GameVersion::WiiPal,     0x8B60},
-            {GameVersion::WiiJpn,     0x8B60}
-            },
-            0x99
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_matLight4DL, u8, 0x99, {
+    {GameVersion::GcnUsa,     0xA000},
+    {GameVersion::GcnPal,     0xA000},
+    {GameVersion::GcnJpn,     0xA000},
+    {GameVersion::WiiUsaRev0, 0x8B00},
+    {GameVersion::WiiUsa,     0x8B60},
+    {GameVersion::WiiPal,     0x8B60},
+    {GameVersion::WiiJpn,     0x8B60},
+});
 
 #define l_J_hana00DL   (l_J_hana00DL_get())
 #define l_J_hana00_cDL (l_J_hana00_cDL_get())
@@ -252,30 +182,15 @@ const u16 l_J_Ohana01_64128_0419TEX__width = 63;
 const u16 l_J_Ohana01_64128_0419TEX__height = 127;
 
 #if TARGET_PC
-using GameVersion = dusk::version::GameVersion;
-
-static u8* l_J_Ohana01_64128_0419TEX_get() {
-    static u8 buf[0x1000];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0xA0A0},
-            {GameVersion::GcnPal,     0xA0A0},
-            {GameVersion::GcnJpn,     0xA0A0},
-            {GameVersion::WiiUsaRev0, 0x8BA0},
-            {GameVersion::WiiUsa,     0x8C00},
-            {GameVersion::WiiPal,     0x8C00},
-            {GameVersion::WiiJpn,     0x8C00}
-            },
-            0x1000
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_J_Ohana01_64128_0419TEX, u8, 0x1000, {
+    {GameVersion::GcnUsa,     0xA0A0},
+    {GameVersion::GcnPal,     0xA0A0},
+    {GameVersion::GcnJpn,     0xA0A0},
+    {GameVersion::WiiUsaRev0, 0x8BA0},
+    {GameVersion::WiiUsa,     0x8C00},
+    {GameVersion::WiiPal,     0x8C00},
+    {GameVersion::WiiJpn,     0x8C00},
+});
 
 #define l_J_Ohana01_64128_0419TEX (l_J_Ohana01_64128_0419TEX_get())
 #else
@@ -408,122 +323,55 @@ static u8 l_flowerTexCoord2[] = {
     0x40, 0x1B, 0x7D, 0x52, 0x3F, 0x80, 0x3F, 0x79, 0x40, 0x1B, 0x7D, 0x52, 0x3F, 0x51, 0x10, 0x6F};
 
 #if TARGET_PC
-using GameVersion = dusk::version::GameVersion;
+DEFINE_GRASS_ASSET(l_J_hana01DL, u8, 0x138, {
+    {GameVersion::GcnUsa,     0xB7C0},
+    {GameVersion::GcnPal,     0xB7C0},
+    {GameVersion::GcnJpn,     0xB7C0},
+    {GameVersion::WiiUsaRev0, 0xA2C0},
+    {GameVersion::WiiUsa,     0xA320},
+    {GameVersion::WiiPal,     0xA320},
+    {GameVersion::WiiJpn,     0xA320},
+});
 
-static u8* l_J_hana01DL_get() {
-    static u8 buf[0x138];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0xB7C0},
-            {GameVersion::GcnPal,     0xB7C0},
-            {GameVersion::GcnJpn,     0xB7C0},
-            {GameVersion::WiiUsaRev0, 0xA2C0},
-            {GameVersion::WiiUsa,     0xA320},
-            {GameVersion::WiiPal,     0xA320},
-            {GameVersion::WiiJpn,     0xA320}
-            },
-            0x138
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_J_hana01_c_00DL, u8, 0xDE, {
+    {GameVersion::GcnUsa,     0xB900},
+    {GameVersion::GcnPal,     0xB900},
+    {GameVersion::GcnJpn,     0xB900},
+    {GameVersion::WiiUsaRev0, 0xA400},
+    {GameVersion::WiiUsa,     0xA460},
+    {GameVersion::WiiPal,     0xA460},
+    {GameVersion::WiiJpn,     0xA460},
+});
 
-static u8* l_J_hana01_c_00DL_get() {
-    static u8 buf[0xDE];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0xB900},
-            {GameVersion::GcnPal,     0xB900},
-            {GameVersion::GcnJpn,     0xB900},
-            {GameVersion::WiiUsaRev0, 0xA400},
-            {GameVersion::WiiUsa,     0xA460},
-            {GameVersion::WiiPal,     0xA460},
-            {GameVersion::WiiJpn,     0xA460}
-            },
-            0xDE
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_J_hana01_c_01DL, u8, 0x128, {
+    {GameVersion::GcnUsa,     0xB9E0},
+    {GameVersion::GcnPal,     0xB9E0},
+    {GameVersion::GcnJpn,     0xB9E0},
+    {GameVersion::WiiUsaRev0, 0xA4E0},
+    {GameVersion::WiiUsa,     0xA540},
+    {GameVersion::WiiPal,     0xA540},
+    {GameVersion::WiiJpn,     0xA540},
+});
 
-static u8* l_J_hana01_c_01DL_get() {
-    static u8 buf[0x128];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0xB9E0},
-            {GameVersion::GcnPal,     0xB9E0},
-            {GameVersion::GcnJpn,     0xB9E0},
-            {GameVersion::WiiUsaRev0, 0xA4E0},
-            {GameVersion::WiiUsa,     0xA540},
-            {GameVersion::WiiPal,     0xA540},
-            {GameVersion::WiiJpn,     0xA540}
-            },
-            0x128
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_mat2DL, u8, 0x99, {
+    {GameVersion::GcnUsa,     0xBB20},
+    {GameVersion::GcnPal,     0xBB20},
+    {GameVersion::GcnJpn,     0xBB20},
+    {GameVersion::WiiUsaRev0, 0xA620},
+    {GameVersion::WiiUsa,     0xA680},
+    {GameVersion::WiiPal,     0xA680},
+    {GameVersion::WiiJpn,     0xA680},
+});
 
-static u8* l_mat2DL_get() {
-    static u8 buf[0x99];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0xBB20},
-            {GameVersion::GcnPal,     0xBB20},
-            {GameVersion::GcnJpn,     0xBB20},
-            {GameVersion::WiiUsaRev0, 0xA620},
-            {GameVersion::WiiUsa,     0xA680},
-            {GameVersion::WiiPal,     0xA680},
-            {GameVersion::WiiJpn,     0xA680}
-            },
-            0x99
-        ),
-        true
-    );
-    return buf;
-}
-
-static u8* l_mat2Light4DL_get() {
-    static u8 buf[0x99];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0xBBC0},
-            {GameVersion::GcnPal,     0xBBC0},
-            {GameVersion::GcnJpn,     0xBBC0},
-            {GameVersion::WiiUsaRev0, 0xA6C0},
-            {GameVersion::WiiUsa,     0xA720},
-            {GameVersion::WiiPal,     0xA720},
-            {GameVersion::WiiJpn,     0xA720}
-            },
-            0x99
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_mat2Light4DL, u8, 0x99, {
+    {GameVersion::GcnUsa,     0xBBC0},
+    {GameVersion::GcnPal,     0xBBC0},
+    {GameVersion::GcnJpn,     0xBBC0},
+    {GameVersion::WiiUsaRev0, 0xA6C0},
+    {GameVersion::WiiUsa,     0xA720},
+    {GameVersion::WiiPal,     0xA720},
+    {GameVersion::WiiJpn,     0xA720},
+});
 
 #define l_J_hana01DL      (l_J_hana01DL_get())
 #define l_J_hana01_c_00DL (l_J_hana01_c_00DL_get())

--- a/src/d/actor/d_flower.inc
+++ b/src/d/actor/d_flower.inc
@@ -13,7 +13,30 @@ const u16 l_J_Ohana00_64TEX__height = 63;
 #if TARGET_PC
 #include "dusk/dvd_asset.hpp"
 using GameVersion = dusk::version::GameVersion;
-static u8* l_J_Ohana00_64TEX_get() { static u8 buf[0x800]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x9060}, {GameVersion::GcnPal, 0x9060}, {GameVersion::GcnJpn, 0x9060}}, 0x800), true); return buf; }
+
+static u8* l_J_Ohana00_64TEX_get() {
+    static u8 buf[0x800];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x9060},
+            {GameVersion::GcnPal,     0x9060},
+            {GameVersion::GcnJpn,     0x9060},
+            {GameVersion::WiiUsaRev0, 0x7B60},
+            {GameVersion::WiiUsa,     0x7BC0},
+            {GameVersion::WiiPal,     0x7BC0},
+            {GameVersion::WiiJpn,     0x7BC0}
+            },
+            0x800
+        ),
+        true
+    );
+    return buf;
+}
+
 #define l_J_Ohana00_64TEX (l_J_Ohana00_64TEX_get())
 
 // from d_grass.inc
@@ -117,10 +140,98 @@ static u8 l_flowerTexCoord[] = {
 #if TARGET_PC
 using GameVersion = dusk::version::GameVersion;
 
-static u8* l_J_hana00DL_get()   { static u8 buf[0x150]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x9D20}, {GameVersion::GcnPal, 0x9D20}, {GameVersion::GcnJpn, 0x9D20}}, 0x150), true); return buf; }
-static u8* l_J_hana00_cDL_get() { static u8 buf[0xDE];  static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x9E80}, {GameVersion::GcnPal, 0x9E80}, {GameVersion::GcnJpn, 0x9E80}}, 0xDE),  true); return buf; }
-static u8* l_matDL_get()        { static u8 buf[0x99];  static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x9F60}, {GameVersion::GcnPal, 0x9F60}, {GameVersion::GcnJpn, 0x9F60}}, 0x99),  true); return buf; }
-static u8* l_matLight4DL_get()  { static u8 buf[0x99];  static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0xA000}, {GameVersion::GcnPal, 0xA000}, {GameVersion::GcnJpn, 0xA000}}, 0x99),  true); return buf; }
+static u8* l_J_hana00DL_get() {
+    static u8 buf[0x150];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x9D20},
+            {GameVersion::GcnPal,     0x9D20},
+            {GameVersion::GcnJpn,     0x9D20},
+            {GameVersion::WiiUsaRev0, 0x8820},
+            {GameVersion::WiiUsa,     0x8880},
+            {GameVersion::WiiPal,     0x8880},
+            {GameVersion::WiiJpn,     0x8880}
+            },
+            0x150
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_J_hana00_cDL_get() {
+    static u8 buf[0xDE];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x9E80},
+            {GameVersion::GcnPal,     0x9E80},
+            {GameVersion::GcnJpn,     0x9E80},
+            {GameVersion::WiiUsaRev0, 0x8980},
+            {GameVersion::WiiUsa,     0x89E0},
+            {GameVersion::WiiPal,     0x89E0},
+            {GameVersion::WiiJpn,     0x89E0}
+            },
+            0xDE
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_matDL_get() {
+    static u8 buf[0x99];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x9F60},
+            {GameVersion::GcnPal,     0x9F60},
+            {GameVersion::GcnJpn,     0x9F60},
+            {GameVersion::WiiUsaRev0, 0x8A60},
+            {GameVersion::WiiUsa,     0x8AC0},
+            {GameVersion::WiiPal,     0x8AC0},
+            {GameVersion::WiiJpn,     0x8AC0}
+            },
+            0x99
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_matLight4DL_get() {
+    static u8 buf[0x99];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0xA000},
+            {GameVersion::GcnPal,     0xA000},
+            {GameVersion::GcnJpn,     0xA000},
+            {GameVersion::WiiUsaRev0, 0x8B00},
+            {GameVersion::WiiUsa,     0x8B60},
+            {GameVersion::WiiPal,     0x8B60},
+            {GameVersion::WiiJpn,     0x8B60}
+            },
+            0x99
+        ),
+        true
+    );
+    return buf;
+}
+
 #define l_J_hana00DL   (l_J_hana00DL_get())
 #define l_J_hana00_cDL (l_J_hana00_cDL_get())
 #define l_matDL        (l_matDL_get())
@@ -142,7 +253,30 @@ const u16 l_J_Ohana01_64128_0419TEX__height = 127;
 
 #if TARGET_PC
 using GameVersion = dusk::version::GameVersion;
-static u8* l_J_Ohana01_64128_0419TEX_get() { static u8 buf[0x1000]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0xA0A0}, {GameVersion::GcnPal, 0xA0A0}, {GameVersion::GcnJpn, 0xA0A0}}, 0x1000), true); return buf; }
+
+static u8* l_J_Ohana01_64128_0419TEX_get() {
+    static u8 buf[0x1000];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0xA0A0},
+            {GameVersion::GcnPal,     0xA0A0},
+            {GameVersion::GcnJpn,     0xA0A0},
+            {GameVersion::WiiUsaRev0, 0x8BA0},
+            {GameVersion::WiiUsa,     0x8C00},
+            {GameVersion::WiiPal,     0x8C00},
+            {GameVersion::WiiJpn,     0x8C00}
+            },
+            0x1000
+        ),
+        true
+    );
+    return buf;
+}
+
 #define l_J_Ohana01_64128_0419TEX (l_J_Ohana01_64128_0419TEX_get())
 #else
 #include "assets/l_J_Ohana01_64128_0419TEX.h"
@@ -276,11 +410,121 @@ static u8 l_flowerTexCoord2[] = {
 #if TARGET_PC
 using GameVersion = dusk::version::GameVersion;
 
-static u8* l_J_hana01DL_get()      { static u8 buf[0x138]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0xB7C0}, {GameVersion::GcnPal, 0xB7C0}, {GameVersion::GcnJpn, 0xB7C0}}, 0x138), true); return buf; }
-static u8* l_J_hana01_c_00DL_get() { static u8 buf[0xDE];  static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0xB900}, {GameVersion::GcnPal, 0xB900}, {GameVersion::GcnJpn, 0xB900}}, 0xDE),  true); return buf; }
-static u8* l_J_hana01_c_01DL_get() { static u8 buf[0x128]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0xB9E0}, {GameVersion::GcnPal, 0xB9E0}, {GameVersion::GcnJpn, 0xB9E0}}, 0x128), true); return buf; }
-static u8* l_mat2DL_get()          { static u8 buf[0x99];  static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0xBB20}, {GameVersion::GcnPal, 0xBB20}, {GameVersion::GcnJpn, 0xBB20}}, 0x99),  true); return buf; }
-static u8* l_mat2Light4DL_get()    { static u8 buf[0x99];  static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0xBBC0}, {GameVersion::GcnPal, 0xBBC0}, {GameVersion::GcnJpn, 0xBBC0}}, 0x99),  true); return buf; }
+static u8* l_J_hana01DL_get() {
+    static u8 buf[0x138];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0xB7C0},
+            {GameVersion::GcnPal,     0xB7C0},
+            {GameVersion::GcnJpn,     0xB7C0},
+            {GameVersion::WiiUsaRev0, 0xA2C0},
+            {GameVersion::WiiUsa,     0xA320},
+            {GameVersion::WiiPal,     0xA320},
+            {GameVersion::WiiJpn,     0xA320}
+            },
+            0x138
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_J_hana01_c_00DL_get() {
+    static u8 buf[0xDE];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0xB900},
+            {GameVersion::GcnPal,     0xB900},
+            {GameVersion::GcnJpn,     0xB900},
+            {GameVersion::WiiUsaRev0, 0xA400},
+            {GameVersion::WiiUsa,     0xA460},
+            {GameVersion::WiiPal,     0xA460},
+            {GameVersion::WiiJpn,     0xA460}
+            },
+            0xDE
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_J_hana01_c_01DL_get() {
+    static u8 buf[0x128];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0xB9E0},
+            {GameVersion::GcnPal,     0xB9E0},
+            {GameVersion::GcnJpn,     0xB9E0},
+            {GameVersion::WiiUsaRev0, 0xA4E0},
+            {GameVersion::WiiUsa,     0xA540},
+            {GameVersion::WiiPal,     0xA540},
+            {GameVersion::WiiJpn,     0xA540}
+            },
+            0x128
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_mat2DL_get() {
+    static u8 buf[0x99];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0xBB20},
+            {GameVersion::GcnPal,     0xBB20},
+            {GameVersion::GcnJpn,     0xBB20},
+            {GameVersion::WiiUsaRev0, 0xA620},
+            {GameVersion::WiiUsa,     0xA680},
+            {GameVersion::WiiPal,     0xA680},
+            {GameVersion::WiiJpn,     0xA680}
+            },
+            0x99
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_mat2Light4DL_get() {
+    static u8 buf[0x99];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0xBBC0},
+            {GameVersion::GcnPal,     0xBBC0},
+            {GameVersion::GcnJpn,     0xBBC0},
+            {GameVersion::WiiUsaRev0, 0xA6C0},
+            {GameVersion::WiiUsa,     0xA720},
+            {GameVersion::WiiPal,     0xA720},
+            {GameVersion::WiiJpn,     0xA720}
+            },
+            0x99
+        ),
+        true
+    );
+    return buf;
+}
+
 #define l_J_hana01DL      (l_J_hana01DL_get())
 #define l_J_hana01_c_00DL (l_J_hana01_c_00DL_get())
 #define l_J_hana01_c_01DL (l_J_hana01_c_01DL_get())

--- a/src/d/actor/d_grass.inc
+++ b/src/d/actor/d_grass.inc
@@ -21,8 +21,52 @@ const u16 l_M_kusa05_RGBATEX__height = 31;
 #if TARGET_PC
 #include "dusk/dvd_asset.hpp"
 using GameVersion = dusk::version::GameVersion;
-static u8* l_M_kusa05_RGBATEX_get() { static u8 buf[0x800]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x7680}, {GameVersion::GcnPal, 0x7680}, {GameVersion::GcnJpn, 0x7680}}, 0x800), true); return buf; }
-static u8* l_M_Hijiki00TEX_get()    { static u8 buf[0x800]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x7E80}, {GameVersion::GcnPal, 0x7E80}, {GameVersion::GcnJpn, 0x7E80}}, 0x800), true); return buf; }
+
+static u8* l_M_kusa05_RGBATEX_get() {
+    static u8 buf[0x800];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x7680},
+            {GameVersion::GcnPal,     0x7680},
+            {GameVersion::GcnJpn,     0x7680},
+            {GameVersion::WiiUsaRev0, 0x6180},
+            {GameVersion::WiiUsa,     0x61E0},
+            {GameVersion::WiiPal,     0x61E0},
+            {GameVersion::WiiJpn,     0x61E0}
+            },
+            0x800
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_M_Hijiki00TEX_get() {
+    static u8 buf[0x800];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x7E80},
+            {GameVersion::GcnPal,     0x7E80},
+            {GameVersion::GcnJpn,     0x7E80},
+            {GameVersion::WiiUsaRev0, 0x6980},
+            {GameVersion::WiiUsa,     0x69E0},
+            {GameVersion::WiiPal,     0x69E0},
+            {GameVersion::WiiJpn,     0x69E0}
+            },
+            0x800
+        ),
+        true
+    );
+    return buf;
+}
 #define l_M_kusa05_RGBATEX (l_M_kusa05_RGBATEX_get())
 #define l_M_Hijiki00TEX    (l_M_Hijiki00TEX_get())
 #else
@@ -116,12 +160,144 @@ static u8 l_texCoord[160] = {
 #if TARGET_PC
 using GameVersion = dusk::version::GameVersion;
 
-static u8* l_M_Kusa_9qDL_get()     { static u8 buf[0xCB]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x8B00}, {GameVersion::GcnPal, 0x8B00}, {GameVersion::GcnJpn, 0x8B00}}, 0xCB),  true); return buf; }
-static u8* l_M_Kusa_9q_cDL_get()   { static u8 buf[0xCB]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x8BE0}, {GameVersion::GcnPal, 0x8BE0}, {GameVersion::GcnJpn, 0x8BE0}}, 0xCB),  true); return buf; }
-static u8* l_M_TenGusaDL_get()     { static u8 buf[0xD4]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x8CC0}, {GameVersion::GcnPal, 0x8CC0}, {GameVersion::GcnJpn, 0x8CC0}}, 0xD4),  true); return buf; }
-static u8* l_Tengusa_matDL_get()   { static u8 buf[0xA8]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x8DA0}, {GameVersion::GcnPal, 0x8DA0}, {GameVersion::GcnJpn, 0x8DA0}}, 0xA8),  true); return buf; }
-static u8* l_kusa9q_matDL_get()    { static u8 buf[0xA8]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x8E60}, {GameVersion::GcnPal, 0x8E60}, {GameVersion::GcnJpn, 0x8E60}}, 0xA8),  true); return buf; }
-static u8* l_kusa9q_l4_matDL_get() { static u8 buf[0xA8]; static bool _ = (dusk::LoadArchivedRelAsset(buf, 'AMEM', "d_a_grass.rel", {{GameVersion::GcnUsa, 0x8F20}, {GameVersion::GcnPal, 0x8F20}, {GameVersion::GcnJpn, 0x8F20}}, 0xA8),  true); return buf; }
+static u8* l_M_Kusa_9qDL_get() {
+    static u8 buf[0xCB];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x8B00},
+            {GameVersion::GcnPal,     0x8B00},
+            {GameVersion::GcnJpn,     0x8B00},
+            {GameVersion::WiiUsaRev0, 0x7600},
+            {GameVersion::WiiUsa,     0x7660},
+            {GameVersion::WiiPal,     0x7660},
+            {GameVersion::WiiJpn,     0x7660}
+            },
+            0xCB
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_M_Kusa_9q_cDL_get() {
+    static u8 buf[0xCB];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x8BE0},
+            {GameVersion::GcnPal,     0x8BE0},
+            {GameVersion::GcnJpn,     0x8BE0},
+            {GameVersion::WiiUsaRev0, 0x76E0},
+            {GameVersion::WiiUsa,     0x7740},
+            {GameVersion::WiiPal,     0x7740},
+            {GameVersion::WiiJpn,     0x7740}
+            },
+            0xCB
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_M_TenGusaDL_get() {
+    static u8 buf[0xD4];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x8CC0},
+            {GameVersion::GcnPal,     0x8CC0},
+            {GameVersion::GcnJpn,     0x8CC0},
+            {GameVersion::WiiUsaRev0, 0x77C0},
+            {GameVersion::WiiUsa,     0x7820},
+            {GameVersion::WiiPal,     0x7820},
+            {GameVersion::WiiJpn,     0x7820}
+            },
+            0xD4
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_Tengusa_matDL_get() {
+    static u8 buf[0xA8];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x8DA0},
+            {GameVersion::GcnPal,     0x8DA0},
+            {GameVersion::GcnJpn,     0x8DA0},
+            {GameVersion::WiiUsaRev0, 0x78A0},
+            {GameVersion::WiiUsa,     0x7900},
+            {GameVersion::WiiPal,     0x7900},
+            {GameVersion::WiiJpn,     0x7900}
+            },
+            0xA8
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_kusa9q_matDL_get() {
+    static u8 buf[0xA8];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x8E60},
+            {GameVersion::GcnPal,     0x8E60},
+            {GameVersion::GcnJpn,     0x8E60},
+            {GameVersion::WiiUsaRev0, 0x7960},
+            {GameVersion::WiiUsa,     0x79C0},
+            {GameVersion::WiiPal,     0x79C0},
+            {GameVersion::WiiJpn,     0x79C0}
+            },
+            0xA8
+        ),
+        true
+    );
+    return buf;
+}
+
+static u8* l_kusa9q_l4_matDL_get() {
+    static u8 buf[0xA8];
+    static bool _ = (
+        dusk::LoadArchivedRelAsset(
+            buf,
+            'AMEM',
+            "d_a_grass.rel",
+            {
+            {GameVersion::GcnUsa,     0x8F20},
+            {GameVersion::GcnPal,     0x8F20},
+            {GameVersion::GcnJpn,     0x8F20},
+            {GameVersion::WiiUsaRev0, 0x7A20},
+            {GameVersion::WiiUsa,     0x7A80},
+            {GameVersion::WiiPal,     0x7A80},
+            {GameVersion::WiiJpn,     0x7A80}
+            },
+            0xA8
+        ),
+        true
+    );
+    return buf;
+}
+
 #define l_M_Kusa_9qDL     (l_M_Kusa_9qDL_get())
 #define l_M_Kusa_9q_cDL   (l_M_Kusa_9q_cDL_get())
 #define l_M_TenGusaDL     (l_M_TenGusaDL_get())

--- a/src/d/actor/d_grass.inc
+++ b/src/d/actor/d_grass.inc
@@ -22,51 +22,38 @@ const u16 l_M_kusa05_RGBATEX__height = 31;
 #include "dusk/dvd_asset.hpp"
 using GameVersion = dusk::version::GameVersion;
 
-static u8* l_M_kusa05_RGBATEX_get() {
-    static u8 buf[0x800];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x7680},
-            {GameVersion::GcnPal,     0x7680},
-            {GameVersion::GcnJpn,     0x7680},
-            {GameVersion::WiiUsaRev0, 0x6180},
-            {GameVersion::WiiUsa,     0x61E0},
-            {GameVersion::WiiPal,     0x61E0},
-            {GameVersion::WiiJpn,     0x61E0}
-            },
-            0x800
-        ),
-        true
-    );
-    return buf;
+template <typename T, size_t N>
+static bool LoadGrassAsset(T (&dst)[N], std::initializer_list<dusk::OffsetVersion> offset) {
+    return dusk::LoadArchivedRelAsset(dst, 'AMEM', "d_a_grass.rel", offset);
 }
 
-static u8* l_M_Hijiki00TEX_get() {
-    static u8 buf[0x800];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x7E80},
-            {GameVersion::GcnPal,     0x7E80},
-            {GameVersion::GcnJpn,     0x7E80},
-            {GameVersion::WiiUsaRev0, 0x6980},
-            {GameVersion::WiiUsa,     0x69E0},
-            {GameVersion::WiiPal,     0x69E0},
-            {GameVersion::WiiJpn,     0x69E0}
-            },
-            0x800
-        ),
-        true
-    );
-    return buf;
-}
+#define DEFINE_GRASS_ASSET(name, type, count, ...)                                                 \
+    static type* name##_get() {                                                                    \
+        static type buf[count];                                                                    \
+        static bool _ = (LoadGrassAsset(buf, __VA_ARGS__), true);                                  \
+        return buf;                                                                                \
+    }
+
+DEFINE_GRASS_ASSET(l_M_kusa05_RGBATEX, u8, 0x800, {
+    {GameVersion::GcnUsa,     0x7680},
+    {GameVersion::GcnPal,     0x7680},
+    {GameVersion::GcnJpn,     0x7680},
+    {GameVersion::WiiUsaRev0, 0x6180},
+    {GameVersion::WiiUsa,     0x61E0},
+    {GameVersion::WiiPal,     0x61E0},
+    {GameVersion::WiiJpn,     0x61E0},
+});
+
+DEFINE_GRASS_ASSET(l_M_Hijiki00TEX, u8, 0x800, {
+    {GameVersion::GcnUsa,     0x7E80},
+    {GameVersion::GcnPal,     0x7E80},
+    {GameVersion::GcnJpn,     0x7E80},
+    {GameVersion::WiiUsaRev0, 0x6980},
+    {GameVersion::WiiUsa,     0x69E0},
+    {GameVersion::WiiPal,     0x69E0},
+    {GameVersion::WiiJpn,     0x69E0},
+});
+
 #define l_M_kusa05_RGBATEX (l_M_kusa05_RGBATEX_get())
 #define l_M_Hijiki00TEX    (l_M_Hijiki00TEX_get())
 #else
@@ -158,145 +145,65 @@ static u8 l_texCoord[160] = {
 };
 
 #if TARGET_PC
-using GameVersion = dusk::version::GameVersion;
+DEFINE_GRASS_ASSET(l_M_Kusa_9qDL, u8, 0xCB, {
+    {GameVersion::GcnUsa,     0x8B00},
+    {GameVersion::GcnPal,     0x8B00},
+    {GameVersion::GcnJpn,     0x8B00},
+    {GameVersion::WiiUsaRev0, 0x7600},
+    {GameVersion::WiiUsa,     0x7660},
+    {GameVersion::WiiPal,     0x7660},
+    {GameVersion::WiiJpn,     0x7660},
+});
 
-static u8* l_M_Kusa_9qDL_get() {
-    static u8 buf[0xCB];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x8B00},
-            {GameVersion::GcnPal,     0x8B00},
-            {GameVersion::GcnJpn,     0x8B00},
-            {GameVersion::WiiUsaRev0, 0x7600},
-            {GameVersion::WiiUsa,     0x7660},
-            {GameVersion::WiiPal,     0x7660},
-            {GameVersion::WiiJpn,     0x7660}
-            },
-            0xCB
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_M_Kusa_9q_cDL, u8, 0xCB, {
+    {GameVersion::GcnUsa,     0x8BE0},
+    {GameVersion::GcnPal,     0x8BE0},
+    {GameVersion::GcnJpn,     0x8BE0},
+    {GameVersion::WiiUsaRev0, 0x76E0},
+    {GameVersion::WiiUsa,     0x7740},
+    {GameVersion::WiiPal,     0x7740},
+    {GameVersion::WiiJpn,     0x7740},
+});
 
-static u8* l_M_Kusa_9q_cDL_get() {
-    static u8 buf[0xCB];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x8BE0},
-            {GameVersion::GcnPal,     0x8BE0},
-            {GameVersion::GcnJpn,     0x8BE0},
-            {GameVersion::WiiUsaRev0, 0x76E0},
-            {GameVersion::WiiUsa,     0x7740},
-            {GameVersion::WiiPal,     0x7740},
-            {GameVersion::WiiJpn,     0x7740}
-            },
-            0xCB
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_M_TenGusaDL, u8, 0xD4, {
+    {GameVersion::GcnUsa,     0x8CC0},
+    {GameVersion::GcnPal,     0x8CC0},
+    {GameVersion::GcnJpn,     0x8CC0},
+    {GameVersion::WiiUsaRev0, 0x77C0},
+    {GameVersion::WiiUsa,     0x7820},
+    {GameVersion::WiiPal,     0x7820},
+    {GameVersion::WiiJpn,     0x7820},
+});
 
-static u8* l_M_TenGusaDL_get() {
-    static u8 buf[0xD4];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x8CC0},
-            {GameVersion::GcnPal,     0x8CC0},
-            {GameVersion::GcnJpn,     0x8CC0},
-            {GameVersion::WiiUsaRev0, 0x77C0},
-            {GameVersion::WiiUsa,     0x7820},
-            {GameVersion::WiiPal,     0x7820},
-            {GameVersion::WiiJpn,     0x7820}
-            },
-            0xD4
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_Tengusa_matDL, u8, 0xA8, {
+    {GameVersion::GcnUsa,     0x8DA0},
+    {GameVersion::GcnPal,     0x8DA0},
+    {GameVersion::GcnJpn,     0x8DA0},
+    {GameVersion::WiiUsaRev0, 0x78A0},
+    {GameVersion::WiiUsa,     0x7900},
+    {GameVersion::WiiPal,     0x7900},
+    {GameVersion::WiiJpn,     0x7900},
+});
 
-static u8* l_Tengusa_matDL_get() {
-    static u8 buf[0xA8];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x8DA0},
-            {GameVersion::GcnPal,     0x8DA0},
-            {GameVersion::GcnJpn,     0x8DA0},
-            {GameVersion::WiiUsaRev0, 0x78A0},
-            {GameVersion::WiiUsa,     0x7900},
-            {GameVersion::WiiPal,     0x7900},
-            {GameVersion::WiiJpn,     0x7900}
-            },
-            0xA8
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_kusa9q_matDL, u8, 0xA8, {
+    {GameVersion::GcnUsa,     0x8E60},
+    {GameVersion::GcnPal,     0x8E60},
+    {GameVersion::GcnJpn,     0x8E60},
+    {GameVersion::WiiUsaRev0, 0x7960},
+    {GameVersion::WiiUsa,     0x79C0},
+    {GameVersion::WiiPal,     0x79C0},
+    {GameVersion::WiiJpn,     0x79C0},
+});
 
-static u8* l_kusa9q_matDL_get() {
-    static u8 buf[0xA8];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x8E60},
-            {GameVersion::GcnPal,     0x8E60},
-            {GameVersion::GcnJpn,     0x8E60},
-            {GameVersion::WiiUsaRev0, 0x7960},
-            {GameVersion::WiiUsa,     0x79C0},
-            {GameVersion::WiiPal,     0x79C0},
-            {GameVersion::WiiJpn,     0x79C0}
-            },
-            0xA8
-        ),
-        true
-    );
-    return buf;
-}
-
-static u8* l_kusa9q_l4_matDL_get() {
-    static u8 buf[0xA8];
-    static bool _ = (
-        dusk::LoadArchivedRelAsset(
-            buf,
-            'AMEM',
-            "d_a_grass.rel",
-            {
-            {GameVersion::GcnUsa,     0x8F20},
-            {GameVersion::GcnPal,     0x8F20},
-            {GameVersion::GcnJpn,     0x8F20},
-            {GameVersion::WiiUsaRev0, 0x7A20},
-            {GameVersion::WiiUsa,     0x7A80},
-            {GameVersion::WiiPal,     0x7A80},
-            {GameVersion::WiiJpn,     0x7A80}
-            },
-            0xA8
-        ),
-        true
-    );
-    return buf;
-}
+DEFINE_GRASS_ASSET(l_kusa9q_l4_matDL, u8, 0xA8, {
+    {GameVersion::GcnUsa,     0x8F20},
+    {GameVersion::GcnPal,     0x8F20},
+    {GameVersion::GcnJpn,     0x8F20},
+    {GameVersion::WiiUsaRev0, 0x7A20},
+    {GameVersion::WiiUsa,     0x7A80},
+    {GameVersion::WiiPal,     0x7A80},
+    {GameVersion::WiiJpn,     0x7A80},
+});
 
 #define l_M_Kusa_9qDL     (l_M_Kusa_9qDL_get())
 #define l_M_Kusa_9q_cDL   (l_M_Kusa_9q_cDL_get())

--- a/src/d/d_bright_check.cpp
+++ b/src/d/d_bright_check.cpp
@@ -83,7 +83,12 @@ void dBrightCheck_c::screenSet() {
     JUT_ASSERT(0, mBrightCheck.Scr != NULL);
     mBrightCheck.Scr->setPriority("zelda_option_check.blo", 0x1100000, mArchive);
 
-    mBrightCheck.Scr->search(MULTI_CHAR('g_abtn_n'))->hide();
+#if TARGET_PC
+    if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn)
+#endif
+    {
+        mBrightCheck.Scr->search(MULTI_CHAR('g_abtn_n'))->hide();
+    }
 
     #if TARGET_PC
     J2DTextBox* settings_text;
@@ -113,9 +118,11 @@ void dBrightCheck_c::screenSet() {
     J2DTextBox* btna_text[5];
     for (int i = 0; i < 5; i++) {
         #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             btna_text[i] = (J2DTextBox*)mBrightCheck.Scr->search(tv_btnA[i]);
-            mBrightCheck.Scr->search(ftv_btnA[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mBrightCheck.Scr->search(ftv_btnA[i])->hide();
+            }
         } else {
             btna_text[i] = (J2DTextBox*)mBrightCheck.Scr->search(ftv_btnA[i]);
             mBrightCheck.Scr->search(tv_btnA[i])->hide();
@@ -222,7 +229,9 @@ void dBrightCheck_c::brightCheckWide() {
 
     // Confirm A Button
     mBrightCheck.Scr->search(MULTI_CHAR('abtn_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mBrightCheck.Scr->search(MULTI_CHAR('gcabtn_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+        mBrightCheck.Scr->search(MULTI_CHAR('gcabtn_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    }
 
     // Text
     mBrightCheck.Scr->search(MULTI_CHAR('menu_6n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);

--- a/src/d/d_bright_check.cpp
+++ b/src/d/d_bright_check.cpp
@@ -83,12 +83,9 @@ void dBrightCheck_c::screenSet() {
     JUT_ASSERT(0, mBrightCheck.Scr != NULL);
     mBrightCheck.Scr->setPriority("zelda_option_check.blo", 0x1100000, mArchive);
 
-#if TARGET_PC
-    if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn)
-#endif
-    {
-        mBrightCheck.Scr->search(MULTI_CHAR('g_abtn_n'))->hide();
-    }
+    IF_DUSK_BLOCK(dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn)
+    mBrightCheck.Scr->search(MULTI_CHAR('g_abtn_n'))->hide();
+    IF_DUSK_BLOCK_END
 
     #if TARGET_PC
     J2DTextBox* settings_text;

--- a/src/d/d_menu_dmap.cpp
+++ b/src/d/d_menu_dmap.cpp
@@ -363,13 +363,15 @@ void dMenu_DmapBg_c::buttonIconScreenInit() {
 
     for (int i = 0; i < 5; i++) {
         #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             ((J2DTextBox*)mButtonScreen->search(cont_at[i]))->setFont(mDoExt_getMesgFont());
             ((J2DTextBox*)mButtonScreen->search(cont_bt[i]))->setFont(mDoExt_getMesgFont());
             ((J2DTextBox*)mButtonScreen->search(cont_at[i]))->setString(32, "");
             ((J2DTextBox*)mButtonScreen->search(cont_bt[i]))->setString(32, "");
-            ((J2DTextBox*)mButtonScreen->search(font_at[i]))->hide();
-            ((J2DTextBox*)mButtonScreen->search(font_bt[i]))->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                ((J2DTextBox*)mButtonScreen->search(font_at[i]))->hide();
+                ((J2DTextBox*)mButtonScreen->search(font_bt[i]))->hide();
+            }
         } else {
             ((J2DTextBox*)mButtonScreen->search(font_at[i]))->setFont(mDoExt_getMesgFont());
             ((J2DTextBox*)mButtonScreen->search(font_bt[i]))->setFont(mDoExt_getMesgFont());
@@ -400,7 +402,7 @@ void dMenu_DmapBg_c::buttonIconScreenInit() {
 
     J2DTextBox* textBox;
     for (int i = 0; i < 2; i++) {
-        textBox = ((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? c_tag_jpn[i] : c_tag[i], c_tag[i])));
+        textBox = (J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? c_tag_jpn[i] : c_tag[i], c_tag[i]));
         textBox->setFont(mDoExt_getMesgFont());
         textBox->setString(32, "");
     }
@@ -436,9 +438,9 @@ void dMenu_DmapBg_c::setAButtonString(u32 i_msgNo) {
 
     for (int i = 0; i < 5; i++) {
         if (i_msgNo == 0) {
-            SAFE_STRCPY(((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? cont_at_jpn[i] : cont_at[i], cont_at[i])))->getStringPtr(), "");
+            SAFE_STRCPY(((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? cont_at_jpn[i] : cont_at[i], cont_at[i])))->getStringPtr(), "");
         } else {
-            dMeter2Info_getStringKanji(i_msgNo, ((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? cont_at_jpn[i] : cont_at[i], cont_at[i])))->getStringPtr(), NULL);
+            dMeter2Info_getStringKanji(i_msgNo, ((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? cont_at_jpn[i] : cont_at[i], cont_at[i])))->getStringPtr(), NULL);
         }
     }
 }
@@ -463,9 +465,9 @@ void dMenu_DmapBg_c::setBButtonString(u32 i_msgNo) {
 
     for (int i = 0; i < 5; i++) {
         if (i_msgNo == 0) {
-            SAFE_STRCPY(((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? cont_bt_jpn[i] : cont_bt[i], cont_bt[i])))->getStringPtr(), "");
+            SAFE_STRCPY(((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? cont_bt_jpn[i] : cont_bt[i], cont_bt[i])))->getStringPtr(), "");
         } else {
-            dMeter2Info_getStringKanji(i_msgNo, ((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? cont_bt_jpn[i] : cont_bt[i], cont_bt[i])))->getStringPtr(), NULL);
+            dMeter2Info_getStringKanji(i_msgNo, ((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? cont_bt_jpn[i] : cont_bt[i], cont_bt[i])))->getStringPtr(), NULL);
         }
     }
 }
@@ -504,12 +506,12 @@ void dMenu_DmapBg_c::setCButtonString(u32 i_msgNo) {
 
     if (msgNo == 0) {
         for (i = 0; i < 2; i++) {
-            SAFE_STRCPY(((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? c_tag_jpn[i] : c_tag[i], c_tag[i])))->getStringPtr(), "");
+            SAFE_STRCPY(((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? c_tag_jpn[i] : c_tag[i], c_tag[i])))->getStringPtr(), "");
         }
         mpCButton->setAlphaRate(0.5f);
     } else {
         for (i = 0; i < 2; i++) {
-            dMeter2Info_getStringKanji(msgNo, ((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? c_tag_jpn[i] : c_tag[i], c_tag[i])))->getStringPtr(), NULL);
+            dMeter2Info_getStringKanji(msgNo, ((J2DTextBox*)mButtonScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? c_tag_jpn[i] : c_tag[i], c_tag[i])))->getStringPtr(), NULL);
         }
         mpCButton->setAlphaRate(1.0f);
     }
@@ -979,8 +981,10 @@ void dMenu_DmapBg_c::dMapBgWide() {
     mButtonScreen->search(MULTI_CHAR('c_btn'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
     mButtonScreen->search(MULTI_CHAR('c_text_s'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
     mButtonScreen->search(MULTI_CHAR('c_text'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mButtonScreen->search(MULTI_CHAR('f_text_s'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
-    mButtonScreen->search(MULTI_CHAR('f_text'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+        mButtonScreen->search(MULTI_CHAR('f_text_s'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+        mButtonScreen->search(MULTI_CHAR('f_text'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);
+    }
 
     // Decorations
     mButtonScreen->search(MULTI_CHAR('kazari_n'))->scale(mDoGph_gInf_c::hudAspectScaleDown, 1.0f);

--- a/src/d/d_menu_fishing.cpp
+++ b/src/d/d_menu_fishing.cpp
@@ -343,12 +343,9 @@ void dMenu_Fishing_c::screenSetBase() {
         field_0x19c[1][i]->setString(0x20, "");
 
         mpFishNameString[i] = (J2DTextBox*)mpScreen->search(name_0[i]);
-#if TARGET_PC
-        if (dusk::version::isGcn())
-#endif
-        {
-            mpScreen->search(fname_0[i])->hide();
-        }
+        IF_DUSK_BLOCK(dusk::version::isGcn())
+        mpScreen->search(fname_0[i])->hide();
+        IF_DUSK_BLOCK_END
         mpFishNameString[i]->setFont(mDoExt_getSubFont());
         mpFishNameString[i]->setString(0x20, "");
         dMeter2Info_getStringKanji(name_id[i], mpFishNameString[i]->getStringPtr(), NULL);

--- a/src/d/d_menu_fishing.cpp
+++ b/src/d/d_menu_fishing.cpp
@@ -343,7 +343,12 @@ void dMenu_Fishing_c::screenSetBase() {
         field_0x19c[1][i]->setString(0x20, "");
 
         mpFishNameString[i] = (J2DTextBox*)mpScreen->search(name_0[i]);
-        mpScreen->search(fname_0[i])->hide();
+#if TARGET_PC
+        if (dusk::version::isGcn())
+#endif
+        {
+            mpScreen->search(fname_0[i])->hide();
+        }
         mpFishNameString[i]->setFont(mDoExt_getSubFont());
         mpFishNameString[i]->setString(0x20, "");
         dMeter2Info_getStringKanji(name_id[i], mpFishNameString[i]->getStringPtr(), NULL);

--- a/src/d/d_menu_fmap2D.cpp
+++ b/src/d/d_menu_fmap2D.cpp
@@ -2420,10 +2420,12 @@ dMenu_Fmap2DTop_c::dMenu_Fmap2DTop_c(JKRExpHeap* i_heap, STControl* i_stick) {
     static const u64 farea_name[3] = {MULTI_CHAR('f_name_1'), MULTI_CHAR('f_name3'), MULTI_CHAR('f_name2')};
     for (int i = 0; i < 3; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             static_cast<J2DTextBox*>(mpTitleScreen->search(area_name[i]))->setFont(mDoExt_getRubyFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(area_name[i]))->setString(0x40, "");
-            mpTitleScreen->search(farea_name[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpTitleScreen->search(farea_name[i])->hide();
+            }
         } else {
             static_cast<J2DTextBox*>(mpTitleScreen->search(farea_name[i]))->setFont(mDoExt_getRubyFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(farea_name[i]))->setString(0x40, "");
@@ -2458,10 +2460,12 @@ dMenu_Fmap2DTop_c::dMenu_Fmap2DTop_c(JKRExpHeap* i_heap, STControl* i_stick) {
 #endif
     for (int i = 0; i < 7; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             static_cast<J2DTextBox*>(mpTitleScreen->search(sfont_name[i]))->setFont(mDoExt_getRubyFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(sfont_name[i]))->setString(0x40, "");
-            mpTitleScreen->search(ffont_name[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpTitleScreen->search(ffont_name[i])->hide();
+            }
         } else {
             static_cast<J2DTextBox*>(mpTitleScreen->search(ffont_name[i]))->setFont(mDoExt_getRubyFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(ffont_name[i]))->setString(0x40, "");
@@ -2485,10 +2489,12 @@ dMenu_Fmap2DTop_c::dMenu_Fmap2DTop_c(JKRExpHeap* i_heap, STControl* i_stick) {
     static const u64 font_zt[5] = {MULTI_CHAR('font_zt1'), MULTI_CHAR('font_zt2'), MULTI_CHAR('font_zt3'), MULTI_CHAR('font_zt4'), MULTI_CHAR('font_zt5')};
     for (int i = 0; i < 5; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             static_cast<J2DTextBox*>(mpTitleScreen->search(cont_zt[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(cont_zt[i]))->setString(0x20, "");
-            mpTitleScreen->search(font_zt[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpTitleScreen->search(font_zt[i])->hide();
+            }
         } else {
             static_cast<J2DTextBox*>(mpTitleScreen->search(font_zt[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(font_zt[i]))->setString(0x20, "");
@@ -2516,10 +2522,12 @@ dMenu_Fmap2DTop_c::dMenu_Fmap2DTop_c(JKRExpHeap* i_heap, STControl* i_stick) {
 #endif
     for (int i = 0; i < 5; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             static_cast<J2DTextBox*>(mpTitleScreen->search(cont_bt[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(cont_bt[i]))->setString(0x20, "");
-            mpTitleScreen->search(font_bt[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpTitleScreen->search(font_bt[i])->hide();
+            }
         } else {
             static_cast<J2DTextBox*>(mpTitleScreen->search(font_bt[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(font_bt[i]))->setString(0x20, "");
@@ -2543,10 +2551,12 @@ dMenu_Fmap2DTop_c::dMenu_Fmap2DTop_c(JKRExpHeap* i_heap, STControl* i_stick) {
     static const u64 font_at[5] = {MULTI_CHAR('font_at1'), MULTI_CHAR('font_at2'), MULTI_CHAR('font_at3'), MULTI_CHAR('font_at4'), MULTI_CHAR('font_at5')};
     for (int i = 0; i < 5; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             static_cast<J2DTextBox*>(mpTitleScreen->search(cont_at[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(cont_at[i]))->setString(0x20, "");
-            mpTitleScreen->search(font_at[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpTitleScreen->search(font_at[i])->hide();
+            }
         } else {
             static_cast<J2DTextBox*>(mpTitleScreen->search(font_at[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(font_at[i]))->setString(0x20, "");
@@ -2571,10 +2581,12 @@ dMenu_Fmap2DTop_c::dMenu_Fmap2DTop_c(JKRExpHeap* i_heap, STControl* i_stick) {
     static const u64 fuji_c[5] = {MULTI_CHAR('fuji_c00'), MULTI_CHAR('fuji_c01'), MULTI_CHAR('fuji_c02'), MULTI_CHAR('fuji_c03'), MULTI_CHAR('fuji_c04')};
     for (int i = 0; i < 5; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             static_cast<J2DTextBox*>(mpTitleScreen->search(juji_c[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(juji_c[i]))->setString(0x20, "");
-            mpTitleScreen->search(fuji_c[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpTitleScreen->search(fuji_c[i])->hide();
+            }
         } else {
             static_cast<J2DTextBox*>(mpTitleScreen->search(fuji_c[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(fuji_c[i]))->setString(0x20, "");
@@ -2598,10 +2610,12 @@ dMenu_Fmap2DTop_c::dMenu_Fmap2DTop_c(JKRExpHeap* i_heap, STControl* i_stick) {
     static const u64 fst_c[5] = {MULTI_CHAR('fst_00'), MULTI_CHAR('fst_01'), MULTI_CHAR('fst_02'), MULTI_CHAR('fst_03'), MULTI_CHAR('fst_04')};
     for (int i = 0; i < 5; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             static_cast<J2DTextBox*>(mpTitleScreen->search(ast_c[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(ast_c[i]))->setString(0x20, "");
-            mpTitleScreen->search(fst_c[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpTitleScreen->search(fst_c[i])->hide();
+            }
         } else {
             static_cast<J2DTextBox*>(mpTitleScreen->search(fst_c[i]))->setFont(mDoExt_getMesgFont());
             static_cast<J2DTextBox*>(mpTitleScreen->search(fst_c[i]))->setString(0x20, "");
@@ -2863,8 +2877,7 @@ void dMenu_Fmap2DTop_c::setTitleNameString(u32 param_0) {
     static const u64 ffont_name[7] = {
         MULTI_CHAR('ffont00'), MULTI_CHAR('ffontl0'), MULTI_CHAR('ffontl1'), MULTI_CHAR('ffontl2'), MULTI_CHAR('ffontb0'), MULTI_CHAR('ffontb3'), MULTI_CHAR('ffontb4')
     };
-
-    auto setTitleNameString_font_name = dusk::version::isRegionJpn() ? sfont_name : ffont_name;
+    auto setTitleNameString_font_name = dusk::version::isJpnOrLessThanWiiJpn() ? sfont_name : ffont_name;
 #elif VERSION == VERSION_GCN_JPN
     static const u64 sfont_name[7] = {
         MULTI_CHAR('sfont00'), MULTI_CHAR('sfontl0'), MULTI_CHAR('sfontl1'), MULTI_CHAR('sfontl2'), MULTI_CHAR('sfontb0'), MULTI_CHAR('sfontb1'), MULTI_CHAR('sfontb2')
@@ -2883,15 +2896,9 @@ void dMenu_Fmap2DTop_c::setTitleNameString(u32 param_0) {
 #endif
     for (int i = 0; i < 7; i++) {
         if (param_0 == 0) {
-            SAFE_STRCPY(((J2DTextBox*)(mpTitleScreen->search(setTitleNameString_font_name[i])))
-                       ->getStringPtr(),
-                   "");
+            SAFE_STRCPY(((J2DTextBox*)(mpTitleScreen->search(setTitleNameString_font_name[i])))->getStringPtr(), "");
         } else {
-            dMeter2Info_getStringKanji(
-                param_0,
-                ((J2DTextBox*)(mpTitleScreen->search(setTitleNameString_font_name[i])))
-                    ->getStringPtr(),
-                NULL);
+            dMeter2Info_getStringKanji(param_0, ((J2DTextBox*)(mpTitleScreen->search(setTitleNameString_font_name[i])))->getStringPtr(), NULL);
         }
     }
 }
@@ -2900,7 +2907,7 @@ void dMenu_Fmap2DTop_c::setAreaNameString(u32 param_0) {
 #if TARGET_PC
     static const u64 iarea_name[3] = {MULTI_CHAR('i_name_s'), MULTI_CHAR('i_name'), MULTI_CHAR('i_name1')};
     static const u64 farea_name[3] = {MULTI_CHAR('f_name_1'), MULTI_CHAR('f_name3'), MULTI_CHAR('f_name2')};
-    auto setAreaNameString_area_name = dusk::version::isRegionJpn() ? iarea_name : farea_name;
+    auto setAreaNameString_area_name = dusk::version::isJpnOrLessThanWiiJpn() ? iarea_name : farea_name;
 #elif VERSION == VERSION_GCN_JPN
     static const u64 iarea_name[3] = {MULTI_CHAR('i_name_s'), MULTI_CHAR('i_name'), MULTI_CHAR('i_name1')};
 #define setAreaNameString_area_name iarea_name
@@ -2910,15 +2917,9 @@ void dMenu_Fmap2DTop_c::setAreaNameString(u32 param_0) {
 #endif
     for (int i = 0; i < 3; i++) {
         if (param_0 == 0) {
-            SAFE_STRCPY(((J2DTextBox*)(mpTitleScreen->search(setAreaNameString_area_name[i])))
-                       ->getStringPtr(),
-                   "");
+            SAFE_STRCPY(((J2DTextBox*)(mpTitleScreen->search(setAreaNameString_area_name[i])))->getStringPtr(), "");
         } else {
-            dMeter2Info_getStringKanji(
-                param_0,
-                ((J2DTextBox*)(mpTitleScreen->search(setAreaNameString_area_name[i])))
-                    ->getStringPtr(),
-                NULL);
+            dMeter2Info_getStringKanji(param_0, ((J2DTextBox*)(mpTitleScreen->search(setAreaNameString_area_name[i])))->getStringPtr(), NULL);
         }
     }
 }
@@ -2937,7 +2938,7 @@ void dMenu_Fmap2DTop_c::setZButtonString(u32 param_0, u8 i_alpha) {
 #if TARGET_PC
     static const u64 cont_zt[5] = {MULTI_CHAR('cont_zt'), MULTI_CHAR('cont_zt1'), MULTI_CHAR('cont_zt2'), MULTI_CHAR('cont_zt3'), MULTI_CHAR('cont_zt4')};
     static const u64 font_zt[5] = {MULTI_CHAR('font_zt1'), MULTI_CHAR('font_zt2'), MULTI_CHAR('font_zt3'), MULTI_CHAR('font_zt4'), MULTI_CHAR('font_zt5')};
-    auto setZButtonString_font_zt = dusk::version::isRegionJpn() ? cont_zt : font_zt;
+    auto setZButtonString_font_zt = dusk::version::isJpnOrLessThanWiiJpn() ? cont_zt : font_zt;
 #elif VERSION == VERSION_GCN_JPN
     static const u64 cont_zt[5] = {MULTI_CHAR('cont_zt'), MULTI_CHAR('cont_zt1'), MULTI_CHAR('cont_zt2'), MULTI_CHAR('cont_zt3'), MULTI_CHAR('cont_zt4')};
     #define setZButtonString_font_zt cont_zt
@@ -2953,10 +2954,7 @@ void dMenu_Fmap2DTop_c::setZButtonString(u32 param_0, u8 i_alpha) {
 #endif
     } else {
         for (int i = 0; i < 5; i++) {
-            dMeter2Info_getStringKanji(
-                param_0,
-                ((J2DTextBox*)(mpTitleScreen->search(setZButtonString_font_zt[i])))->getStringPtr(),
-                NULL);
+            dMeter2Info_getStringKanji(param_0, ((J2DTextBox*)(mpTitleScreen->search(setZButtonString_font_zt[i])))->getStringPtr(), NULL);
         }
 
         if (i_alpha == ALPHA_DEFAULT) {
@@ -2975,7 +2973,7 @@ void dMenu_Fmap2DTop_c::setBButtonString(u32 param_0, u8 i_alpha) {
 #if TARGET_PC
     static const u64 cont_bt[5] = {MULTI_CHAR('cont_bt1'), MULTI_CHAR('cont_bt2'), MULTI_CHAR('cont_bt3'), MULTI_CHAR('cont_bt4'), MULTI_CHAR('cont_bt')};
     static const u64 font_bt[5] = {MULTI_CHAR('font_bt1'), MULTI_CHAR('font_bt2'), MULTI_CHAR('font_bt3'), MULTI_CHAR('font_bt4'), MULTI_CHAR('font_bt5')};
-    auto setBButtonString_font_bt = dusk::version::isRegionJpn() ? cont_bt : font_bt;
+    auto setBButtonString_font_bt = dusk::version::isJpnOrLessThanWiiJpn() ? cont_bt : font_bt;
 #elif VERSION == VERSION_GCN_JPN
     static const u64 cont_bt[5] = {MULTI_CHAR('cont_bt1'), MULTI_CHAR('cont_bt2'), MULTI_CHAR('cont_bt3'), MULTI_CHAR('cont_bt4'), MULTI_CHAR('cont_bt')};
 #define setBButtonString_font_bt cont_bt
@@ -2987,10 +2985,7 @@ void dMenu_Fmap2DTop_c::setBButtonString(u32 param_0, u8 i_alpha) {
         mAlphaButtonB = ALPHA_MIN;
     } else {
         for (int i = 0; i < 5; i++) {
-            dMeter2Info_getStringKanji(
-                param_0,
-                ((J2DTextBox*)(mpTitleScreen->search(setBButtonString_font_bt[i])))->getStringPtr(),
-                NULL);
+            dMeter2Info_getStringKanji(param_0, ((J2DTextBox*)(mpTitleScreen->search(setBButtonString_font_bt[i])))->getStringPtr(), NULL);
         }
 
         if (i_alpha == ALPHA_DEFAULT) {
@@ -3005,7 +3000,7 @@ void dMenu_Fmap2DTop_c::setAButtonString(u32 param_0, u8 i_alpha) {
 #if TARGET_PC
     static const u64 cont_at[5] = {MULTI_CHAR('cont_at'), MULTI_CHAR('cont_at1'), MULTI_CHAR('cont_at2'), MULTI_CHAR('cont_at3'), MULTI_CHAR('cont_at4')};
     static const u64 font_at[5] = {MULTI_CHAR('font_at1'), MULTI_CHAR('font_at2'), MULTI_CHAR('font_at3'), MULTI_CHAR('font_at4'), MULTI_CHAR('font_at5')};
-    auto setAButtonString_font_at = dusk::version::isRegionJpn() ? cont_at : font_at;
+    auto setAButtonString_font_at = dusk::version::isJpnOrLessThanWiiJpn() ? cont_at : font_at;
 #elif VERSION == VERSION_GCN_JPN
     static const u64 cont_at[5] = {MULTI_CHAR('cont_at'), MULTI_CHAR('cont_at1'), MULTI_CHAR('cont_at2'), MULTI_CHAR('cont_at3'), MULTI_CHAR('cont_at4')};
 #define setAButtonString_font_at cont_at
@@ -3017,10 +3012,7 @@ void dMenu_Fmap2DTop_c::setAButtonString(u32 param_0, u8 i_alpha) {
         mAlphaButtonA = ALPHA_MIN;
     } else {
         for (int i = 0; i < 5; i++) {
-            dMeter2Info_getStringKanji(
-                param_0,
-                ((J2DTextBox*)(mpTitleScreen->search(setAButtonString_font_at[i])))->getStringPtr(),
-                NULL);
+            dMeter2Info_getStringKanji(param_0, ((J2DTextBox*)(mpTitleScreen->search(setAButtonString_font_at[i])))->getStringPtr(), NULL);
         }
 
         if (i_alpha == ALPHA_DEFAULT) {
@@ -3034,8 +3026,8 @@ void dMenu_Fmap2DTop_c::setAButtonString(u32 param_0, u8 i_alpha) {
 void dMenu_Fmap2DTop_c::setCrossLRString(u32 param_0) {
 #if PLATFORM_GCN || (VERSION == VERSION_SHIELD)
 #if TARGET_PC
-    static const u64 juji_c_jpn[5] = {MULTI_CHAR('juji_c00'), MULTI_CHAR('juji_c01'), MULTI_CHAR('juji_c02'), MULTI_CHAR('juji_c03'), MULTI_CHAR('juji_c04')};
-    static const u64 juji_c[5] = {MULTI_CHAR('fuji_c00'), MULTI_CHAR('fuji_c01'), MULTI_CHAR('fuji_c02'), MULTI_CHAR('fuji_c03'), MULTI_CHAR('fuji_c04')};
+    static const u64 juji_c[5] = {MULTI_CHAR('juji_c00'), MULTI_CHAR('juji_c01'), MULTI_CHAR('juji_c02'), MULTI_CHAR('juji_c03'), MULTI_CHAR('juji_c04')};
+    static const u64 fuji_c[5] = {MULTI_CHAR('fuji_c00'), MULTI_CHAR('fuji_c01'), MULTI_CHAR('fuji_c02'), MULTI_CHAR('fuji_c03'), MULTI_CHAR('fuji_c04')};
 #elif VERSION == VERSION_GCN_JPN
     static const u64 juji_c[5] = {MULTI_CHAR('juji_c00'), MULTI_CHAR('juji_c01'), MULTI_CHAR('juji_c02'), MULTI_CHAR('juji_c03'), MULTI_CHAR('juji_c04')};
 #else
@@ -3043,14 +3035,14 @@ void dMenu_Fmap2DTop_c::setCrossLRString(u32 param_0) {
 #endif
     if (param_0 == 0) {
         for (int i = 0; i < 5; i++) {
-            J2DTextBox* text_box = static_cast<J2DTextBox*>(mpTitleScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? juji_c_jpn[i] : juji_c[i], juji_c[i])));
+            J2DTextBox* text_box = static_cast<J2DTextBox*>(mpTitleScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? juji_c[i] : fuji_c[i], juji_c[i])));
             SAFE_STRCPY(text_box->getStringPtr(), "");
         }
         mpTitleScreen->search(MULTI_CHAR('juy_sha0'))->show();
         mAlphaDpad = 1;
     } else {
         for (int i = 0; i < 5; i++) {
-            J2DTextBox* text_box = static_cast<J2DTextBox*>(mpTitleScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? juji_c_jpn[i] : juji_c[i], juji_c[i])));
+            J2DTextBox* text_box = static_cast<J2DTextBox*>(mpTitleScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? juji_c[i] : fuji_c[i], juji_c[i])));
             dMeter2Info_getStringKanji(param_0, text_box->getStringPtr(), NULL);
         }
         mpTitleScreen->search(MULTI_CHAR('juy_sha0'))->show();
@@ -3062,8 +3054,8 @@ void dMenu_Fmap2DTop_c::setCrossLRString(u32 param_0) {
 void dMenu_Fmap2DTop_c::set3DStickString(u32 param_0) {
 #if PLATFORM_GCN || (VERSION == VERSION_SHIELD)
 #if TARGET_PC
-    static const u64 ast_c_jpn[5] = {MULTI_CHAR('ast_00'), MULTI_CHAR('ast_01'), MULTI_CHAR('ast_02'), MULTI_CHAR('ast_03'), MULTI_CHAR('ast_04')};
-    static const u64 ast_c[5] = {MULTI_CHAR('fst_00'), MULTI_CHAR('fst_01'), MULTI_CHAR('fst_02'), MULTI_CHAR('fst_03'), MULTI_CHAR('fst_04')};
+    static const u64 ast_c[5] = {MULTI_CHAR('ast_00'), MULTI_CHAR('ast_01'), MULTI_CHAR('ast_02'), MULTI_CHAR('ast_03'), MULTI_CHAR('ast_04')};
+    static const u64 fst_c[5] = {MULTI_CHAR('fst_00'), MULTI_CHAR('fst_01'), MULTI_CHAR('fst_02'), MULTI_CHAR('fst_03'), MULTI_CHAR('fst_04')};
 #elif VERSION == VERSION_GCN_JPN
     static const u64 ast_c[5] = {MULTI_CHAR('ast_00'), MULTI_CHAR('ast_01'), MULTI_CHAR('ast_02'), MULTI_CHAR('ast_03'), MULTI_CHAR('ast_04')};
 #else
@@ -3071,14 +3063,14 @@ void dMenu_Fmap2DTop_c::set3DStickString(u32 param_0) {
 #endif
     if (param_0 == 0) {
         for (int i = 0; i < 5; i++) {
-            J2DTextBox* text_box = static_cast<J2DTextBox*>(mpTitleScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? ast_c_jpn[i] : ast_c[i], ast_c[i])));
+            J2DTextBox* text_box = static_cast<J2DTextBox*>(mpTitleScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? ast_c[i] : fst_c[i], ast_c[i])));
             SAFE_STRCPY(text_box->getStringPtr(), "");
         }
         mpTitleScreen->search(MULTI_CHAR('as_sha0'))->show();
         mAlphaAnalogStick = 1;
     } else {
         for (int i = 0; i < 5; i++) {
-            J2DTextBox* text_box = static_cast<J2DTextBox*>(mpTitleScreen->search(DUSK_IF_ELSE(dusk::version::isRegionJpn() ? ast_c_jpn[i] : ast_c[i], ast_c[i])));
+            J2DTextBox* text_box = static_cast<J2DTextBox*>(mpTitleScreen->search(DUSK_IF_ELSE(dusk::version::isJpnOrLessThanWiiJpn() ? ast_c[i] : fst_c[i], ast_c[i])));
             dMeter2Info_getStringKanji(param_0, text_box->getStringPtr(), NULL);
         }
         mpTitleScreen->search(MULTI_CHAR('as_sha0'))->show();

--- a/src/d/d_menu_option.cpp
+++ b/src/d/d_menu_option.cpp
@@ -1710,9 +1710,11 @@ void dMenu_Option_c::screenSet() {
     mpString->getString(0x55C, field_0x270[2], NULL, NULL, NULL, 0);
     for (int i = 0; i < 5; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             field_0x25c[i] = (J2DTextBox*)mpTVScreen->search(tv_btnA[i]);
-            mpTVScreen->search(ftv_btnA[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpTVScreen->search(ftv_btnA[i])->hide();
+            }
         } else {
             field_0x25c[i] = (J2DTextBox*)mpTVScreen->search(ftv_btnA[i]);
             mpTVScreen->search(tv_btnA[i])->hide();

--- a/src/d/d_menu_option.cpp
+++ b/src/d/d_menu_option.cpp
@@ -159,7 +159,9 @@ void dMenu_Option_c::_create() {
     
     mpTVButtonText = JKR_NEW CPaneMgr(mpTVScreen, MULTI_CHAR('a_text_n'), 0, NULL);
     JUT_ASSERT(298, mpTVButtonText != NULL);
+    IF_DUSK_BLOCK(dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn)
     mpTVScreen->search(MULTI_CHAR('g_abtn_n'))->hide();
+    IF_DUSK_BLOCK_END
 
     mpScreenIcon = JKR_NEW J2DScreen();
     JUT_ASSERT(325, mpScreenIcon != NULL);

--- a/src/d/d_menu_ring.cpp
+++ b/src/d/d_menu_ring.cpp
@@ -333,16 +333,13 @@ dMenu_Ring_c::dMenu_Ring_c(JKRExpHeap* i_heap, STControl* i_stick, CSTControl* i
         mpScreen->search(MULTI_CHAR('yx_te_s3'))->hide();
         mpScreen->search(MULTI_CHAR('yx_te_s4'))->hide();
         mpScreen->search(MULTI_CHAR('yx_text'))->hide();
-#if TARGET_PC
-        if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn)
-#endif
-        {
-            mpScreen->search(MULTI_CHAR('fyx_te_1'))->hide();
-            mpScreen->search(MULTI_CHAR('fyx_te_2'))->hide();
-            mpScreen->search(MULTI_CHAR('fyx_te_3'))->hide();
-            mpScreen->search(MULTI_CHAR('fyx_te_4'))->hide();
-            mpScreen->search(MULTI_CHAR('fyx_tex'))->hide();
-        }
+        IF_DUSK_BLOCK(dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn)
+        mpScreen->search(MULTI_CHAR('fyx_te_1'))->hide();
+        mpScreen->search(MULTI_CHAR('fyx_te_2'))->hide();
+        mpScreen->search(MULTI_CHAR('fyx_te_3'))->hide();
+        mpScreen->search(MULTI_CHAR('fyx_te_4'))->hide();
+        mpScreen->search(MULTI_CHAR('fyx_tex'))->hide();
+        IF_DUSK_BLOCK_END
         mpScreen->search(MULTI_CHAR('x_btn_n'))->hide();
         mpScreen->search(MULTI_CHAR('y_btn_n'))->hide();
     }

--- a/src/d/d_menu_ring.cpp
+++ b/src/d/d_menu_ring.cpp
@@ -333,11 +333,16 @@ dMenu_Ring_c::dMenu_Ring_c(JKRExpHeap* i_heap, STControl* i_stick, CSTControl* i
         mpScreen->search(MULTI_CHAR('yx_te_s3'))->hide();
         mpScreen->search(MULTI_CHAR('yx_te_s4'))->hide();
         mpScreen->search(MULTI_CHAR('yx_text'))->hide();
-        mpScreen->search(MULTI_CHAR('fyx_te_1'))->hide();
-        mpScreen->search(MULTI_CHAR('fyx_te_2'))->hide();
-        mpScreen->search(MULTI_CHAR('fyx_te_3'))->hide();
-        mpScreen->search(MULTI_CHAR('fyx_te_4'))->hide();
-        mpScreen->search(MULTI_CHAR('fyx_tex'))->hide();
+#if TARGET_PC
+        if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn)
+#endif
+        {
+            mpScreen->search(MULTI_CHAR('fyx_te_1'))->hide();
+            mpScreen->search(MULTI_CHAR('fyx_te_2'))->hide();
+            mpScreen->search(MULTI_CHAR('fyx_te_3'))->hide();
+            mpScreen->search(MULTI_CHAR('fyx_te_4'))->hide();
+            mpScreen->search(MULTI_CHAR('fyx_tex'))->hide();
+        }
         mpScreen->search(MULTI_CHAR('x_btn_n'))->hide();
         mpScreen->search(MULTI_CHAR('y_btn_n'))->hide();
     }
@@ -345,9 +350,11 @@ dMenu_Ring_c::dMenu_Ring_c(JKRExpHeap* i_heap, STControl* i_stick, CSTControl* i
     for (i = 0; i < 5; i++) {
 #if TARGET_PC
         J2DTextBox* fxy_TextBox;
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             fxy_TextBox = (J2DTextBox*)mpScreen->search(xy_text[i]);
-            mpScreen->search(fxy_text[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpScreen->search(fxy_text[i])->hide();
+            }
         } else {
             fxy_TextBox = (J2DTextBox*)mpScreen->search(fxy_text[i]);
             mpScreen->search(xy_text[i])->hide();
@@ -366,13 +373,17 @@ dMenu_Ring_c::dMenu_Ring_c(JKRExpHeap* i_heap, STControl* i_stick, CSTControl* i
     for (i = 0; i < 5; i++) {
 #if TARGET_PC
         J2DTextBox* fc_TextBox;
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             if (dusk::getSettings().game.swapDirectSelect) {
                 fc_TextBox = (J2DTextBox*)mpScreen->search(c_text1[i]);
-                mpScreen->search(fc_text1[i])->hide();
+                if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                    mpScreen->search(fc_text1[i])->hide();
+                }
             } else {
                 fc_TextBox = (J2DTextBox*)mpScreen->search(c_text[i]);
-                mpScreen->search(fc_text[i])->hide();
+                if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                    mpScreen->search(fc_text[i])->hide();
+                }
             }
         } else {
             if (dusk::getSettings().game.swapDirectSelect) {
@@ -397,13 +408,17 @@ dMenu_Ring_c::dMenu_Ring_c(JKRExpHeap* i_heap, STControl* i_stick, CSTControl* i
     for (i = 0; i < 5; i++) {
 #if TARGET_PC
         J2DTextBox* fc1_TextBox;
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             if (dusk::getSettings().game.swapDirectSelect) {
                 fc1_TextBox = (J2DTextBox*)mpScreen->search(c_text[i]);
-                mpScreen->search(fc_text[i])->hide();
+                if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                    mpScreen->search(fc_text[i])->hide();
+                }
             } else {
                 fc1_TextBox = (J2DTextBox*)mpScreen->search(c_text1[i]);
-                mpScreen->search(fc_text1[i])->hide();
+                if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                    mpScreen->search(fc_text1[i])->hide();
+                }
             }
         } else {
             if (dusk::getSettings().game.swapDirectSelect) {
@@ -427,9 +442,11 @@ dMenu_Ring_c::dMenu_Ring_c(JKRExpHeap* i_heap, STControl* i_stick, CSTControl* i
     }
     for (int i = 0; i < 5; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             mpComboOffString[i] = (J2DTextBox*)mpScreen->search(t_on[i]);
-            mpScreen->search(ft_on[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpScreen->search(ft_on[i])->hide();
+            }
         } else {
             mpComboOffString[i] = (J2DTextBox*)mpScreen->search(ft_on[i]);
             mpScreen->search(t_on[i])->hide();
@@ -447,9 +464,11 @@ dMenu_Ring_c::dMenu_Ring_c(JKRExpHeap* i_heap, STControl* i_stick, CSTControl* i
     }
     for (int i = 0; i < 5; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             mpBowArrowComboString[i] = (J2DTextBox*)mpScreen->search(t_off[i]);
-            mpScreen->search(ft_off[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpScreen->search(ft_off[i])->hide();
+            }
         } else {
             mpBowArrowComboString[i] = (J2DTextBox*)mpScreen->search(ft_off[i]);
             mpScreen->search(t_off[i])->hide();
@@ -486,19 +505,21 @@ dMenu_Ring_c::dMenu_Ring_c(JKRExpHeap* i_heap, STControl* i_stick, CSTControl* i
     mpCircle = JKR_NEW CPaneMgr(mpCenterScreen, MULTI_CHAR('circle_n'), 2, NULL);
     J2DTextBox* textBox[4];
 #if TARGET_PC
-    if (dusk::version::isRegionJpn()) {
+    if (dusk::version::isJpnOrLessThanWiiJpn()) {
         textBox[0] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n04'));
         textBox[1] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n05'));
         textBox[2] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n06'));
         textBox[3] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n07'));
-        J2DPane* pane = mpCenterScreen->search(MULTI_CHAR('fitem_n1'));
-        pane->mVisible = false;
-        pane = mpCenterScreen->search(MULTI_CHAR('fitem_n2'));
-        pane->mVisible = false;
-        pane = mpCenterScreen->search(MULTI_CHAR('fitem_n3'));
-        pane->mVisible = false;
-        pane = mpCenterScreen->search(MULTI_CHAR('fitem_n4'));
-        pane->mVisible = false;
+        if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+            J2DPane* pane = mpCenterScreen->search(MULTI_CHAR('fitem_n1'));
+            pane->mVisible = false;
+            pane = mpCenterScreen->search(MULTI_CHAR('fitem_n2'));
+            pane->mVisible = false;
+            pane = mpCenterScreen->search(MULTI_CHAR('fitem_n3'));
+            pane->mVisible = false;
+            pane = mpCenterScreen->search(MULTI_CHAR('fitem_n4'));
+            pane->mVisible = false;
+        }
     } else {
         textBox[0] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('fitem_n1'));
         textBox[1] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('fitem_n2'));
@@ -1292,17 +1313,11 @@ void dMenu_Ring_c::setScale() {
 void dMenu_Ring_c::setNameString(u32 i_stringID) {
     J2DTextBox* textBox[4];
 #if TARGET_PC
-    if (dusk::version::isRegionJpn()) {
-        textBox[0] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n04'));
-        textBox[1] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n05'));
-        textBox[2] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n06'));
-        textBox[3] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n07'));
-    } else {
-        textBox[0] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('fitem_n1'));
-        textBox[1] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('fitem_n2'));
-        textBox[2] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('fitem_n3'));
-        textBox[3] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('fitem_n4'));
-    }
+    const bool useDomestic = dusk::version::isJpnOrLessThanWiiJpn();
+    textBox[0] = (J2DTextBox*)mpCenterScreen->search(useDomestic ? MULTI_CHAR('item_n04') : MULTI_CHAR('fitem_n1'));
+    textBox[1] = (J2DTextBox*)mpCenterScreen->search(useDomestic ? MULTI_CHAR('item_n05') : MULTI_CHAR('fitem_n2'));
+    textBox[2] = (J2DTextBox*)mpCenterScreen->search(useDomestic ? MULTI_CHAR('item_n06') : MULTI_CHAR('fitem_n3'));
+    textBox[3] = (J2DTextBox*)mpCenterScreen->search(useDomestic ? MULTI_CHAR('item_n07') : MULTI_CHAR('fitem_n4'));
 #elif VERSION == VERSION_GCN_JPN
     textBox[0] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n04'));
     textBox[1] = (J2DTextBox*)mpCenterScreen->search(MULTI_CHAR('item_n05'));

--- a/src/d/d_meter2_draw.cpp
+++ b/src/d/d_meter2_draw.cpp
@@ -1386,6 +1386,22 @@ void dMeter2Draw_c::initButtonCross() {
     dMeter2Info_getString(
         0x62, static_cast<J2DTextBox*>(mpScreen->search(MULTI_CHAR('cont_ju9')))->getStringPtr(), NULL);
 
+#if TARGET_PC
+    // These panes are not wide enough for French text (and possibly other languages)
+    // on Wii PAL. Resize them to always match their counterparts in later releases.
+    static u64 const juTags[] = {
+        MULTI_CHAR('cont_ju0'), MULTI_CHAR('cont_ju1'), MULTI_CHAR('cont_ju2'),
+        MULTI_CHAR('cont_ju3'), MULTI_CHAR('cont_ju4'), MULTI_CHAR('cont_ju5'),
+        MULTI_CHAR('cont_ju6'), MULTI_CHAR('cont_ju7'), MULTI_CHAR('cont_ju8'),
+        MULTI_CHAR('cont_ju9'),
+    };
+
+    for (u64 tag : juTags) {
+        J2DPane* pane = mpScreen->search(tag);
+        pane->resize(120.0f, pane->getHeight());
+    }
+#endif
+
     mpButtonCrossParent->setAlphaRate(0.0f);
     drawButtonCross(g_drawHIO.mButtonCrossOFFPosX, g_drawHIO.mButtonCrossOFFPosY);
 }

--- a/src/d/d_meter_button.cpp
+++ b/src/d/d_meter_button.cpp
@@ -1208,9 +1208,11 @@ void dMeterButton_c::screenInitButton() {
 
     for (int i = 0; i < 10; i++) {
 #if TARGET_PC
-        if (dusk::version::isRegionJpn()) {
+        if (dusk::version::isJpnOrLessThanWiiJpn()) {
             mpTextBox[i] = (J2DTextBox*)mpButtonScreen->search(text_tag[i]);
-            mpButtonScreen->search(ftext_tag[i])->hide();
+            if (dusk::version::getGameVersion() >= dusk::version::GameVersion::WiiJpn) {
+                mpButtonScreen->search(ftext_tag[i])->hide();
+            }
         } else {
             mpTextBox[i] = (J2DTextBox*)mpButtonScreen->search(ftext_tag[i]);
             mpButtonScreen->search(text_tag[i])->hide();

--- a/src/d/d_msg_object.cpp
+++ b/src/d/d_msg_object.cpp
@@ -30,6 +30,7 @@
 #include "m_Do/m_Do_lib.h"
 
 #if TARGET_PC
+#include "dusk/language.hpp"
 #include "dusk/menu_pointer.h"
 #include "dusk/settings.h"
 #include "dusk/version.hpp"
@@ -1731,7 +1732,9 @@ void dMsgObject_c::readMessageGroupLocal(mDoDvdThd_mountXArchive_c** p_arcMount)
 #endif
 
     int msgGroup = dStage_stagInfo_GetMsgGroup(dComIfGp_getStage()->getStagInfo());
-    #if REGION_PAL
+#if TARGET_PC
+    snprintf(arcName, sizeof(arcName), "/res/%s/bmgres%d.arc", dusk::language::msg_folder(), msgGroup);
+#elif REGION_PAL
     switch (dComIfGs_getPalLanguage()) {
     case dSv_player_config_c::LANGUAGE_GERMAN:
         sprintf(arcName, "/res/Msgde/bmgres%d.arc", msgGroup);
@@ -1748,39 +1751,11 @@ void dMsgObject_c::readMessageGroupLocal(mDoDvdThd_mountXArchive_c** p_arcMount)
     default:
         sprintf(arcName, "/res/Msguk/bmgres%d.arc", msgGroup);
     }
-    #elif REGION_JPN
+#elif REGION_JPN
     sprintf(arcName, "/res/Msgjp/bmgres%d.arc", msgGroup);
-    #else
-#if TARGET_PC
-    // Original game UB
-
-    if (dusk::version::isRegionPal()) {
-        switch (dComIfGs_getPalLanguage()) {
-        case dSv_player_config_c::LANGUAGE_GERMAN:
-            snprintf(arcName, sizeof(arcName), "/res/Msgde/bmgres%d.arc", msgGroup);
-            break;
-        case dSv_player_config_c::LANGUAGE_FRENCH:
-            snprintf(arcName, sizeof(arcName), "/res/Msgfr/bmgres%d.arc", msgGroup);
-            break;
-        case dSv_player_config_c::LANGUAGE_SPANISH:
-            snprintf(arcName, sizeof(arcName), "/res/Msgsp/bmgres%d.arc", msgGroup);
-            break;
-        case dSv_player_config_c::LANGUAGE_ITALIAN:
-            snprintf(arcName, sizeof(arcName), "/res/Msgit/bmgres%d.arc", msgGroup);
-            break;
-        default:
-            snprintf(arcName, sizeof(arcName), "/res/Msguk/bmgres%d.arc", msgGroup);
-        }
-    } else if (dusk::version::isRegionJpn()) {
-        snprintf(arcName, sizeof(arcName), "/res/Msgjp/bmgres%d.arc", msgGroup);
-    } else {
-        snprintf(arcName, sizeof(arcName), "/res/Msgus/bmgres%d.arc", msgGroup);
-    }
-
 #else
     sprintf(arcName, "/res/Msgus/bmgres%d.arc", msgGroup);
 #endif
-    #endif
 
     *p_arcMount = mDoDvdThd_mountXArchive_c::create(arcName, 0, JKRArchive::MOUNT_MEM, NULL);
 

--- a/src/d/d_s_logo.cpp
+++ b/src/d/d_s_logo.cpp
@@ -24,6 +24,7 @@
 #include "JSystem/JUtility/JUTConsole.h"
 
 #ifdef TARGET_PC
+#include "dusk/language.hpp"
 #include "dusk/logging.h"
 #include "dusk/main.h"
 #include "dusk/mods/svc/save.hpp"
@@ -1598,30 +1599,15 @@ void dScnLogo_c::dvdDataLoad() {
     mpButtonCommand = aramMount(BUTTON_RES_PATH, mDoExt_getJ2dHeap());
     mpCardIconCommand = aramMount(ICON_RES_PATH, mDoExt_getJ2dHeap());
 
-    #if TARGET_PC
-    if (isRegionPal()) {
-        switch (getPalLanguage()) {
-        case 1:
-            mpBmgResCommand = onMemMount("/res/Msgde/bmgres.arc");
-            break;
-        case 2:
-            mpBmgResCommand = onMemMount("/res/Msgfr/bmgres.arc");
-            break;
-        case 3:
-            mpBmgResCommand = onMemMount("/res/Msgsp/bmgres.arc");
-            break;
-        case 4:
-            mpBmgResCommand = onMemMount("/res/Msgit/bmgres.arc");
-            break;
-        case 0:
-        default:
-            mpBmgResCommand = onMemMount("/res/Msguk/bmgres.arc");
-            break;
-        }
-    } else {
-        mpBmgResCommand = onMemMount(MSG_PATH);
-    }
-    #elif VERSION == VERSION_GCN_PAL
+#if TARGET_PC
+#if AVOID_UB
+    static char bmgPath[32];
+#else
+    static char bmgPath[22];
+#endif
+    snprintf(bmgPath, sizeof(bmgPath), "/res/%s/bmgres.arc", dusk::language::msg_folder());
+    mpBmgResCommand = onMemMount(bmgPath);
+#elif VERSION == VERSION_GCN_PAL
     switch (getPalLanguage()) {
     case 1:
         mpBmgResCommand = onMemMount("/res/Msgde/bmgres.arc");
@@ -1640,7 +1626,7 @@ void dScnLogo_c::dvdDataLoad() {
         mpBmgResCommand = onMemMount("/res/Msguk/bmgres.arc");
         break;
     }
-    #elif VERSION == VERSION_SHIELD_DEBUG
+#elif VERSION == VERSION_SHIELD_DEBUG
     switch (getPalLanguage()) {
     case 2:
         mpBmgResCommand = onMemMount("/res/Msgfr/bmgres.arc");
@@ -1652,9 +1638,9 @@ void dScnLogo_c::dvdDataLoad() {
         mpBmgResCommand = onMemMount("/res/Msgus/bmgres.arc");
         break;
     }
-    #else
+#else
     mpBmgResCommand = onMemMount(MSG_PATH);
-    #endif
+#endif
 
     mpMsgComCommand = aramMount(MSG_COM_PATH, mDoExt_getJ2dHeap());
     mpMsgResCommand[0] = aramMount(MSG_RES0_PATH, mDoExt_getJ2dHeap());

--- a/src/d/d_s_logo.cpp
+++ b/src/d/d_s_logo.cpp
@@ -996,7 +996,7 @@ dScnLogo_c::~dScnLogo_c() {
     mDoExt_setAraCacheSize(free_size - aram_heap->getTotalFreeSize());
 
 #if TARGET_PC
-    if (getGameVersion() == GameVersion::GcnJpn) {
+    if (isRegionJpn()) {
         if (dComIfGp_getFontArchive() != NULL) {
             dComIfGp_getFontArchive()->unmount();
             dComIfGp_setFontArchive(NULL);

--- a/src/d/d_s_logo.cpp
+++ b/src/d/d_s_logo.cpp
@@ -884,7 +884,7 @@ dScnLogo_c::~dScnLogo_c() {
     JKR_DELETE(mProgressiveSel);
 
     #if TARGET_PC
-    if (getGameVersion() == GameVersion::GcnPal) {
+    if (isRegionPal()) {
         mpPalLogoResCommand->getArchive()->removeResourceAll();
         mpPalLogoResCommand->getArchive()->unmount();
         mpPalLogoResCommand->destroy();
@@ -1059,7 +1059,7 @@ static int phase_0(dScnLogo_c* i_this) {
     JKRHEAP_NAME(i_this->mLogo01Heap, "Logo01");
 
     #if TARGET_PC || VERSION == VERSION_GCN_PAL
-    IF_DUSK_BLOCK(getGameVersion() == GameVersion::GcnPal)
+    IF_DUSK_BLOCK(isRegionPal())
     switch (i_this->getPalLanguage()) {
     case 1:
         i_this->mpPalLogoResCommand = mDoDvdThd_mountArchive_c::create("/res/Layout/LogoPalGm.arc", 0, NULL);
@@ -1100,7 +1100,7 @@ static int phase_1(dScnLogo_c* i_this) {
     #endif
 
     #if TARGET_PC || VERSION == VERSION_GCN_PAL
-    IF_DUSK_BLOCK(getGameVersion() == GameVersion::GcnPal)
+    IF_DUSK_BLOCK(isRegionPal())
     if (!mDoDvdThd::SyncWidthSound) {
         return cPhs_INIT_e;
     }
@@ -1335,7 +1335,7 @@ void dScnLogo_c::logoInitGC() {
     mDolbyLogo = JKR_NEW dDlst_2D_c(dolbyImg, 189, 150, 232, 112, 255);
 
 #if TARGET_PC
-    if (getGameVersion() == GameVersion::GcnPal) {
+    if (isRegionPal()) {
         u8 language = getPalLanguage();
         if (language >= 5) {
             language = 0;
@@ -1599,7 +1599,7 @@ void dScnLogo_c::dvdDataLoad() {
     mpCardIconCommand = aramMount(ICON_RES_PATH, mDoExt_getJ2dHeap());
 
     #if TARGET_PC
-    if (getGameVersion() == GameVersion::GcnPal) {
+    if (isRegionPal()) {
         switch (getPalLanguage()) {
         case 1:
             mpBmgResCommand = onMemMount("/res/Msgde/bmgres.arc");

--- a/src/d/d_s_logo.cpp
+++ b/src/d/d_s_logo.cpp
@@ -53,8 +53,8 @@ struct homeBtnData {
 #if TARGET_PC
 using namespace dusk::version;
 
-#define LOGO_ARC versionSelect<const char*>({{GameVersion::GcnJpn, "Logo"}, {GameVersion::GcnPal, "LogoPal"}, {GameVersion::WiiJpn, "Logo"}, {GameVersion::WiiPal, "LogoPal"}}, "LogoUs")
-#define MSG_PATH versionSelect<const char*>({{GameVersion::GcnJpn, "/res/Msgjp/bmgres.arc"}, {GameVersion::WiiJpn, "/res/Msgjp/bmgres.arc"}}, "/res/Msgus/bmgres.arc")
+#define LOGO_ARC regionSelect<const char*>("LogoUs", "LogoPal", "Logo")
+#define MSG_PATH regionSelect<const char*>("/res/Msgus/bmgres.arc", "/res/Msgus/bmgres.arc", "/res/Msgjp/bmgres.arc")
 #elif VERSION == VERSION_SHIELD
 #define LOGO_ARC "LogoUs"
 #define MSG_PATH  "/res/Msgcn/bmgres.arc"
@@ -81,15 +81,15 @@ using namespace dusk::version;
 #if TARGET_PC && 0
 using namespace dusk::version;
 
-#define FMAP_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/fmapres.arc"}, {GameVersion::GcnPal, "/res/Layout/fmapres.arc"}, {GameVersion::GcnJpn, "/res/Layout/fmapres.arc"}}, "/res/LayoutRevo/fmapresR.arc")
-#define DMAP_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/dmapres.arc"}, {GameVersion::GcnPal, "/res/Layout/dmapres.arc"}, {GameVersion::GcnJpn, "/res/Layout/dmapres.arc"}}, "/res/LayoutRevo/dmapresR.arc")
-#define COLLECT_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/clctres.arc"}, {GameVersion::GcnPal, "/res/Layout/clctres.arc"}, {GameVersion::GcnJpn, "/res/Layout/clctres.arc"}}, "/res/LayoutRevo/clctresR.arc")
+#define FMAP_RES_PATH platformSelect("/res/Layout/fmapres.arc", "/res/LayoutRevo/fmapresR.arc")
+#define DMAP_RES_PATH platformSelect("/res/Layout/dmapres.arc", "/res/LayoutRevo/dmapresR.arc")
+#define COLLECT_RES_PATH platformSelect("/res/Layout/clctres.arc", "/res/LayoutRevo/clctresR.arc")
 
-#define MSG_COM_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgcom.arc"}, {GameVersion::GcnPal, "/res/Layout/msgcom.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgcom.arc"}}, "/res/LayoutRevo/msgcomR.arc")
-#define MSG_RES0_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgres00.arc"}, {GameVersion::GcnPal, "/res/Layout/msgres00.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgres00.arc"}}, "/res/LayoutRevo/msgres00R.arc")
-#define MSG_RES1_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgres01.arc"}, {GameVersion::GcnPal, "/res/Layout/msgres01.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgres01.arc"}}, "/res/LayoutRevo/msgres01R.arc")
-#define MSG_RES2_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgres02.arc"}, {GameVersion::GcnPal, "/res/Layout/msgres02.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgres02.arc"}}, "/res/LayoutRevo/msgres02R.arc")
-#define MSG_RES3_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgres03.arc"}, {GameVersion::GcnPal, "/res/Layout/msgres03.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgres03.arc"}}, "/res/LayoutRevo/msgres03R.arc")
+#define MSG_COM_PATH platformSelect("/res/Layout/msgcom.arc", "/res/LayoutRevo/msgcomR.arc")
+#define MSG_RES0_PATH platformSelect("/res/Layout/msgres00.arc", "/res/LayoutRevo/msgres00R.arc")
+#define MSG_RES1_PATH platformSelect("/res/Layout/msgres01.arc", "/res/LayoutRevo/msgres01R.arc")
+#define MSG_RES2_PATH platformSelect("/res/Layout/msgres02.arc", "/res/LayoutRevo/msgres02R.arc")
+#define MSG_RES3_PATH platformSelect("/res/Layout/msgres03.arc", "/res/LayoutRevo/msgres03R.arc")
 #elif PLATFORM_WII || VERSION == VERSION_SHIELD_DEBUG
 #define FMAP_RES_PATH "/res/LayoutRevo/fmapresR.arc"
 #define DMAP_RES_PATH "/res/LayoutRevo/dmapresR.arc"
@@ -114,7 +114,7 @@ using namespace dusk::version;
 
 #if TARGET_PC
 #define ICON_RES_PATH "/res/CardIcon/cardicon.arc"
-#define PARTICLE_COM_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Particle/common.jpc"}, {GameVersion::GcnPal, "/res/Particle/common.jpc"}, {GameVersion::GcnJpn, "/res/Particle/common.jpc"}}, "/res/Particle/common-r.jpc")
+#define PARTICLE_COM_PATH platformSelect<const char*>("/res/Particle/common.jpc", "/res/Particle/common-r.jpc")
 #elif PLATFORM_WII || PLATFORM_SHIELD
 #define ICON_RES_PATH "/res/WiiBannerIcon/bannerIcon.arc"
 #define PARTICLE_COM_PATH "/res/Particle/common-r.jpc"
@@ -125,10 +125,10 @@ using namespace dusk::version;
 
 // TODO: Probably shouldn't actually load LayoutRevo, so I disabled it for now
 #if TARGET_PC && 0
-#define RING_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/ringres.arc"}, {GameVersion::GcnPal, "/res/Layout/ringres.arc"}, {GameVersion::GcnJpn, "/res/Layout/ringres.arc"}}, "/res/LayoutRevo/ringresR.arc")
-#define ITEM_INF_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/itmInfRes.arc"}, {GameVersion::GcnPal, "/res/Layout/itmInfRes.arc"}, {GameVersion::GcnJpn, "/res/Layout/itmInfRes.arc"}}, "/res/LayoutRevo/itmInfResR.arc")
-#define BUTTON_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/button.arc"}, {GameVersion::GcnPal, "/res/Layout/button.arc"}, {GameVersion::GcnJpn, "/res/Layout/button.arc"}}, "/res/LayoutRevo/buttonR.arc")
-#define MAIN2D_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/main2D.arc"}, {GameVersion::GcnPal, "/res/Layout/main2D.arc"}, {GameVersion::GcnJpn, "/res/Layout/main2D.arc"}}, "/res/LayoutRevo/main2DR.arc")
+#define RING_RES_PATH platformSelect("/res/Layout/ringres.arc", "/res/LayoutRevo/ringresR.arc")
+#define ITEM_INF_RES_PATH platformSelect("/res/Layout/itmInfRes.arc", "/res/LayoutRevo/itmInfResR.arc")
+#define BUTTON_RES_PATH platformSelect("/res/Layout/button.arc", "/res/LayoutRevo/buttonR.arc")
+#define MAIN2D_PATH platformSelect("/res/Layout/main2D.arc", "/res/LayoutRevo/main2DR.arc")
 #elif PLATFORM_WII
 #define RING_RES_PATH "/res/LayoutRevo/ringresR.arc"
 #define ITEM_INF_RES_PATH "/res/LayoutRevo/itmInfResR.arc"
@@ -1662,7 +1662,9 @@ void dScnLogo_c::dvdDataLoad() {
     mpMsgResCommand[2] = aramMount(MSG_RES2_PATH, mDoExt_getJ2dHeap());
     mpMsgResCommand[3] = aramMount(MSG_RES3_PATH, mDoExt_getJ2dHeap());
 #if TARGET_PC
-    const auto res4Path = versionSelect<const char*>({{GameVersion::GcnJpn, "/res/Layout/msgres04.arc"}, {GameVersion::WiiJpn, "/res/Layout/msgres04.arc"}}, "/res/Layout/msgres04F.arc");
+    const auto res4Path = regionSelect<const char*>("/res/Layout/msgres04F.arc",
+                                                    "/res/Layout/msgres04F.arc",
+                                                    "/res/Layout/msgres04.arc");
     mpMsgResCommand[4] = aramMount(res4Path, mDoExt_getJ2dHeap());
 #elif VERSION == VERSION_GCN_JPN
     mpMsgResCommand[4] = aramMount("/res/Layout/msgres04.arc", mDoExt_getJ2dHeap());
@@ -1675,20 +1677,12 @@ void dScnLogo_c::dvdDataLoad() {
     mpMain2DCommand = onMemMount(MAIN2D_PATH);
 
 #if TARGET_PC
-    const auto fontResPath = versionSelect<const char*>(
-        {
-            {GameVersion::GcnJpn, "/res/Fontjp/fontres.arc"},
-            {GameVersion::GcnPal, "/res/Fonteu/fontres.arc"},
-            {GameVersion::WiiJpn, "/res/Fontjp/fontres.arc"},
-            {GameVersion::WiiPal, "/res/Fonteu/fontres.arc"},
-        }, "/res/Fontus/fontres.arc");
-    const auto fontRubyPath = versionSelect<const char*>(
-        {
-            {GameVersion::GcnJpn, "/res/Fontjp/rubyres.arc"},
-            {GameVersion::GcnPal, "/res/Fonteu/rubyres.arc"},
-            {GameVersion::WiiJpn, "/res/Fontjp/rubyres.arc"},
-            {GameVersion::WiiPal, "/res/Fonteu/rubyres.arc"},
-        }, "/res/Fontus/rubyres.arc");
+    const auto fontResPath = regionSelect<const char*>("/res/Fontus/fontres.arc",
+                                                       "/res/Fonteu/fontres.arc",
+                                                       "/res/Fontjp/fontres.arc");
+    const auto fontRubyPath = regionSelect<const char*>("/res/Fontus/rubyres.arc",
+                                                        "/res/Fonteu/rubyres.arc",
+                                                        "/res/Fontjp/rubyres.arc");
 
     // Note: GCN_JPN mounts this archive as tail instead of head.
     // I'm guessing this is fine since we have more RAM.

--- a/src/d/d_s_logo.cpp
+++ b/src/d/d_s_logo.cpp
@@ -53,8 +53,8 @@ struct homeBtnData {
 #if TARGET_PC
 using namespace dusk::version;
 
-#define LOGO_ARC versionSelect<const char*>({{GameVersion::GcnJpn, "Logo"}, {GameVersion::GcnPal, "LogoPal"}}, "LogoUs")
-#define MSG_PATH versionSelect<const char*>({{GameVersion::GcnJpn, "/res/Msgjp/bmgres.arc"}}, "/res/Msgus/bmgres.arc")
+#define LOGO_ARC versionSelect<const char*>({{GameVersion::GcnJpn, "Logo"}, {GameVersion::GcnPal, "LogoPal"}, {GameVersion::WiiJpn, "Logo"}, {GameVersion::WiiPal, "LogoPal"}}, "LogoUs")
+#define MSG_PATH versionSelect<const char*>({{GameVersion::GcnJpn, "/res/Msgjp/bmgres.arc"}, {GameVersion::WiiJpn, "/res/Msgjp/bmgres.arc"}}, "/res/Msgus/bmgres.arc")
 #elif VERSION == VERSION_SHIELD
 #define LOGO_ARC "LogoUs"
 #define MSG_PATH  "/res/Msgcn/bmgres.arc"
@@ -77,7 +77,20 @@ using namespace dusk::version;
 #define PROGRESSIVE_MODE_ON  OS_PROGRESSIVE_MODE_ON
 #endif
 
-#if PLATFORM_WII || VERSION == VERSION_SHIELD_DEBUG
+// TODO: Probably shouldn't actually load LayoutRevo, so I disabled it for now
+#if TARGET_PC && 0
+using namespace dusk::version;
+
+#define FMAP_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/fmapres.arc"}, {GameVersion::GcnPal, "/res/Layout/fmapres.arc"}, {GameVersion::GcnJpn, "/res/Layout/fmapres.arc"}}, "/res/LayoutRevo/fmapresR.arc")
+#define DMAP_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/dmapres.arc"}, {GameVersion::GcnPal, "/res/Layout/dmapres.arc"}, {GameVersion::GcnJpn, "/res/Layout/dmapres.arc"}}, "/res/LayoutRevo/dmapresR.arc")
+#define COLLECT_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/clctres.arc"}, {GameVersion::GcnPal, "/res/Layout/clctres.arc"}, {GameVersion::GcnJpn, "/res/Layout/clctres.arc"}}, "/res/LayoutRevo/clctresR.arc")
+
+#define MSG_COM_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgcom.arc"}, {GameVersion::GcnPal, "/res/Layout/msgcom.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgcom.arc"}}, "/res/LayoutRevo/msgcomR.arc")
+#define MSG_RES0_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgres00.arc"}, {GameVersion::GcnPal, "/res/Layout/msgres00.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgres00.arc"}}, "/res/LayoutRevo/msgres00R.arc")
+#define MSG_RES1_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgres01.arc"}, {GameVersion::GcnPal, "/res/Layout/msgres01.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgres01.arc"}}, "/res/LayoutRevo/msgres01R.arc")
+#define MSG_RES2_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgres02.arc"}, {GameVersion::GcnPal, "/res/Layout/msgres02.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgres02.arc"}}, "/res/LayoutRevo/msgres02R.arc")
+#define MSG_RES3_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/msgres03.arc"}, {GameVersion::GcnPal, "/res/Layout/msgres03.arc"}, {GameVersion::GcnJpn, "/res/Layout/msgres03.arc"}}, "/res/LayoutRevo/msgres03R.arc")
+#elif PLATFORM_WII || VERSION == VERSION_SHIELD_DEBUG
 #define FMAP_RES_PATH "/res/LayoutRevo/fmapresR.arc"
 #define DMAP_RES_PATH "/res/LayoutRevo/dmapresR.arc"
 #define COLLECT_RES_PATH "/res/LayoutRevo/clctresR.arc"
@@ -99,7 +112,10 @@ using namespace dusk::version;
 #define MSG_RES3_PATH "/res/Layout/msgres03.arc"
 #endif
 
-#if PLATFORM_WII || PLATFORM_SHIELD
+#if TARGET_PC
+#define ICON_RES_PATH "/res/CardIcon/cardicon.arc"
+#define PARTICLE_COM_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Particle/common.jpc"}, {GameVersion::GcnPal, "/res/Particle/common.jpc"}, {GameVersion::GcnJpn, "/res/Particle/common.jpc"}}, "/res/Particle/common-r.jpc")
+#elif PLATFORM_WII || PLATFORM_SHIELD
 #define ICON_RES_PATH "/res/WiiBannerIcon/bannerIcon.arc"
 #define PARTICLE_COM_PATH "/res/Particle/common-r.jpc"
 #else
@@ -107,7 +123,13 @@ using namespace dusk::version;
 #define PARTICLE_COM_PATH "/res/Particle/common.jpc"
 #endif
 
-#if PLATFORM_WII
+// TODO: Probably shouldn't actually load LayoutRevo, so I disabled it for now
+#if TARGET_PC && 0
+#define RING_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/ringres.arc"}, {GameVersion::GcnPal, "/res/Layout/ringres.arc"}, {GameVersion::GcnJpn, "/res/Layout/ringres.arc"}}, "/res/LayoutRevo/ringresR.arc")
+#define ITEM_INF_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/itmInfRes.arc"}, {GameVersion::GcnPal, "/res/Layout/itmInfRes.arc"}, {GameVersion::GcnJpn, "/res/Layout/itmInfRes.arc"}}, "/res/LayoutRevo/itmInfResR.arc")
+#define BUTTON_RES_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/button.arc"}, {GameVersion::GcnPal, "/res/Layout/button.arc"}, {GameVersion::GcnJpn, "/res/Layout/button.arc"}}, "/res/LayoutRevo/buttonR.arc")
+#define MAIN2D_PATH versionSelect<const char*>({{GameVersion::GcnUsa, "/res/Layout/main2D.arc"}, {GameVersion::GcnPal, "/res/Layout/main2D.arc"}, {GameVersion::GcnJpn, "/res/Layout/main2D.arc"}}, "/res/LayoutRevo/main2DR.arc")
+#elif PLATFORM_WII
 #define RING_RES_PATH "/res/LayoutRevo/ringresR.arc"
 #define ITEM_INF_RES_PATH "/res/LayoutRevo/itmInfResR.arc"
 #define BUTTON_RES_PATH "/res/LayoutRevo/buttonR.arc"
@@ -1640,8 +1662,8 @@ void dScnLogo_c::dvdDataLoad() {
     mpMsgResCommand[2] = aramMount(MSG_RES2_PATH, mDoExt_getJ2dHeap());
     mpMsgResCommand[3] = aramMount(MSG_RES3_PATH, mDoExt_getJ2dHeap());
 #if TARGET_PC
-    const auto res4Path = versionSelect<const char*>({{GameVersion::GcnJpn, "/res/Layout/msgres04.arc"}}, "/res/Layout/msgres04F.arc");
-    mpMsgResCommand[4] = aramMount( res4Path, mDoExt_getJ2dHeap());
+    const auto res4Path = versionSelect<const char*>({{GameVersion::GcnJpn, "/res/Layout/msgres04.arc"}, {GameVersion::WiiJpn, "/res/Layout/msgres04.arc"}}, "/res/Layout/msgres04F.arc");
+    mpMsgResCommand[4] = aramMount(res4Path, mDoExt_getJ2dHeap());
 #elif VERSION == VERSION_GCN_JPN
     mpMsgResCommand[4] = aramMount("/res/Layout/msgres04.arc", mDoExt_getJ2dHeap());
 #else
@@ -1657,11 +1679,15 @@ void dScnLogo_c::dvdDataLoad() {
         {
             {GameVersion::GcnJpn, "/res/Fontjp/fontres.arc"},
             {GameVersion::GcnPal, "/res/Fonteu/fontres.arc"},
+            {GameVersion::WiiJpn, "/res/Fontjp/fontres.arc"},
+            {GameVersion::WiiPal, "/res/Fonteu/fontres.arc"},
         }, "/res/Fontus/fontres.arc");
     const auto fontRubyPath = versionSelect<const char*>(
         {
             {GameVersion::GcnJpn, "/res/Fontjp/rubyres.arc"},
             {GameVersion::GcnPal, "/res/Fonteu/rubyres.arc"},
+            {GameVersion::WiiJpn, "/res/Fontjp/rubyres.arc"},
+            {GameVersion::WiiPal, "/res/Fonteu/rubyres.arc"},
         }, "/res/Fontus/rubyres.arc");
 
     // Note: GCN_JPN mounts this archive as tail instead of head.

--- a/src/d/d_save.cpp
+++ b/src/d/d_save.cpp
@@ -1086,7 +1086,7 @@ void dSv_player_config_c::setVibration(u8 i_status) {
 
 u8 dSv_player_config_c::getPalLanguage() const {
 #if TARGET_PC || VERSION == VERSION_GCN_PAL
-    IF_DUSK_BLOCK(dusk::version::getGameVersion() == dusk::version::GameVersion::GcnPal)
+    IF_DUSK_BLOCK(dusk::version::isRegionPal())
     switch (OSGetLanguage()) {
     case 0:
         return LANGUAGE_ENGLISH;

--- a/src/dusk/dvd_asset.hpp
+++ b/src/dusk/dvd_asset.hpp
@@ -23,9 +23,20 @@ bool LoadDolAsset(void* dst, std::initializer_list<OffsetVersion> virtualAddress
  */
 bool LoadRelAsset(void* dst, const char* dvdPath, std::initializer_list<OffsetVersion> offset, s32 size);
 
+template <typename T, size_t N>
+bool LoadRelAsset(T (&dst)[N], const char* dvdPath, std::initializer_list<OffsetVersion> offset) {
+    return LoadRelAsset(static_cast<void*>(dst), dvdPath, offset, static_cast<s32>(sizeof(dst)));
+}
+
 /**
  * Load bytes from a REL inside RELS.arc
  */
 bool LoadArchivedRelAsset(void* dst, u32 memType, const char* relFileName, std::initializer_list<OffsetVersion> offset, s32 size);
+
+template <typename T, size_t N>
+bool LoadArchivedRelAsset(T (&dst)[N], u32 memType, const char* relFileName,
+                          std::initializer_list<OffsetVersion> offset) {
+    return LoadArchivedRelAsset(static_cast<void*>(dst), memType, relFileName, offset, static_cast<s32>(sizeof(dst)));
+}
 
 }  // namespace dusk

--- a/src/dusk/iso_validate.cpp
+++ b/src/dusk/iso_validate.cpp
@@ -107,6 +107,7 @@ void update_info(const borealis::disc::Result& result, DiscInfo& info) noexcept 
     if (!result.metadata.gameId.empty()) {
         info.platform = result.metadata.platform;
         info.region = region_from_game_id(result.metadata.gameId);
+        info.revision = result.metadata.revision;
     }
 }
 

--- a/src/dusk/iso_validate.cpp
+++ b/src/dusk/iso_validate.cpp
@@ -41,9 +41,12 @@ constexpr auto AcceptedDiscs = std::to_array<borealis::disc::AcceptedDisc>({
         .expectedHash = borealis::disc::parse_xxh3_128("9ef597588b0035ca9e91b333fa9a8a7e"),
     },
     {
-        // TODO: How to support revisions?
-        .gameId = "RZDE01",
-        .expectedHash = borealis::disc::parse_xxh3_128("b3d91fbea59e5c66934d04c01566728e"),  // Rev. 2: c3ec420921a1b36d6ae43f576491d25c
+        .gameId = "RZDE01", .revision = 0,
+        .expectedHash = borealis::disc::parse_xxh3_128("b3d91fbea59e5c66934d04c01566728e"),
+    },
+    {
+        .gameId = "RZDE01", .revision = 2,
+        .expectedHash = borealis::disc::parse_xxh3_128("c3ec420921a1b36d6ae43f576491d25c"),
     },
     {
         .gameId = "RZDJ01",

--- a/src/dusk/iso_validate.cpp
+++ b/src/dusk/iso_validate.cpp
@@ -40,10 +40,22 @@ constexpr auto AcceptedDiscs = std::to_array<borealis::disc::AcceptedDisc>({
         .gameId = "GZ2P01",
         .expectedHash = borealis::disc::parse_xxh3_128("9ef597588b0035ca9e91b333fa9a8a7e"),
     },
+    {
+        // TODO: How to support revisions?
+        .gameId = "RZDE01",
+        .expectedHash = borealis::disc::parse_xxh3_128("b3d91fbea59e5c66934d04c01566728e"),  // Rev. 2: c3ec420921a1b36d6ae43f576491d25c
+    },
+    {
+        .gameId = "RZDJ01",
+        .expectedHash = borealis::disc::parse_xxh3_128("d3866821c7fc6999e6e8bbef8b6875aa"),
+    },
+    {
+        .gameId = "RZDP01",
+        .expectedHash = borealis::disc::parse_xxh3_128("6095a924a57e5fb4294ac96fb85a09a1"),
+    },
 });
 
-constexpr auto RecognizedGameIds =
-    std::to_array<std::string_view>({"RZDE01", "RZDJ01", "RZDK01", "RZDP01"});
+constexpr auto RecognizedGameIds = std::to_array<std::string_view>({"RZDK01"});
 
 constexpr borealis::disc::Catalog DiscCatalog{
     .acceptedDiscs = AcceptedDiscs,

--- a/src/dusk/iso_validate.hpp
+++ b/src/dusk/iso_validate.hpp
@@ -37,6 +37,7 @@ using VerificationStatus = borealis::disc::Progress;
 struct DiscInfo {
     Platform platform = Platform::Unknown;
     Region region = Region::NorthAmerica;
+    std::uint8_t revision = 0;
 };
 
 ValidationError inspect(const char* path, DiscInfo& info);

--- a/src/dusk/language.cpp
+++ b/src/dusk/language.cpp
@@ -1,0 +1,79 @@
+#include "dusk/language.hpp"
+
+#include "dusk/version.hpp"
+
+namespace dusk::language {
+namespace {
+
+constexpr GameLanguage kEnglishOnly[] = {GameLanguage::English};
+constexpr GameLanguage kJapaneseOnly[] = {GameLanguage::Japanese};
+constexpr GameLanguage kPalLanguages[] = {
+    GameLanguage::English,
+    GameLanguage::German,
+    GameLanguage::French,
+    GameLanguage::Spanish,
+    GameLanguage::Italian,
+};
+constexpr GameLanguage kWiiUsaLanguages[] = {
+    GameLanguage::English,
+    GameLanguage::French,
+    GameLanguage::Spanish,
+};
+
+}  // namespace
+
+std::span<const GameLanguage> available_languages(const iso::DiscInfo& info) noexcept {
+    switch (info.region) {
+    case iso::Region::Japan:
+        return kJapaneseOnly;
+    case iso::Region::Europe:
+        return kPalLanguages;
+    case iso::Region::NorthAmerica:
+        if (info.platform == iso::Platform::Wii && info.revision == 2) {
+            return kWiiUsaLanguages;
+        }
+        return kEnglishOnly;
+    default:
+        return kEnglishOnly;
+    }
+}
+
+const char* language_name(GameLanguage language) noexcept {
+    switch (language) {
+    case GameLanguage::English:
+        return "English";
+    case GameLanguage::German:
+        return "German";
+    case GameLanguage::French:
+        return "French";
+    case GameLanguage::Spanish:
+        return "Spanish";
+    case GameLanguage::Italian:
+        return "Italian";
+    case GameLanguage::Japanese:
+        return "Japanese";
+    }
+    return "English";
+}
+
+const char* msg_folder() noexcept {
+    using namespace version;
+
+    switch (getSettings().game.language.getValue()) {
+    case GameLanguage::German:
+        return "Msgde";
+    case GameLanguage::French:
+        return "Msgfr";
+    case GameLanguage::Spanish:
+        return "Msgsp";
+    case GameLanguage::Italian:
+        return "Msgit";
+    case GameLanguage::Japanese:
+        return "Msgjp";
+    case GameLanguage::English:
+    default:
+        return isRegionPal() ? "Msguk" : "Msgus";
+    }
+}
+
+}  // namespace dusk::language

--- a/src/dusk/language.hpp
+++ b/src/dusk/language.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "dusk/iso_validate.hpp"
+#include "dusk/settings.h"
+
+#include <span>
+
+namespace dusk::language {
+
+std::span<const GameLanguage> available_languages(const iso::DiscInfo& info) noexcept;
+
+const char* language_name(GameLanguage language) noexcept;
+const char* msg_folder() noexcept;
+
+}  // namespace dusk::language

--- a/src/dusk/settings.h
+++ b/src/dusk/settings.h
@@ -33,6 +33,7 @@ enum class GameLanguage : u8 {
     French = OS_LANGUAGE_FRENCH,
     Spanish = OS_LANGUAGE_SPANISH,
     Italian = OS_LANGUAGE_ITALIAN,
+    Japanese = 6,
 };
 
 enum class DiscVerificationState : u8 {
@@ -89,7 +90,7 @@ struct ConfigEnumRange<Resampler> {
 template <>
 struct ConfigEnumRange<GameLanguage> {
     static constexpr auto min = GameLanguage::English;
-    static constexpr auto max = GameLanguage::Italian;
+    static constexpr auto max = GameLanguage::Japanese;
 };
 
 template <>

--- a/src/dusk/ui/prelaunch.cpp
+++ b/src/dusk/ui/prelaunch.cpp
@@ -292,7 +292,7 @@ std::string get_error_msg(iso::ValidationError error) {
     case iso::ValidationError::WrongGame:
         return "The selected game is not supported by Dusklight.";
     case iso::ValidationError::WrongVersion:
-        return "Dusklight currently supports GameCube USA and PAL disc images only.";
+        return "Dusklight does not currently support the Wii's Korean version.";
     case iso::ValidationError::Canceled:
         return "Disc verification was canceled. Dusklight cannot guarantee the selected disc "
                "image is compatible.";

--- a/src/dusk/ui/prelaunch.cpp
+++ b/src/dusk/ui/prelaunch.cpp
@@ -917,6 +917,9 @@ void Prelaunch::update() {
                 break;
             case iso::Region::NorthAmerica:
                 innerRML += "USA";
+                if (state.activeDiscInfo.platform == iso::Platform::Wii) {
+                    innerRML += fmt::format(" Rev. {}", state.activeDiscInfo.revision);
+                }
                 break;
             case iso::Region::Korea:
                 innerRML += "KOR";

--- a/src/dusk/ui/prelaunch.cpp
+++ b/src/dusk/ui/prelaunch.cpp
@@ -4,6 +4,7 @@
 #include "dusk/config.hpp"
 #include "dusk/data.hpp"
 #include "dusk/iso_validate.hpp"
+#include "dusk/language.hpp"
 #include "dusk/main.h"
 #include "dusk/settings.h"
 #include "modal.hpp"
@@ -317,6 +318,24 @@ void persist_disc_choice(const std::string& path, iso::ValidationError validatio
     }
 }
 
+void apply_language_for_disc(const iso::DiscInfo& info) {
+    const auto langs = language::available_languages(info);
+    auto& language = getSettings().game.language;
+    const GameLanguage previous = language.getValue();
+    if (std::ranges::find(langs, previous) != langs.end()) {
+        return;
+    }
+
+    const GameLanguage fallback = langs.front();
+    language.setValue(fallback);
+    config::save();
+
+    auto& state = prelaunch_state();
+    state.initialLanguage = fallback;
+    state.unavailableLanguage = previous;
+    state.pendingLanguageUnavailableNotice = true;
+}
+
 void apply_valid_disc_result(
     const std::string& path, const iso::DiscInfo& info, iso::ValidationError validation) {
     auto& state = prelaunch_state();
@@ -329,6 +348,7 @@ void apply_valid_disc_result(
         state.activeDiscInfo = info;
     }
     persist_disc_choice(path, validation);
+    apply_language_for_disc(info);
 }
 
 void apply_disc_verification_result(const DiscVerificationResult& result) {
@@ -548,6 +568,7 @@ void refresh_configured_disc_state() noexcept {
         if (state.configuredDiscPath == state.activeDiscPath) {
             state.activeDiscInfo = info;
         }
+        apply_language_for_disc(info);
         return;
     }
 
@@ -629,6 +650,36 @@ void try_push_verification_modal(Document& host) {
             },
         .onDismiss = dismiss,
         .icon = "error",
+    }));
+}
+
+void try_push_language_unavailable_modal(Document& host) {
+    auto& state = prelaunch_state();
+
+    if (!state.pendingLanguageUnavailableNotice) {
+        return;
+    }
+    state.pendingLanguageUnavailableNotice = false;
+
+    const Rml::String bodyRml = fmt::format(
+        "<b>{}</b> is not available on this disc. Language has been reset to <b>{}</b>.",
+        language::language_name(state.unavailableLanguage),
+        language::language_name(getSettings().game.language.getValue()));
+
+    auto dismiss = [](Modal& modal) { modal.pop(); };
+
+    host.push(std::make_unique<Modal>(Modal::Props{
+        .title = "Language unavailable",
+        .bodyRml = bodyRml,
+        .actions =
+            {
+                ModalAction{
+                    .label = "OK",
+                    .onPressed = dismiss,
+                },
+            },
+        .onDismiss = dismiss,
+        .icon = "warning",
     }));
 }
 
@@ -844,6 +895,7 @@ void Prelaunch::update() {
 
     if (top_document() == this) {
         try_push_verification_modal(*this);
+        try_push_language_unavailable_modal(*this);
     }
 
     const auto& state = prelaunch_state();

--- a/src/dusk/ui/prelaunch.hpp
+++ b/src/dusk/ui/prelaunch.hpp
@@ -49,6 +49,8 @@ struct PrelaunchState {
     std::string activeDiscPath;
     iso::DiscInfo activeDiscInfo{};
     GameLanguage initialLanguage = GameLanguage::English;
+    GameLanguage unavailableLanguage = GameLanguage::English;
+    bool pendingLanguageUnavailableNotice = false;
     std::string initialGraphicsBackend;
     int initialCardFileType = 0;
     std::string errorString;
@@ -63,5 +65,6 @@ void refresh_configured_disc_state() noexcept;
 void open_iso_picker() noexcept;
 bool is_restart_pending() noexcept;
 void try_push_verification_modal(Document& host);
+void try_push_language_unavailable_modal(Document& host);
 
 }  // namespace dusk::ui

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -11,6 +11,7 @@
 #include "dusk/data.hpp"
 #include "dusk/imgui/ImGuiEngine.hpp"
 #include "dusk/io.hpp"
+#include "dusk/language.hpp"
 #include "dusk/presentation.hpp"
 #include <borealis/io.hpp>
 #include <borealis/file_select.hpp>
@@ -52,14 +53,6 @@
 
 namespace dusk::ui {
 namespace {
-
-constexpr std::array kLanguageNames = {
-    "English",
-    "German",
-    "French",
-    "Spanish",
-    "Italian",
-};
 
 constexpr std::array kCardFileTypes = {
     "Card Image",
@@ -562,18 +555,15 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                     .key = "Language",
                     .getValue =
                         [] {
-                            const auto& state = prelaunch_state();
-                            if (!state.configuredDiscCanLaunch || state.configuredDiscInfo.region != iso::Region::Europe) {
-                                return kLanguageNames[0];
-                            }
-                            const u8 idx = static_cast<u8>(getSettings().game.language.getValue());
-                            return kLanguageNames[idx];
+                            return language::language_name(getSettings().game.language.getValue());
                         },
                     .isDisabled =
                         [] {
                             const auto& state = prelaunch_state();
-                            return !state.configuredDiscCanLaunch ||
-                                   state.configuredDiscInfo.region != iso::Region::Europe;
+                            if (!state.configuredDiscCanLaunch) {
+                                return true;
+                            }
+                            return language::available_languages(state.configuredDiscInfo).size() <= 1;
                         },
                     .isModified =
                         [] {
@@ -582,18 +572,22 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                         },
                 }),
                 rightPane, [](Pane& pane) {
-                    for (int i = 0; i < kLanguageNames.size(); i++) {
+                    const auto& state = prelaunch_state();
+                    const auto languages = state.configuredDiscCanLaunch
+                                               ? language::available_languages(state.configuredDiscInfo)
+                                               : language::available_languages({});
+                    for (const GameLanguage language : languages) {
                         pane.add_button({
-                                            .text = kLanguageNames[i],
+                                            .text = language::language_name(language),
                                             .isSelected =
-                                                [i] {
+                                                [language] {
                                                     return getSettings().game.language.getValue() ==
-                                                           static_cast<GameLanguage>(i);
+                                                           language;
                                                 },
                                         })
-                            .on_pressed([i] {
+                            .on_pressed([language] {
                                 mDoAud_seStartMenu(kSoundItemChange);
-                                getSettings().game.language.setValue(static_cast<GameLanguage>(i));
+                                getSettings().game.language.setValue(language);
                                 config::save();
                             });
                     }
@@ -1543,6 +1537,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
 void SettingsWindow::update() {
     if (mPrelaunch && top_document() == this) {
         try_push_verification_modal(*this);
+        try_push_language_unavailable_modal(*this);
     }
 
     Window::update();

--- a/src/dusk/version.cpp
+++ b/src/dusk/version.cpp
@@ -26,10 +26,17 @@ void init() {
 
     if (game == "GZ2E"sv) {
         gameVersion = GameVersion::GcnUsa;
-    } else if (game == "GZ2P") {
+    } else if (game == "GZ2P"sv) {
         gameVersion = GameVersion::GcnPal;
-    } else if (game == "GZ2J") {
+    } else if (game == "GZ2J"sv) {
         gameVersion = GameVersion::GcnJpn;
+    } else if (game == "RZDE"sv) {
+        // TODO: How to support revisions?
+        gameVersion = GameVersion::WiiUsaRev0;
+    } else if (game == "RZDP"sv) {
+        gameVersion = GameVersion::WiiPal;
+    } else if (game == "RZDJ"sv) {
+        gameVersion = GameVersion::WiiJpn;
     } else {
         // TODO: Handle remaining valid versions.
         DuskLog.fatal("Unknown/unsupported game version in disc: {}", game);

--- a/src/dusk/version.cpp
+++ b/src/dusk/version.cpp
@@ -60,8 +60,12 @@ bool isWii() {
         || getGameVersion() == GameVersion::WiiKor;
 }
 
+bool isJpnOrLessThanWiiJpn() {
+    return isRegionJpn() || getGameVersion() < GameVersion::WiiJpn;
+}
+
 bool isPalOrAtLeastWiiR2() {
-    return getGameVersion() == GameVersion::GcnPal || getGameVersion() >= GameVersion::WiiUsa;
+    return isRegionPal() || (isWii() && getGameVersion() != GameVersion::WiiUsaRev0);
 }
 
 bool isRegionJpn() {

--- a/src/dusk/version.cpp
+++ b/src/dusk/version.cpp
@@ -30,9 +30,10 @@ void init() {
         gameVersion = GameVersion::GcnPal;
     } else if (game == "GZ2J"sv) {
         gameVersion = GameVersion::GcnJpn;
-    } else if (game == "RZDE"sv) {
-        // TODO: How to support revisions?
+    } else if (game == "RZDE"sv && diskId.gameVersion == 0) {
         gameVersion = GameVersion::WiiUsaRev0;
+    } else if (game == "RZDE"sv && diskId.gameVersion == 2) {
+        gameVersion = GameVersion::WiiUsa;
     } else if (game == "RZDP"sv) {
         gameVersion = GameVersion::WiiPal;
     } else if (game == "RZDJ"sv) {

--- a/src/dusk/version.hpp
+++ b/src/dusk/version.hpp
@@ -5,18 +5,19 @@
  */
 namespace dusk::version {
     enum class GameVersion : u8 {
-        GcnUsa = VERSION_GCN_USA,
-        GcnPal = VERSION_GCN_PAL,
-        GcnJpn = VERSION_GCN_JPN,
-        WiiUsaRev0 = VERSION_WII_USA_R0,
-        WiiUsa = VERSION_WII_USA_R2,
-        WiiPal = VERSION_WII_PAL,
-        WiiJpn = VERSION_WII_JPN,
-        WiiKor = VERSION_WII_KOR,
+        WiiUsaRev0,
+        WiiPal,
+        WiiJpn,
+        GcnUsa,
+        GcnPal,
+        GcnJpn,
+        WiiUsa,
+        WiiKor,
     };
 
     bool isGcn();
     bool isWii();
+    bool isJpnOrLessThanWiiJpn();
     bool isPalOrAtLeastWiiR2();
 
     bool isRegionPal();

--- a/src/dusk/version.hpp
+++ b/src/dusk/version.hpp
@@ -61,4 +61,14 @@ namespace dusk::version {
 
         return defaultValue;
     }
+
+    template<typename T>
+    T platformSelect(const T& gcn, const T& wii) {
+        return isGcn() ? gcn : wii;
+    }
+
+    template<typename T>
+    T regionSelect(const T& usa, const T& pal, const T& jpn) {
+        return isRegionUsa() ? usa : isRegionPal() ? pal : jpn;
+    }
 }  // namespace dusk::version

--- a/src/m_Do/m_Do_ext.cpp
+++ b/src/m_Do/m_Do_ext.cpp
@@ -3713,7 +3713,7 @@ static ResFONT* mDoExt_resfont0;
 static void mDoExt_initFont0() {
     static char const fontdata[] = "rodan_b_24_22.bfn";
 #if TARGET_PC
-    if (dusk::version::getGameVersion() == dusk::version::GameVersion::GcnJpn) {
+    if (dusk::version::isRegionJpn()) {
         mDoExt_initFontCommon(&mDoExt_font0, &mDoExt_resfont0, mDoExt_getZeldaHeap(),
                               fontdata, dComIfGp_getFontArchive(), 0, 200, 512);
     } else {
@@ -3748,7 +3748,7 @@ void mDoExt_removeMesgFont() {
             mDoExt_font0 = NULL;
             if (mDoExt_resfont0 != NULL) {
 #if TARGET_PC
-                if (dusk::version::getGameVersion() == dusk::version::GameVersion::GcnJpn) {
+                if (dusk::version::isRegionJpn()) {
                     JKRFileLoader::removeResource(mDoExt_resfont0, NULL);
                 } else {
                     JKRFree(mDoExt_resfont0);


### PR DESCRIPTION
This PR adds support for playing Dusklight using all commercial Wii disc images except for the Korean release, which would require more decomp work to support its language.

Testing occurred between two devs, myself and MelonSpeedruns, sporadically checking various languages, save files at varying points in the game, for varying lengths of time up to at least 2 hour sessions, with any crashes that were found quickly fixed. At this time there are no known issues, but more people testing more extensively is always appreciated.

Some things to note about using a Wii disc image (this is mostly directed at any users reading this):
- The game will still use the `Layout` directory's GCN interface. This is necessary because the upstream decompilation does not yet have all the necessary code for driving the Wii interface from `LayoutRevo`.
- Gameplay and control scheme are not determined by the disc image, which means using a Wii disc will not result in e.g. Link having third-person aiming or the world being mirrored by default.
- Using a Wii disc image would not make Dusklight natively capable of playing using a Wii Remote, or add any Wii-specific behavior like the Navi cursor or controller speaker sounds.