### PR TITLE
A couple fixes for Wii discs

### DIFF
--- a/src/d/actor/d_a_player.cpp
+++ b/src/d/actor/d_a_player.cpp
@@ -367,31 +367,7 @@ JKRHeap* daPy_anmHeap_c::setAnimeHeap() {
 }
 
 #if !PLATFORM_WII
-#if TARGET_PC
-#include "dusk/dvd_asset.hpp"
-using GameVersion = dusk::version::GameVersion;
-static const u8* l_sightDL_get() { 
-    static u8 buf[0x89];
-    static bool _ = (
-        dusk::LoadDolAsset(
-            buf,
-            {
-            {GameVersion::GcnUsa,     0x803BA0C0},
-            {GameVersion::GcnPal,     0x803BBDA0},
-            {GameVersion::GcnJpn,     0x803B4220},
-            {GameVersion::WiiUsaRev0, 0x803F63C0},
-            {GameVersion::WiiUsa,     0x803E1640},
-            {GameVersion::WiiPal,     0x803E23A0},
-            {GameVersion::WiiJpn,     0x803DF600}
-            },
-            0x89
-        ),
-        true
-    );
-    return buf;
-}
-#define l_sightDL (l_sightDL_get())
-#else
+#if !TARGET_PC
 #include "assets/l_sightDL__d_a_player.h"
 #endif
 
@@ -435,7 +411,33 @@ void daPy_sightPacket_c::draw() {
     GXLoadPosMtxImm(mProjMtx, GX_PNMTX0);
     GXSetCurrentMtx(0);
     GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR_NULL);
+#if TARGET_PC
+    GXSetNumTexGens(1);
+    GXSetNumTevStages(1);
+    GXSetTexCoordGen(GX_TEXCOORD0, GX_TG_MTX2x4, GX_TG_TEX0, GX_IDENTITY);
+    GXSetCullMode(GX_CULL_NONE);
+    GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_C1, GX_CC_C0, GX_CC_TEXC, GX_CC_ZERO);
+    GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+    GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_ZERO, GX_CA_A0, GX_CA_TEXA, GX_CA_ZERO);
+    GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+    GXSetBlendMode(GX_BM_BLEND, GX_BL_SRCALPHA, GX_BL_INVSRCALPHA, GX_LO_CLEAR);
+    GXSetZMode(GX_FALSE, GX_LEQUAL, GX_FALSE);
+    GXSetColorUpdate(GX_TRUE);
+    GXSetAlphaUpdate(GX_FALSE);
+    GXSetDither(GX_TRUE);
+    GXBegin(GX_TRIANGLESTRIP, GX_VTXFMT0, 4);
+    GXPosition3u8(1, 1, 0);
+    GXTexCoord2u8(1, 1);
+    GXPosition3u8(255, 1, 0);
+    GXTexCoord2u8(0, 1);
+    GXPosition3u8(1, 255, 0);
+    GXTexCoord2u8(1, 0);
+    GXPosition3u8(255, 255, 0);
+    GXTexCoord2u8(0, 0);
+    GXEnd();
+#else
     GXCallDisplayList(l_sightDL, 0x80);
+#endif
     J3DShape::resetVcdVatCache();
 }
 

--- a/src/d/d_meter2_draw.cpp
+++ b/src/d/d_meter2_draw.cpp
@@ -198,6 +198,20 @@ dMeter2Draw_c::dMeter2Draw_c(JKRExpHeap* mp_heap) {
     IF_DUSK_BLOCK_END
 #endif
 
+#if TARGET_PC
+    if (dusk::version::isLessThanWiiJpn()) {
+        if (J2DPicture* b_btn = static_cast<J2DPicture*>(mpScreen->search(MULTI_CHAR('b_btn')))) {
+            b_btn->setAlpha(255);
+            b_btn->setWhite(JUtility::TColor(195, 63, 63, 255));
+        }
+
+        for (int i = 0; i < 5; i++) {
+            static_cast<J2DTextBox*>(mpXYText[i][0]->getPanePtr())->setCharSpace(0.0f);
+            static_cast<J2DTextBox*>(mpXYText[i][1]->getPanePtr())->setCharSpace(0.0f);
+        }
+    }
+#endif
+
     init();
     field_0xa8 = 0;
     field_0x1e4 = 0;
@@ -2460,7 +2474,7 @@ void dMeter2Draw_c::drawButtonA(u8 i_action, f32 i_posX, f32 i_posY, f32 i_textP
     mpButtonA->paneTrans(i_posX, i_posY);
     mpTextA->scale(var_f30 * i_scale, var_f30 * i_scale);
     mpTextA->paneTrans(g_drawHIO.mButtonATextPosX + i_textPosX,
-                       g_drawHIO.mButtonATextPosY + i_textPosY);
+                       g_drawHIO.mButtonATextPosY + i_textPosY IF_DUSK(+ (dusk::version::isLessThanWiiJpn() ? 6.0f : 0.0f)));
 }
 
 void dMeter2Draw_c::drawButtonB(u8 i_action, bool param_1, f32 i_posX, f32 i_posY, f32 i_textPosX,
@@ -2658,6 +2672,11 @@ void dMeter2Draw_c::drawButtonXY(int i_no, u8 i_itemNo, u8 i_action, bool param_
 
     static u64 const tag[] = {MULTI_CHAR('item_x_n'), MULTI_CHAR('item_y_n')};
 
+#if TARGET_PC
+    const float btnXOffsetX = dusk::version::isLessThanWiiJpn() ? 2.0f : 0.0f;
+    const float btnXOffsetY = dusk::version::isLessThanWiiJpn() ? 38.0f : 0.0f;
+#endif
+
     if (!param_3) {
         mpScreen->search(tag[i_no])->hide();
 
@@ -2704,7 +2723,8 @@ void dMeter2Draw_c::drawButtonXY(int i_no, u8 i_itemNo, u8 i_action, bool param_
 
         if (i_no == SELECT_X_e) {
             mpTextXY[i_no]->scale(g_drawHIO.mButtonXYTextScale, g_drawHIO.mButtonXYTextScale);
-            mpTextXY[i_no]->paneTrans(g_drawHIO.mButtonXYTextPosX, g_drawHIO.mButtonXYTextPosY);
+            mpTextXY[i_no]->paneTrans(g_drawHIO.mButtonXYTextPosX IF_DUSK(- btnXOffsetX),
+                                      g_drawHIO.mButtonXYTextPosY IF_DUSK(+ btnXOffsetY));
         } else if (i_no == SELECT_Y_e) {
             mpTextXY[i_no]->scale(g_drawHIO.mButtonXYTextScale, g_drawHIO.mButtonXYTextScale);
             mpTextXY[i_no]->paneTrans(g_drawHIO.mButtonXYTextPosX, g_drawHIO.mButtonXYTextPosY);
@@ -2766,7 +2786,8 @@ void dMeter2Draw_c::drawButtonXY(int i_no, u8 i_itemNo, u8 i_action, bool param_
             mpLightXY[0]->setAlphaRate(mButtonXItemBaseAlpha[var_r29] * field_0x7f0);
 
             mpTextXY[i_no]->scale(g_drawHIO.mButtonXYTextScale, g_drawHIO.mButtonXYTextScale);
-            mpTextXY[i_no]->paneTrans(g_drawHIO.mButtonXYTextPosX, g_drawHIO.mButtonXYTextPosY);
+            mpTextXY[i_no]->paneTrans(g_drawHIO.mButtonXYTextPosX IF_DUSK(- btnXOffsetX),
+                                      g_drawHIO.mButtonXYTextPosY IF_DUSK(+ btnXOffsetY));
         } else if (i_no == SELECT_Y_e) {
             mpButtonXY[1]->scale(g_drawHIO.mButtonYScale, g_drawHIO.mButtonYScale);
             mpButtonXY[1]->paneTrans(g_drawHIO.mButtonYPosX, g_drawHIO.mButtonYPosY);

--- a/src/dusk/version.cpp
+++ b/src/dusk/version.cpp
@@ -60,8 +60,12 @@ bool isWii() {
         || getGameVersion() == GameVersion::WiiKor;
 }
 
+bool isLessThanWiiJpn() {
+    return getGameVersion() < GameVersion::WiiJpn;
+}
+
 bool isJpnOrLessThanWiiJpn() {
-    return isRegionJpn() || getGameVersion() < GameVersion::WiiJpn;
+    return isRegionJpn() || isLessThanWiiJpn();
 }
 
 bool isPalOrAtLeastWiiR2() {

--- a/src/dusk/version.hpp
+++ b/src/dusk/version.hpp
@@ -17,6 +17,7 @@ namespace dusk::version {
 
     bool isGcn();
     bool isWii();
+    bool isLessThanWiiJpn();
     bool isJpnOrLessThanWiiJpn();
     bool isPalOrAtLeastWiiR2();
 


### PR DESCRIPTION
1. Aiming reticles were not displayed. The DOL address I'd thought I'd located for it was a false positive, and the sight simply does not exist for Wii discs. I've now translated the display list op codes into GX calls, circumventing the need to find the reticle on disc for any revision. Closes #2335

2. There were more differences in the meter2 BLO(s) than I originally noticed, so I've corrected those. The corrections in this PR include the B button alpha / tint, and the X and Y text locations and the spacing of their characters.