### PR TITLE
Display prelaunch settings after 'return to main menu'

### DIFF
--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1371,6 +1371,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             mDoAud_seStartMenu(kSoundClick);
             pop();
             ui::prelaunch_state().returnToPrelaunchOnReset = true;
+            ui::prelaunch_state().firstLaunch = true;
             JUTGamePad::C3ButtonReset::sResetSwitchPushing = true;
         }),
             rightPane, [](Pane& pane) {


### PR DESCRIPTION
If the game had been launched the return to main menu did not show the prelaunch settings, see attached video.

[Screencast_20260823_155253.webm](https://github.com/user-attachments/assets/ed6f477d-2e4c-491d-935b-c91c334d5adc)
