### PR TITLE
Instant Death Fixes

### DIFF
--- a/src/d/actor/d_a_alink_damage.inc
+++ b/src/d/actor/d_a_alink_damage.inc
@@ -157,10 +157,11 @@ f32 daAlink_c::damageMagnification(BOOL i_checkZoraMag, int param_1) {
     }
 
     #if TARGET_PC
-    base_mag *= dusk::getSettings().game.damageMultiplier;
     if (dusk::getSettings().game.instantDeath) {
-        base_mag = 9999.0f;
+        return 9999.0f; // don't need to multiply this further, 9999 is plenty
     }
+
+    base_mag *= dusk::getSettings().game.damageMultiplier;
     #endif
 
     if (checkWolf() && !checkCargoCarry() && param_1 == 0) {

--- a/src/d/d_meter2.cpp
+++ b/src/d/d_meter2.cpp
@@ -606,7 +606,12 @@ void dMeter2_c::moveLife() {
             life_count = (dComIfGs_getMaxLife() / 5) * 4;
         }
 
+#if TARGET_PC
+        int new_life = dComIfGs_getLife() + dComIfGp_getItemLifeCount(); // prevent an overflow with really large damage values
+#else
         s16 new_life = dComIfGs_getLife() + dComIfGp_getItemLifeCount();
+#endif
+
         if (new_life > life_count) {
             new_life = life_count;
         } else if (new_life < 0) {

--- a/src/d/d_meter2.cpp
+++ b/src/d/d_meter2.cpp
@@ -606,11 +606,7 @@ void dMeter2_c::moveLife() {
             life_count = (dComIfGs_getMaxLife() / 5) * 4;
         }
 
-#if TARGET_PC
-        int new_life = dComIfGs_getLife() + dComIfGp_getItemLifeCount(); // prevent an overflow with really large damage values
-#else
-        s16 new_life = dComIfGs_getLife() + dComIfGp_getItemLifeCount();
-#endif
+        DUSK_IF_ELSE(int, s16) new_life = dComIfGs_getLife() + dComIfGp_getItemLifeCount(); // prevent an overflow with really large damage values
 
         if (new_life > life_count) {
             new_life = life_count;


### PR DESCRIPTION
Alternate take on #1899

Does not check that `ItemLifeCount` isn't NaN/inf/some other float value that can't be converted to an int properly. In theory the value could still be too big even for `int` so if desired I could add a clamp and/or NaN checks, though I don't think any cases currently hit that in practice.

The change to `d_a_alink_damage` is entirely optional (though in theory lets the base damage go higher without overflowing in some cases), open to removing it if it's deemed unnecessary

Fixes #1563 
Seems to fix #1552, though I am not sure exactly what scenario they used to cause it