### PR TITLE
Mods: Avoid RTLD_DEEPBIND; configure exports manually

### DIFF
--- a/cmake/ModExports.exp
+++ b/cmake/ModExports.exp
@@ -1,0 +1,5 @@
+_mod_ctx
+_mod_initialize
+_mod_meta
+_mod_shutdown
+_mod_update

--- a/cmake/ModExports.ver
+++ b/cmake/ModExports.ver
@@ -1,0 +1,10 @@
+DUSKLIGHT_MOD_1 {
+    global:
+        mod_ctx;
+        mod_initialize;
+        mod_meta;
+        mod_shutdown;
+        mod_update;
+    local:
+        *;
+};

--- a/cmake/ModExports.ver
+++ b/cmake/ModExports.ver
@@ -1,4 +1,4 @@
-DUSKLIGHT_MOD_1 {
+{
     global:
         mod_ctx;
         mod_initialize;

--- a/cmake/ModSDK.cmake
+++ b/cmake/ModSDK.cmake
@@ -185,6 +185,20 @@ function(add_mod target_name)
                 WINDOWS_EXPORT_ALL_SYMBOLS OFF)
         target_compile_features(${target_name} PRIVATE cxx_std_20)
         target_link_libraries(${target_name} PRIVATE dusklight_mod_api)
+
+        if (APPLE)
+            set(_mod_exports "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/ModExports.exp")
+            target_link_options(${target_name} PRIVATE
+                    -Xlinker -exported_symbols_list -Xlinker "${_mod_exports}")
+            set_property(TARGET ${target_name} APPEND PROPERTY LINK_DEPENDS "${_mod_exports}")
+        elseif (UNIX)
+            set(_mod_exports "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/ModExports.ver")
+            target_link_options(${target_name} PRIVATE
+                    "-Wl,--version-script=${_mod_exports}"
+                    -Wl,--no-undefined-version)
+            set_property(TARGET ${target_name} APPEND PROPERTY LINK_DEPENDS "${_mod_exports}")
+        endif ()
+
         foreach (_feature IN LISTS _features)
             target_link_libraries(${target_name} PRIVATE dusklight_mod_feature_${_feature})
             if (_feature STREQUAL "webgpu")

--- a/sdk/include/mods/meta.hpp
+++ b/sdk/include/mods/meta.hpp
@@ -46,8 +46,8 @@ extern "C" const unsigned char mod_meta_bounds_end[] __asm("section$end$__DATA$_
 #define MOD_META_BOUNDS_BEGIN (mod_meta_bounds_begin)
 #define MOD_META_BOUNDS_END (mod_meta_bounds_end)
 #else
-extern "C" const unsigned char __start_modmeta[];
-extern "C" const unsigned char __stop_modmeta[];
+extern "C" __attribute__((visibility("hidden"))) const unsigned char __start_modmeta[];
+extern "C" __attribute__((visibility("hidden"))) const unsigned char __stop_modmeta[];
 #define MOD_META_BOUNDS_DEFN
 #define MOD_META_BOUNDS_BEGIN (__start_modmeta)
 #define MOD_META_BOUNDS_END (__stop_modmeta)

--- a/src/dusk/mods/loader/native_module.cpp
+++ b/src/dusk/mods/loader/native_module.cpp
@@ -6,14 +6,6 @@
 #include <Windows.h>
 #endif
 
-#if defined(__SANITIZE_ADDRESS__)
-#define ADDRESS_SANITIZER 1
-#elif defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#define ADDRESS_SANITIZER 1
-#endif
-#endif
-
 namespace {
 #if defined(_WIN32)
 void* pl_dlopen(const std::filesystem::path& p) {
@@ -39,11 +31,7 @@ std::string pl_dlerror() {
 #else
 #include <dlfcn.h>
 void* pl_dlopen(const std::filesystem::path& p) {
-    int flags = RTLD_LAZY | RTLD_LOCAL;
-#if defined(RTLD_DEEPBIND) && !defined(ADDRESS_SANITIZER)
-    flags |= RTLD_DEEPBIND;
-#endif
-    return dlopen(p.c_str(), flags);
+    return dlopen(p.c_str(), RTLD_LAZY | RTLD_LOCAL);
 }
 void* pl_dlsym(void* h, const char* name) {
     return dlsym(h, name);


### PR DESCRIPTION
We used `RTLD_DEEPBIND` to try to avoid mod export conflicts, but it appears to break `libstdc++` locale handling (classic Linux jank). Instead, we can use manually curated exports on Linux/Apple to avoid any sneaking through from static libraries.